### PR TITLE
Change SAI submodule URL to opencomputeproject/master

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "dash-pipeline/SAI/SAI"]
 	path = dash-pipeline/SAI/SAI
-	url = https://github.com/reshmaintel/SAI.git
-	branch = dash-ptf-ci
+	url = https://github.com/opencomputeproject/SAI.git
+	branch = master
 [submodule "test/SAI-Challenger"]
 	path = test/SAI-Challenger
 	url = https://github.com/opencomputeproject/SAI-Challenger

--- a/dash-pipeline/SAI/templates/saifixedapis.cpp.j2
+++ b/dash-pipeline/SAI/templates/saifixedapis.cpp.j2
@@ -250,6 +250,8 @@ sai_status_t sai_api_initialize(
         _In_ uint64_t flags,
         _In_ const sai_service_method_table_t *services) { return SAI_STATUS_SUCCESS; }
 
+sai_status_t sai_api_uninitialize(void) { return SAI_STATUS_SUCCESS; }
+
 sai_status_t sai_log_set(
         _In_ sai_api_t api,
         _In_ sai_log_level_t log_level) { return SAI_STATUS_SUCCESS; }

--- a/test/test-cases/functional/ptf/run-tests.sh
+++ b/test/test-cases/functional/ptf/run-tests.sh
@@ -92,5 +92,5 @@ ptf \
     --interface 0@${iface_array[0]} \
     --interface 1@${iface_array[1]} \
     --test-case-timeout=${TIMEOUT} \
-    --test-params="test_reboot_mode=cold;target='${TARGET}';traffic_check='${TRAFFIC}';${TEST_PARAMS}" \
+    --test-params="test_reboot_mode='cold';target='${TARGET}';traffic_check='${TRAFFIC}';${TEST_PARAMS}" \
     ${EXTRA_PARAMETERS}

--- a/test/test-cases/functional/ptf/run-tests.sh
+++ b/test/test-cases/functional/ptf/run-tests.sh
@@ -92,5 +92,5 @@ ptf \
     --interface 0@${iface_array[0]} \
     --interface 1@${iface_array[1]} \
     --test-case-timeout=${TIMEOUT} \
-    --test-params="target='${TARGET}';traffic_check='${TRAFFIC}';${TEST_PARAMS}" \
+    --test-params="test_reboot_mode=cold;target='${TARGET}';traffic_check='${TRAFFIC}';${TEST_PARAMS}" \
     ${EXTRA_PARAMETERS}


### PR DESCRIPTION
Since PTF VxLAN changes are merged into latest PTF and PTF submodule is updated in official SAI repo by https://github.com/opencomputeproject/SAI/pull/1720, switch DASH to use opencompute SAI repo master branch instead of dev repo that is now.