### PR TITLE
update saithrift-bld Dockerfile to accept the ubuntu image SHA as ARG

### DIFF
--- a/dash-pipeline/Makefile
+++ b/dash-pipeline/Makefile
@@ -73,6 +73,8 @@ DOCKER_RUN := docker run \
 	--rm \
 	$(DOCKER_FLAGS)
 
+SHA1SUM := sha1sum | awk '{print substr($$1,0,11);}'
+
 SAI/SAI: sai-submodule
 
 sai-submodule:
@@ -163,7 +165,7 @@ DOCKER_RUN_SAITHRIFT_BLDR =\
 
 sai: sai-clean sai-headers sai-meta libsai
 
-sai-headers: p4 | SAI/SAI
+sai-headers: p4 docker-saithrift-bldr-image-exists | SAI/SAI
 	@echo "Generate SAI library headers and implementation..."
 	mkdir -p SAI/lib && chmod -R o+w SAI && \
 	$(DOCKER_RUN) \
@@ -238,7 +240,7 @@ kill-switch:
 # SAI-THRIFT SERVER TARGETS
 ###############################
 
-saithrift-server:
+saithrift-server: docker-saithrift-bldr-image-exists
 	$(DOCKER_RUN_SAITHRIFT_BLDR) \
 	    make $@
 
@@ -267,7 +269,7 @@ run-saithrift-server-bash:
 	$(DOCKER_RUN_SAITHRIFT_SRVR) \
 	/bin/bash
 
-saithrift-server-clean:
+saithrift-server-clean: docker-saithrift-bldr-image-exists
 	$(DOCKER_RUN_SAITHRIFT_BLDR) \
 	    make $@
 	rm -rf SAI/rpc
@@ -328,7 +330,7 @@ init-switch:
 # DOCKER BUILD/PUBLISH TARGETS
 ###############################
 
-DOCKER_BMV2_BLDR_IMG_TAG = $(shell cat dockerfiles/Dockerfile.bmv2-bldr | sha1sum | awk '{print substr($$1,0,11);}')
+DOCKER_BMV2_BLDR_IMG_TAG = $(shell cat dockerfiles/Dockerfile.bmv2-bldr | $(SHA1SUM))
 DOCKER_BMV2_BLDR_IMG = $(DOCKER_BMV2_BLDR_IMG_NAME):$(DOCKER_BMV2_BLDR_IMG_TAG)
 
 docker-bmv2-bldr:
@@ -363,15 +365,26 @@ docker-publish-bmv2-bldr:
 		docker push $(DOCKER_BMV2_BLDR_IMG_NAME):$(DOCKER_BMV2_BLDR_IMG_CTAG)
 
 ###############################
+# Ubuntu docker image SHA
+# amd64/ubuntu:20.04 on 2022-07-03
+AMD64_UBUNTU_20_04 := b2339eee806d44d6a8adc0a790f824fb71f03366dd754d400316ae5a7e3ece3e
+# amd64/ubuntu:22.04 on 2023-05-16
+AMD64_UBUNTU_22_04 := ca5534a51dd04bbcebe9b23ba05f389466cf0c190f1f8f182d7eea92a9671d00
 
-DOCKER_SAITHRIFT_BLDR_IMG_TAG = $(shell cat dockerfiles/Dockerfile.saithrift-bldr | sha1sum | awk '{print substr($$1,0,11);}')
+AMD64_UBUNTU_SHA256 ?= $(AMD64_UBUNTU_22_04)
+
+DOCKER_SAITHRIFT_BLDR_IMG_TAG = $(shell cat dockerfiles/Dockerfile.saithrift-bldr | sed 's/ubuntu_image_sha/$(AMD64_UBUNTU_SHA256)/g' | $(SHA1SUM))
 DOCKER_SAITHRIFT_BLDR_IMG = $(DOCKER_SAITHRIFT_BLDR_IMG_NAME):$(DOCKER_SAITHRIFT_BLDR_IMG_TAG)
+
+docker-saithrift-bldr-image-exists:
+	docker images --format "{{.Repository}}:{{.Tag}}" | grep $(DOCKER_SAITHRIFT_BLDR_IMG) || make docker-saithrift-bldr
 
 docker-saithrift-bldr:
 	{ [ x$(ENABLE_DOCKER_PULL) == xy ] && docker pull $(DOCKER_SAITHRIFT_BLDR_IMG); } || \
 	docker build \
 		-f dockerfiles/Dockerfile.saithrift-bldr \
 	    -t $(DOCKER_SAITHRIFT_BLDR_IMG) \
+	    --build-arg ubuntu_image_sha=$(AMD64_UBUNTU_SHA256) \
 	    --build-arg user=$(DASH_USER) \
 	    --build-arg group=$(DASH_GROUP) \
 	    --build-arg uid=$(DASH_UID) \
@@ -395,7 +408,7 @@ docker-publish-saithrift-bldr:
 ###############################
 # Builder, has base packages to make client docker
 
-DOCKER_SAITHRIFT_CLIENT_BLDR_IMG_TAG = $(shell cat dockerfiles/Dockerfile.saithrift-client-bldr | sha1sum | awk '{print substr($$1,0,11);}')
+DOCKER_SAITHRIFT_CLIENT_BLDR_IMG_TAG = $(shell cat dockerfiles/Dockerfile.saithrift-client-bldr | $(SHA1SUM))
 DOCKER_SAITHRIFT_CLIENT_BLDR_IMG = $(DOCKER_SAITHRIFT_CLIENT_BLDR_IMG_NAME):$(DOCKER_SAITHRIFT_CLIENT_BLDR_IMG_TAG)
 
 docker-saithrift-client-bldr:
