### PR TITLE
minor fixes (passed value and removal ordering) in testcases

### DIFF
--- a/test/test-cases/functional/ptf/saidasheni.py
+++ b/test/test-cases/functional/ptf/saidasheni.py
@@ -114,7 +114,7 @@ class CreateDeleteEniTest(VnetAPI):
         """
         Verifies Direction Lookup creation
         """
-        self.dir_lookup = self.direction_lookup_create(vni=self.outbound_vnet)
+        self.dir_lookup = self.direction_lookup_create(vni=self.vm_vni)
 
     def createEniTest(self):
         """

--- a/test/test-cases/functional/saic/sai-api/test_sai_api_vnet_out_route.py
+++ b/test/test-cases/functional/saic/sai-api/test_sai_api_vnet_out_route.py
@@ -181,6 +181,18 @@ class TestSaiVnetOutboundRoutingEntry:
         assert all( [result == 0 for result in results]), "SAI_OUTBOUND_ROUTING_ENTRY_ACTION_ROUTE_VNET Get error"
 
     def test_vnet_outbound_routing_entry_remove(self, dpu):
+        commands = [
+            {
+                "name": "ore",
+                "op": "remove",
+                "type": "SAI_OBJECT_TYPE_OUTBOUND_ROUTING_ENTRY",
+            },
+        ]
+        results = [*dpu.process_commands(commands)]
+        print("\n======= SAI commands RETURN values create =======")
+        pprint(results)
+
+        assert all( [result == 0 for result in results]), "SAI_OBJECT_TYPE_OUTBOUND_ROUTING_ENTRY Remove error"
 
         # Remove ENI
         commands = [
@@ -212,15 +224,3 @@ class TestSaiVnetOutboundRoutingEntry:
 
         assert all( [result == 0 for result in results]), "SAI_OBJECT_TYPE_VNET Remove error"
         
-        commands = [
-            {
-                "name": "ore",
-                "op": "remove",
-                "type": "SAI_OBJECT_TYPE_OUTBOUND_ROUTING_ENTRY",
-            },
-        ]
-        results = [*dpu.process_commands(commands)]
-        print("\n======= SAI commands RETURN values create =======")
-        pprint(results)
-
-        assert all( [result == 0 for result in results]), "SAI_OBJECT_TYPE_OUTBOUND_ROUTING_ENTRY Remove error"


### PR DESCRIPTION
the vni passed in saidasheni.py was incorrect
the outbound route needs to be removed before the ENI (reverse order of create)