### PR TITLE
Adds SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION api to dash_underlay_routing

### DIFF
--- a/dash-pipeline/bmv2/underlay.p4
+++ b/dash-pipeline/bmv2/underlay.p4
@@ -33,6 +33,16 @@ control underlay(
 #endif // TARGET_DPDK_PNA  
     }
 
+    action pkt_act(bit<9> packet_action, bit<9> next_hop_id) {
+        if(packet_action == 0) {
+            /* Drops the packet */
+            meta.dropped = true;
+        } else if (packet_action == 1) {
+            /* Forwards the packet on different/same port it arrived based on routing */
+            set_nhop(next_hop_id);
+        }
+    }
+
     action def_act() {
 #ifdef TARGET_BMV2_V1MODEL
         standard_metadata.egress_spec = standard_metadata.ingress_port;
@@ -61,8 +71,9 @@ control underlay(
         }
 
         actions = {
-            /* Send packet on different/same port it arrived based on routing */
-            set_nhop;
+            // Processes a packet based on the specified packet action.
+            // Depending on the packet action, it either drops the packet or forwards it to the specified next-hop. 
+            pkt_act;
 
             /* Send packet on same port it arrived (echo) by default */
             @defaultonly def_act;

--- a/dash-pipeline/bmv2/underlay.p4
+++ b/dash-pipeline/bmv2/underlay.p4
@@ -2,6 +2,11 @@
 #include "dash_headers.p4"
 #include "dash_metadata.p4"
 
+// The values in this context have been sourced from the 'saiswitch.h' file and 
+// have been manually designated to maintain alignment with enum values specified in the SAI commit <d8d40b4>.
+#define SAI_PACKET_ACTION_DROP 0
+#define SAI_PACKET_ACTION_FORWARD 1
+
 control underlay(
       inout headers_t hdr
     , inout metadata_t meta
@@ -34,10 +39,10 @@ control underlay(
     }
 
     action pkt_act(bit<9> packet_action, bit<9> next_hop_id) {
-        if(packet_action == 0) {
+        if(packet_action == SAI_PACKET_ACTION_DROP) {
             /* Drops the packet */
             meta.dropped = true;
-        } else if (packet_action == 1) {
+        } else if (packet_action == SAI_PACKET_ACTION_FORWARD) {
             /* Forwards the packet on different/same port it arrived based on routing */
             set_nhop(next_hop_id);
         }

--- a/test/test-cases/scale/saic/vnet_route_setup_commands_bidirectional.json
+++ b/test/test-cases/scale/saic/vnet_route_setup_commands_bidirectional.json
@@ -26,6 +26,32 @@
         ]
     },
     {
+        "name": "vpe_2",
+        "op": "create",
+        "type": "SAI_OBJECT_TYPE_VIP_ENTRY",
+        "key": {
+            "switch_id": "$SWITCH_ID",
+            "vip": "10.11.1.20"
+        },
+        "attributes": [
+            "SAI_VIP_ENTRY_ATTR_ACTION",
+            "SAI_VIP_ENTRY_ACTION_ACCEPT"
+        ]
+    },
+    {
+        "name": "vpe_3",
+        "op": "create",
+        "type": "SAI_OBJECT_TYPE_VIP_ENTRY",
+        "key": {
+            "switch_id": "$SWITCH_ID",
+            "vip": "170.16.1.100"
+        },
+        "attributes": [
+            "SAI_VIP_ENTRY_ATTR_ACTION",
+            "SAI_VIP_ENTRY_ACTION_ACCEPT"
+        ]
+    },
+    {
         "name": "dle",
         "op": "create",
         "type": "SAI_OBJECT_TYPE_DIRECTION_LOOKUP_ENTRY",
@@ -218,6 +244,136 @@
         ]
     },
     {
+        "name": "eni_2",
+        "op": "create",
+        "type": "SAI_OBJECT_TYPE_ENI",
+        "attributes": [
+            "SAI_ENI_ATTR_CPS",
+            "10000",
+            "SAI_ENI_ATTR_PPS",
+            "100000",
+            "SAI_ENI_ATTR_FLOWS",
+            "100000",
+            "SAI_ENI_ATTR_ADMIN_STATE",
+            "True",
+            "SAI_ENI_ATTR_VM_UNDERLAY_DIP",
+            "10.11.1.10",
+            "SAI_ENI_ATTR_VM_VNI",
+            "9",
+            "SAI_ENI_ATTR_VNET_ID",
+            "$vnet",
+            "SAI_ENI_ATTR_INBOUND_V4_STAGE1_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_INBOUND_V4_STAGE2_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_INBOUND_V4_STAGE3_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_INBOUND_V4_STAGE4_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_INBOUND_V4_STAGE5_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_INBOUND_V6_STAGE1_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_INBOUND_V6_STAGE2_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_INBOUND_V6_STAGE3_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_INBOUND_V6_STAGE4_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_INBOUND_V6_STAGE5_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_OUTBOUND_V4_STAGE1_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_OUTBOUND_V4_STAGE2_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_OUTBOUND_V4_STAGE3_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_OUTBOUND_V4_STAGE4_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_OUTBOUND_V4_STAGE5_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_OUTBOUND_V6_STAGE1_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_OUTBOUND_V6_STAGE2_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_OUTBOUND_V6_STAGE3_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_OUTBOUND_V6_STAGE4_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_OUTBOUND_V6_STAGE5_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_V4_METER_POLICY_ID",
+            "0",
+            "SAI_ENI_ATTR_V6_METER_POLICY_ID",
+            "0"
+        ]
+    },
+    {
+        "name": "eni_3",
+        "op": "create",
+        "type": "SAI_OBJECT_TYPE_ENI",
+        "attributes": [
+            "SAI_ENI_ATTR_CPS",
+            "10000",
+            "SAI_ENI_ATTR_PPS",
+            "100000",
+            "SAI_ENI_ATTR_FLOWS",
+            "100000",
+            "SAI_ENI_ATTR_ADMIN_STATE",
+            "True",
+            "SAI_ENI_ATTR_VM_UNDERLAY_DIP",
+            "170.16.1.1",
+            "SAI_ENI_ATTR_VM_VNI",
+            "9",
+            "SAI_ENI_ATTR_VNET_ID",
+            "$vnet",
+            "SAI_ENI_ATTR_INBOUND_V4_STAGE1_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_INBOUND_V4_STAGE2_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_INBOUND_V4_STAGE3_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_INBOUND_V4_STAGE4_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_INBOUND_V4_STAGE5_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_INBOUND_V6_STAGE1_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_INBOUND_V6_STAGE2_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_INBOUND_V6_STAGE3_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_INBOUND_V6_STAGE4_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_INBOUND_V6_STAGE5_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_OUTBOUND_V4_STAGE1_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_OUTBOUND_V4_STAGE2_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_OUTBOUND_V4_STAGE3_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_OUTBOUND_V4_STAGE4_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_OUTBOUND_V4_STAGE5_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_OUTBOUND_V6_STAGE1_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_OUTBOUND_V6_STAGE2_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_OUTBOUND_V6_STAGE3_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_OUTBOUND_V6_STAGE4_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_OUTBOUND_V6_STAGE5_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_V4_METER_POLICY_ID",
+            "0",
+            "SAI_ENI_ATTR_V6_METER_POLICY_ID",
+            "0"
+        ]
+    },
+    {
         "name": "eam",
         "op": "create",
         "type": "SAI_OBJECT_TYPE_ENI_ETHER_ADDRESS_MAP_ENTRY",
@@ -328,23 +484,67 @@
         ]
     },
     {
-        "name": "route_entry_3",
+        "name": "ocpe_2",
+        "op": "create",
+        "type": "SAI_OBJECT_TYPE_OUTBOUND_CA_TO_PA_ENTRY",
+        "key": {
+            "switch_id": "$SWITCH_ID",
+            "dst_vnet_id": "$vnet",
+            "dip": "171.18.1.100"
+        },
+        "attributes": [
+            "SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_UNDERLAY_DIP",
+            "10.11.1.15",
+            "SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_OVERLAY_DMAC",
+            "00:BB:BB:BB:00:00",
+            "SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_USE_DST_VNET_VNI",
+            "True",
+            "SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_METER_CLASS",
+            "0",
+            "SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_METER_CLASS_OVERRIDE",
+            "False"
+        ]
+    },
+    {
+        "name": "ocpe_3",
+        "op": "create",
+        "type": "SAI_OBJECT_TYPE_OUTBOUND_CA_TO_PA_ENTRY",
+        "key": {
+            "switch_id": "$SWITCH_ID",
+            "dst_vnet_id": "$vnet",
+            "dip": "12.1.2.50"
+        },
+        "attributes": [
+            "SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_UNDERLAY_DIP",
+            "170.16.1.20",
+            "SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_OVERLAY_DMAC",
+            "00:DD:DD:DD:00:00",
+            "SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_USE_DST_VNET_VNI",
+            "True",
+            "SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_METER_CLASS",
+            "0",
+            "SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_METER_CLASS_OVERRIDE",
+            "False"
+        ]
+    },
+    {
+        "name": "route_entry_1",
         "op": "create",
         "type": "SAI_OBJECT_TYPE_ROUTE_ENTRY",
         "key": {
             "switch_id": "$SWITCH_ID",
             "vr_id": "10",
-            "destination": "10.0.0.20/8"
+            "destination": "10.10.0.20/16"
         },
         "attributes": [
             "SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION",
             "SAI_PACKET_ACTION_FORWARD",
             "SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID",
-            "1"
+            "0"
         ]
     },
     {
-        "name": "route_entry_4",
+        "name": "route_entry_2",
         "op": "create",
         "type": "SAI_OBJECT_TYPE_ROUTE_ENTRY",
         "key": {
@@ -354,9 +554,41 @@
         },
         "attributes": [
             "SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION",
+            "SAI_PACKET_ACTION_FORWARD",
+            "SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID",
+            "1"
+        ]
+    },
+    {
+        "name": "route_entry_3",
+        "op": "create",
+        "type": "SAI_OBJECT_TYPE_ROUTE_ENTRY",
+        "key": {
+            "switch_id": "$SWITCH_ID",
+            "vr_id": "10",
+            "destination": "10.11.0.20/16"
+        },
+        "attributes": [
+            "SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION",
             "SAI_PACKET_ACTION_DROP",
             "SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID",
-            "2"
+            "0"
+        ]
+    },
+    {
+        "name": "route_entry_4",
+        "op": "create",
+        "type": "SAI_OBJECT_TYPE_ROUTE_ENTRY",
+        "key": {
+            "switch_id": "$SWITCH_ID",
+            "vr_id": "10",
+            "destination": "170.0.0.10/8"
+        },
+        "attributes": [
+            "SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION",
+            "SAI_PACKET_ACTION_DROP",
+            "SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID",
+            "1"
         ]
     }
 ]

