### PR TITLE
Updated SAI-Challenger to latest main as of May 30

### DIFF
--- a/dash-pipeline/dockerfiles/DOCKER_SAI_CHALLENGER_CLIENT_BLDR_IMG.env
+++ b/dash-pipeline/dockerfiles/DOCKER_SAI_CHALLENGER_CLIENT_BLDR_IMG.env
@@ -2,4 +2,4 @@
 # Changing this will cause build/publish to occur in CI actions
 export DASH_ACR_REGISTRY=sonicdash.azurecr.io
 export DOCKER_SAI_CHALLENGER_CLIENT_BLDR_IMG_NAME=${DASH_ACR_REGISTRY}/dash-saichallenger-client-bldr
-export DOCKER_SAI_CHALLENGER_CLIENT_BLDR_IMG_CTAG?=230515
+export DOCKER_SAI_CHALLENGER_CLIENT_BLDR_IMG_CTAG?=230530

--- a/dash-pipeline/dockerfiles/Dockerfile.saichallenger-client
+++ b/dash-pipeline/dockerfiles/Dockerfile.saichallenger-client
@@ -1,4 +1,4 @@
-FROM sonicdash.azurecr.io/dash-saichallenger-client-bldr:230515
+FROM sonicdash.azurecr.io/dash-saichallenger-client-bldr:230530
 
 ENV SAI_CHALLENGER_PATH /sai-challenger
 ENV DASH_PATH /dash

--- a/dash-pipeline/dockerfiles/Dockerfile.saichallenger-client-bldr
+++ b/dash-pipeline/dockerfiles/Dockerfile.saichallenger-client-bldr
@@ -1,5 +1,5 @@
 # Requires <url of sai-challenger branch> <commit sha> or something
-# sc-client:230515
+# sc-client:230530
 FROM sc-client
 
 ADD tests/ /tests/

--- a/dash-pipeline/tests/requirements.txt
+++ b/dash-pipeline/tests/requirements.txt
@@ -1,2 +1,2 @@
 snappi==0.9.4
-pytest==6.0.1
+pytest>=6.0.1

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,2 +1,2 @@
 snappi==0.9.4
-pytest==6.0.1
+pytest>=6.0.1


### PR DESCRIPTION
This new version of SAI-Challenger auto-generates `sai_thrift_metadata.py` in run-time.
Fixes Issue https://github.com/sonic-net/DASH/issues/374