### PR TITLE
update p4 compile dependency to avoid parallel identical docker runs for both the json and the p4rt.txt

### DIFF
--- a/dash-pipeline/Makefile
+++ b/dash-pipeline/Makefile
@@ -103,8 +103,10 @@ p4: $(P4_ARTIFACTS)
 p4-clean:
 	rm -rf $(P4_OUTDIR)
 
+$(P4_OUTDIR)/dash_pipeline.json: $(P4_OUTDIR)/dash_pipeline_p4rt.txt
+
 # Compile P4 into bmv2 .json fle and P4info for SAI header autogeneration
-$(P4_ARTIFACTS): $(P4_SRC)
+$(P4_OUTDIR)/dash_pipeline_p4rt.txt: $(P4_SRC)
 	@echo "Compile P4 program $(P4_MAIN) for bmv2 ..."
 	mkdir -p $(P4_OUTDIR)
 	docker run \


### PR DESCRIPTION
p4 depends on 
P4_ARTIFACTS=$(P4_OUTDIR)/dash_pipeline.json $(P4_OUTDIR)/dash_pipeline_p4rt.txt

the makefile was modified to include a P4_ARTIFACTS rule. this means that 2 identical parallel docker runs will be launched (one for each of the files) causing an issue when compiling p4 (DOCKER_FLAGS= make -j p4)

the fix is to create a rule for the json file (to depend on p4rt) and update the docker run rule to be for the p4rt file.