--- a/test/test-cases/scale/saic/vnet_route_setup_commands_bidirectional.json
+++ b/test/test-cases/scale/saic/vnet_route_setup_commands_bidirectional.json
@@ -337,6 +337,8 @@
             "destination": "10.0.0.20/8"
         },
         "attributes": [
+            "SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION",
+            "SAI_PACKET_ACTION_FORWARD",
             "SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID",
             "1"
         ]
@@ -351,6 +353,8 @@
             "destination": "172.0.0.10/8"
         },
         "attributes": [
+            "SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION",
+            "SAI_PACKET_ACTION_DROP",
             "SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID",
             "2"
         ]

--- a/test/test-cases/scale/saic/vnet_route_setup_commands_unidirectional.json
+++ b/test/test-cases/scale/saic/vnet_route_setup_commands_unidirectional.json
@@ -171,21 +171,5 @@
             "SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_METER_CLASS_OVERRIDE",
             "False"
         ]
-    },
-    {
-        "name": "route_entry_1",
-        "op": "create",
-        "type": "SAI_OBJECT_TYPE_ROUTE_ENTRY",
-        "key": {
-            "switch_id": "$SWITCH_ID",
-            "vr_id": "10",
-            "destination": "0.0.0.0/0"
-        },
-        "attributes": [
-            "SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION",
-            "SAI_PACKET_ACTION_FORWARD",
-            "SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID",
-            "1"
-        ]
     }
 ]