@@ -483,7 +496,7 @@ run-saithrift-client-bash:
 ###############################
 
 
-DOCKER_P4C_BMV2_IMG_TAG = $(shell cat dockerfiles/Dockerfile.p4c-bmv2 | sha1sum | awk '{print substr($$1,0,11);}')
+DOCKER_P4C_BMV2_IMG_TAG = $(shell cat dockerfiles/Dockerfile.p4c-bmv2 | $(SHA1SUM))
 DOCKER_P4C_BMV2_IMG = $(DOCKER_P4C_BMV2_IMG_NAME):$(DOCKER_P4C_BMV2_IMG_TAG)
 
 docker-dash-p4c:
@@ -512,7 +525,7 @@ docker-publish-dash-p4c:
 
 ###############################
 
-DOCKER_P4C_DPDK_IMG_TAG = $(shell cat dockerfiles/Dockerfile.p4c-dpdk | sha1sum | awk '{print substr($$1,0,11);}')
+DOCKER_P4C_DPDK_IMG_TAG = $(shell cat dockerfiles/Dockerfile.p4c-dpdk | $(SHA1SUM))
 DOCKER_P4C_DPDK_IMG = $(DOCKER_P4C_DPDK_IMG_NAME):$(DOCKER_P4C_DPDK_IMG_TAG)
 
 docker-dash-p4c-dpdk:
@@ -541,7 +554,7 @@ docker-publish-dash-p4c-dpdk:
 
 ###############################
 
-DOCKER_GRPC_IMG_TAG = $(shell cat dockerfiles/Dockerfile.grpc1.43.2 | sha1sum | awk '{print substr($$1,0,11);}')
+DOCKER_GRPC_IMG_TAG = $(shell cat dockerfiles/Dockerfile.grpc1.43.2 | $(SHA1SUM))
 DOCKER_GRPC_IMG = $(DOCKER_GRPC_IMG_NAME):$(DOCKER_GRPC_IMG_TAG)
 
 docker-dash-grpc:
@@ -639,7 +652,7 @@ ifeq ($(SAI_CHALLENGER_TEST),)
 SAI_CHALLENGER_TEST := .
 endif
 
-DOCKER_SAI_CHALLENGER_CLIENT_BLDR_IMG_TAG = $(shell cat dockerfiles/Dockerfile.saichallenger-client-bldr | sha1sum | awk '{print substr($$1,0,11);}')
+DOCKER_SAI_CHALLENGER_CLIENT_BLDR_IMG_TAG = $(shell cat dockerfiles/Dockerfile.saichallenger-client-bldr | $(SHA1SUM))
 DOCKER_SAI_CHALLENGER_CLIENT_BLDR_IMG = $(DOCKER_SAI_CHALLENGER_CLIENT_BLDR_IMG_NAME):$(DOCKER_SAI_CHALLENGER_CLIENT_BLDR_IMG_TAG)
 
 docker-saichallenger-client-bldr:

--- a/dash-pipeline/dockerfiles/Dockerfile.saithrift-bldr
+++ b/dash-pipeline/dockerfiles/Dockerfile.saithrift-bldr
@@ -1,12 +1,14 @@
 
+ARG ubuntu_image_sha
+
 FROM sonicdash.azurecr.io/dash-grpc:1.43.2 as grpc
 FROM sonicdash.azurecr.io/dash-bmv2-bldr:220819 as bmv2
-# amd64/ubuntu:20.04 on 2022-07-03
-FROM amd64/ubuntu@sha256:b2339eee806d44d6a8adc0a790f824fb71f03366dd754d400316ae5a7e3ece3e as builder
+
+FROM amd64/ubuntu@sha256:$ubuntu_image_sha as builder
+
 LABEL maintainer="SONiC-DASH Community "
 LABEL description="This Docker image contains the toolchain to build \
 the saithrift client & server + sai-P4Runtime adaptor layer, for DASH."
-
 
 # Configure make to run as many parallel jobs as cores available
 ARG available_processors
@@ -17,7 +19,7 @@ ENV TZ=America/Los_Angeles
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 ENV GIT_SSL_NO_VERIFY=true
 
-ENV SAI_PTF_DEPS    sudo git python wget doxygen graphviz aspell-en \
+ENV SAI_PTF_DEPS    sudo git python3 wget doxygen graphviz aspell-en \
                     libgetopt-long-descriptive-perl libconst-fast-perl \
                     libtemplate-perl libnamespace-autoclean-perl libmoose-perl libmoosex-aliases-perl
 
@@ -42,7 +44,7 @@ RUN wget http://archive.apache.org/dist/thrift/0.11.0/thrift-0.11.0.tar.gz && \
     make && \
     make install && \
     cd lib/py && \
-    python setup.py sdist && \
+    python3 setup.py sdist && \
     sudo cp dist/* /usr/lib && \
     cd / && \
     rm -rf thrift-0.11.0 thrift-0.11.0.tar.gz


### PR DESCRIPTION
when libsai.so is created with a compiler version that is newer than what is run within the saithrift builder docker container, we may run into unresolved linkage error (such as unresolved __libc_single_threaded).
however, if the compiler is older, we are fine.

so we need to upgrade the distro used within the saithrift build docker image.
more generically, this change allows to provide the ubuntu SHA to be used by docker to build the image from the calling Makefile.

by default, we'll use a 22.04 ubuntu version, but this can be overridden by setting AMD64_UBUNTU_SHA256 to the wanted hash.