### PR TITLE
[SAI] Fix NextObjIndex method to embed objeect type into generated OID

### DIFF
--- a/dash-pipeline/SAI/templates/saiapi.cpp.j2
+++ b/dash-pipeline/SAI/templates/saiapi.cpp.j2
@@ -46,7 +46,7 @@ static sai_status_t dash_sai_create_{{ table.name }}(
     // Generate a SAI object ID and fill it as the P4 table key
     auto mf = matchActionEntry->add_match();
     mf->set_field_id({{table['keys'][0].id}});
-    objId = NextObjIndex((sai_object_type_t)SAI_OBJECT_TYPE_{{ table.name | upper}});
+    objId = NextObjectId((sai_object_type_t)SAI_OBJECT_TYPE_{{ table.name | upper}});
     auto mf_exact = mf->mutable_exact();
     {{table['keys'][0].field}}SetVal(objId, mf_exact, {{table['keys'][0].bitwidth}});
     {% else %}

--- a/dash-pipeline/SAI/templates/saiapi.cpp.j2
+++ b/dash-pipeline/SAI/templates/saiapi.cpp.j2
@@ -46,7 +46,7 @@ static sai_status_t dash_sai_create_{{ table.name }}(
     // Generate a SAI object ID and fill it as the P4 table key
     auto mf = matchActionEntry->add_match();
     mf->set_field_id({{table['keys'][0].id}});
-    objId = NextObjectId((sai_object_type_t)SAI_OBJECT_TYPE_{{ table.name | upper}});
+    objId = NextObjectId((sai_object_type_t)SAI_OBJECT_TYPE_{{ table.name | upper }});
     auto mf_exact = mf->mutable_exact();
     {{table['keys'][0].field}}SetVal(objId, mf_exact, {{table['keys'][0].bitwidth}});
     {% else %}

--- a/dash-pipeline/SAI/templates/saiapi.cpp.j2
+++ b/dash-pipeline/SAI/templates/saiapi.cpp.j2
@@ -46,7 +46,7 @@ static sai_status_t dash_sai_create_{{ table.name }}(
     // Generate a SAI object ID and fill it as the P4 table key
     auto mf = matchActionEntry->add_match();
     mf->set_field_id({{table['keys'][0].id}});
-    objId = NextObjIndex();
+    objId = NextObjIndex((sai_object_type_t)SAI_OBJECT_TYPE_{{ table.name | upper}});
     auto mf_exact = mf->mutable_exact();
     {{table['keys'][0].field}}SetVal(objId, mf_exact, {{table['keys'][0].bitwidth}});
     {% else %}
@@ -170,7 +170,7 @@ static sai_status_t dash_sai_create_{{ table.name }}(
     //if (matchedParams != expectedParams) {
     //    goto ErrRet;
     //}
-    if (false == InsertInTable(matchActionEntry, &objId)) {
+    if (false == InsertInTable(matchActionEntry, (sai_object_type_t)SAI_OBJECT_TYPE_{{ table.name | upper }}, &objId)) {
         goto ErrRet;
     }
 

--- a/dash-pipeline/SAI/templates/saifixedapis.cpp.j2
+++ b/dash-pipeline/SAI/templates/saifixedapis.cpp.j2
@@ -60,7 +60,7 @@ static sai_status_t dash_sai_get_switch_attribute(
 
                 attr->value.u32 = cfg->m_bmv2NumPorts;
 
-                DASH_LOG_NOTICE("[%d] attr %d SAI_SWITCH_ATTR_NUMBER_OF_ACTIVE_PORTS = %d", i, attr->id, attr->value.u32);
+                DASH_LOG_NOTICE("[%d] SAI_SWITCH_ATTR_NUMBER_OF_ACTIVE_PORTS = %d", i, attr->value.u32);
 
                 break;
 
@@ -73,7 +73,7 @@ static sai_status_t dash_sai_get_switch_attribute(
                     attr->value.objlist.list[j] = port_list.at(j);
                 }
 
-                DASH_LOG_NOTICE("[%d] attr %d SAI_SWITCH_ATTR_PORT_LIST = [%d objids]", i, attr->id, cfg->m_bmv2NumPorts);
+                DASH_LOG_NOTICE("[%d] SAI_SWITCH_ATTR_PORT_LIST = [%d objids]", i, cfg->m_bmv2NumPorts);
 
                 break;
 
@@ -81,7 +81,7 @@ static sai_status_t dash_sai_get_switch_attribute(
 
                 attr->value.oid = DASH_BMV2_DEFAULT_VLAN_ID;
 
-                DASH_LOG_NOTICE("[%d] attr %d SAI_SWITCH_ATTR_DEFAULT_VLAN_ID = %lx", i, attr->id, attr->value.oid);
+                DASH_LOG_NOTICE("[%d] SAI_SWITCH_ATTR_DEFAULT_VLAN_ID = %lx", i, attr->value.oid);
 
                 break;
 
@@ -89,7 +89,7 @@ static sai_status_t dash_sai_get_switch_attribute(
 
                 attr->value.oid = DASH_BMV2_DEFAULT_VRF_ID;
 
-                DASH_LOG_NOTICE("attr %d SAI_SWITCH_ATTR_DEFAULT_VIRTUAL_ROUTER_ID = %lx", attr->id, attr->value.oid);
+                DASH_LOG_NOTICE("[%d] SAI_SWITCH_ATTR_DEFAULT_VIRTUAL_ROUTER_ID = %lx", i, attr->value.oid);
 
                 break;
 
@@ -97,7 +97,7 @@ static sai_status_t dash_sai_get_switch_attribute(
 
                 attr->value.oid = DASH_BMV2_DEFAULT_1Q_BRIDGE_ID;
 
-                DASH_LOG_NOTICE("attr %d SAI_SWITCH_ATTR_DEFAULT_1Q_BRIDGE_ID = %lx", attr->id, attr->value.oid);
+                DASH_LOG_NOTICE("[%d] SAI_SWITCH_ATTR_DEFAULT_1Q_BRIDGE_ID = %lx", i, attr->value.oid);
 
                 break;
 
@@ -105,13 +105,13 @@ static sai_status_t dash_sai_get_switch_attribute(
 
                 attr->value.oid = DASH_BMV2_DEFAULT_CPU_PORT_ID;
 
-                DASH_LOG_NOTICE("[%d] attr %d DASH_BMV2_DEFAULT_CPU_PORT_ID = %lx", i, attr->id, attr->value.oid);
+                DASH_LOG_NOTICE("[%d] SAI_SWITCH_ATTR_CPU_PORT = %lx", i, attr->value.oid);
 
                 break;
 
             default:
 
-                DASH_LOG_WARN("attr %d is NOT SUPPORTED, but returning SAI_STATUS_SUCCESS", attr->id);
+                DASH_LOG_WARN("[%d] attr %d is NOT SUPPORTED, but returning SAI_STATUS_SUCCESS", i, attr->id);
 
                 memset(&attr->value, 0, sizeof(attr->value)); // clear potential caller garbage
 
@@ -159,13 +159,13 @@ static sai_status_t dash_sai_get_port_attribute(
 
                 attr->value.u32 = DASH_BMV2_CPU_QOS_NUMBER_OF_QUEUES;
 
-                DASH_LOG_NOTICE("attr %d SAI_PORT_ATTR_QOS_NUMBER_OF_QUEUES = %d", attr->id, attr->value.u32);
+                DASH_LOG_NOTICE("[%d] SAI_PORT_ATTR_QOS_NUMBER_OF_QUEUES = %d", i, attr->value.u32);
 
                 break;
 
             default:
 
-                DASH_LOG_WARN("attr %d is NOT SUPPORTED, but returning SAI_STATUS_SUCCESS", attr->id);
+                DASH_LOG_WARN("[%d] attr %d is NOT SUPPORTED, but returning SAI_STATUS_SUCCESS", i, attr->id);
 
                 memset(&attr->value, 0, sizeof(attr->value)); // clear potential caller garbage
 

--- a/dash-pipeline/SAI/templates/utils.cpp.j2
+++ b/dash-pipeline/SAI/templates/utils.cpp.j2
@@ -111,7 +111,7 @@ bool InsertInTable(std::shared_ptr<p4::v1::TableEntry> entry, sai_object_type_t 
 
     if (*objId == 0)
     {
-        *objId = NextObjIndex(objectType);
+        *objId = NextObjectId(objectType);
     }
 
     tableEntryMap.insert(std::make_pair(*objId, entry));
@@ -119,7 +119,7 @@ bool InsertInTable(std::shared_ptr<p4::v1::TableEntry> entry, sai_object_type_t 
     return true;
 }
 
-sai_object_id_t NextObjIndex(sai_object_type_t objectType)
+sai_object_id_t NextObjectId(sai_object_type_t objectType)
 {
     DASH_LOG_ENTER();
 

--- a/dash-pipeline/SAI/templates/utils.cpp.j2
+++ b/dash-pipeline/SAI/templates/utils.cpp.j2
@@ -6,6 +6,8 @@ static std::unordered_multimap<sai_object_id_t, std::shared_ptr<p4::v1::TableEnt
 static std::mutex tableLock;
 static std::atomic<sai_object_id_t> nextId;
 
+#define MUTEX std::lock_guard<std::mutex> _lock(tableLock);
+
 std::unique_ptr<p4::v1::P4Runtime::Stub> stub;
 
 void correctIpPrefix(void *ip, const void *mask, size_t length)
@@ -43,7 +45,7 @@ int leadingNonZeroBits(const sai_ip6_t ipv6) {
 }
 
 
-int GetDeviceId()
+static int GetDeviceId()
 {
     DASH_LOG_ENTER();
 
@@ -94,28 +96,34 @@ grpc::StatusCode MutateTableEntry(std::shared_ptr<p4::v1::TableEntry> entry, p4:
     return status.error_code();
 }
 
-bool InsertInTable(std::shared_ptr<p4::v1::TableEntry> entry, sai_object_id_t *objId)
+bool InsertInTable(std::shared_ptr<p4::v1::TableEntry> entry, sai_object_type_t objectType, sai_object_id_t *objId)
 {
     DASH_LOG_ENTER();
 
     auto retCode = MutateTableEntry(entry, p4::v1::Update_Type_INSERT);
-    if (grpc::StatusCode::OK != retCode) {
+
+    if (grpc::StatusCode::OK != retCode)
+    {
         return false;
     }
 
-    std::lock_guard<std::mutex> lock(tableLock);
+    MUTEX;
 
     if (*objId == 0)
     {
-        *objId = NextObjIndex();
+        *objId = NextObjIndex(objectType);
     }
+
     tableEntryMap.insert(std::make_pair(*objId, entry));
+
     return true;
 }
 
-sai_object_id_t NextObjIndex()
+sai_object_id_t NextObjIndex(sai_object_type_t objectType)
 {
     DASH_LOG_ENTER();
+
+    // TODO make proper oid
 
     return ++nextId;
 }
@@ -124,8 +132,10 @@ bool RemoveFromTable(sai_object_id_t id)
 {
     DASH_LOG_ENTER();
 
-    std::lock_guard<std::mutex> lock(tableLock);
+    MUTEX;
+
     auto range = tableEntryMap.equal_range(id);
+
     if (range.first == range.second)
     {
         DASH_LOG_ERROR("id: %ld not present in the table for deletion!", id);
@@ -135,14 +145,18 @@ bool RemoveFromTable(sai_object_id_t id)
 
     grpc::StatusCode retCode = grpc::StatusCode::OK;
 
-    for (auto itr = range.first; itr != range.second; ++itr) {
+    for (auto itr = range.first; itr != range.second; ++itr)
+    {
         auto entry = itr->second;
         auto tempRet = MutateTableEntry(entry, p4::v1::Update_Type_DELETE);
-        if (grpc::StatusCode::OK != tempRet) {
+
+        if (grpc::StatusCode::OK != tempRet)
+        {
             retCode = tempRet;
         }
     }
 
     tableEntryMap.erase(id);
+
     return retCode == grpc::StatusCode::OK;
 }

--- a/dash-pipeline/SAI/templates/utils.cpp.j2
+++ b/dash-pipeline/SAI/templates/utils.cpp.j2
@@ -119,13 +119,14 @@ bool InsertInTable(std::shared_ptr<p4::v1::TableEntry> entry, sai_object_type_t 
     return true;
 }
 
+// TODO to be removed and merged
+#define DASH_OBJECT_SHFT 48
+#define DASH_MAKE_OID(_objtype, _objval) (sai_object_id_t)(((sai_object_id_t)_objtype<<DASH_OBJECT_SHFT)+(sai_object_id_t)_objval)
 sai_object_id_t NextObjectId(sai_object_type_t objectType)
 {
     DASH_LOG_ENTER();
 
-    // TODO make proper oid
-
-    return ++nextId;
+    return DASH_MAKE_OID(objectType, ++nextId);
 }
 
 bool RemoveFromTable(sai_object_id_t id)

--- a/dash-pipeline/SAI/templates/utils.h.j2
+++ b/dash-pipeline/SAI/templates/utils.h.j2
@@ -313,10 +313,8 @@ void u64SetMask(const sai_uint64_t &value, T &t, int bits = 64) {
 
 grpc::StatusCode MutateTableEntry(std::shared_ptr<p4::v1::TableEntry>, p4::v1::Update_Type updateType);
 
-sai_object_id_t NextObjIndex();
+sai_object_id_t NextObjIndex(sai_object_type_t objectType);
 
-bool InsertInTable(std::shared_ptr<p4::v1::TableEntry> entry, sai_object_id_t *objId);
+bool InsertInTable(std::shared_ptr<p4::v1::TableEntry> entry, sai_object_type_t objectType, sai_object_id_t *objId);
 
 bool RemoveFromTable(sai_object_id_t id);
-
-int GetDeviceId();

--- a/dash-pipeline/SAI/templates/utils.h.j2
+++ b/dash-pipeline/SAI/templates/utils.h.j2
@@ -313,7 +313,7 @@ void u64SetMask(const sai_uint64_t &value, T &t, int bits = 64) {
 
 grpc::StatusCode MutateTableEntry(std::shared_ptr<p4::v1::TableEntry>, p4::v1::Update_Type updateType);
 
-sai_object_id_t NextObjIndex(sai_object_type_t objectType);
+sai_object_id_t NextObjectId(sai_object_type_t objectType);
 
 bool InsertInTable(std::shared_ptr<p4::v1::TableEntry> entry, sai_object_type_t objectType, sai_object_id_t *objId);
 

--- a/dash-pipeline/tests/libsai/init_switch/init_switch.cpp
+++ b/dash-pipeline/tests/libsai/init_switch/init_switch.cpp
@@ -1,15 +1,23 @@
-#include <iostream>
 #include "utils.h"
 
-/*
-   Run this program to indirectly cause simple_switch_grpc to load its P4 pipeline
- */
+#include <iostream>
+
+// Run this program to indirectly cause simple_switch_grpc to load its P4 pipeline
+
 int main(int argc, char **argv)
 {
-    // Make one benign call into libsai; it will force library load and
-    // invoke static lib initializer Init() which calls SetForwardingPipelineConfigRequest()
-    GetDeviceId();
-    std::cout << "Switch is initialized." << std::endl;
+    // try initialize SAI api, this will load sai library and initialize P4 GRPC
 
-    return 0;
+    sai_status_t status = sai_api_initialize(0, nullptr);
+
+    if (status == SAI_STATUS_SUCCESS)
+    {
+        std::cout << "sai_api_initialize success" << std::endl;
+
+        return 0;
+    }
+
+    std::cout << "sai_api_initialize failed: " << status << std::endl;
+
+    return 1;
 }


### PR DESCRIPTION
Couple changes:

* fix NextObjIndex and rename to NextObjectId, which embeds correct object type, this will be needed in sai_object_type_query
* fix dome log messages in get_switch_attribute
* move GetDeviceId to static, since no longer required to be public
* fix init_switch.cpp, since previously was using GetDeviceId to init GRPS channel, now  this is done inside sai_api_initialize