--- a/test/test-cases/scale/saic/vnet_route_setup_commands_unidirectional.json
+++ b/test/test-cases/scale/saic/vnet_route_setup_commands_unidirectional.json
@@ -182,6 +182,8 @@
             "destination": "0.0.0.0/0"
         },
         "attributes": [
+            "SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION",
+            "SAI_PACKET_ACTION_FORWARD",
             "SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID",
             "1"
         ]


### PR DESCRIPTION
**Description of PR**
This subsequent PR is the continuation of dash_underlay implementation PR #404  in BMv2 of the design mentioned in the dash hld under swss lite.

The focus of this PR is on introducing the implementation of SAI call for "SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION" 

The attribute implemented is "SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION". In this PR we have added support for packet action types "SAI_PACKET_ACTION_DROP" and "SAI_PACKET_ACTION_FORWARD". 

**Functionality**
In the current implementation, when there is no match in the routing table, the packet continues to be reflected on the same port and when a route is matched in the routing table, the packet is directed to a different port as specified by the matching route.

This PR decides whether to drop or forward the packet first. If the packet is to be forwarded, it goes through the next hop functionality else drops the packet.

**Main Changes**
- Add "packet_action" action to Underlay routing table P4 logic.
- Add VNET API for testing the functionality.

**How did you verify/test it?**
Can run the following test cases successfully:
- test_config_vnet_route_bidirectional.py
- test_config_vnet_route_unidirectional.py