### PR TITLE
[SAI] Update SAI submodule to the latest origin/master

### DIFF
--- a/dash-pipeline/Makefile
+++ b/dash-pipeline/Makefile
@@ -196,7 +196,7 @@ sai-meta:
 		-v $(PWD)/..:/dash \
 		-w /dash/dash-pipeline/SAI/SAI/meta \
 		$(DOCKER_SAITHRIFT_BLDR_IMG) \
-	    make
+	    make all libsaimetadata.so
 
 libsai: SAI/lib/libsai.so
 

--- a/dash-pipeline/SAI/saithrift/Makefile
+++ b/dash-pipeline/SAI/saithrift/Makefile
@@ -34,6 +34,7 @@ saithrift-server: host
 
 	# Install vendor specific SAI library i.e. DASH bmv2 libsai.so in /usr/lib.
 	sudo cp $(LIB)/libsai.so /usr/lib
+	sudo cp $(META)/libsaimetadata.so /usr/lib
 
 	@echo "Build SAI thrift server and libraries..."
 	$(SUDO) mkdir -p $(RPC_INST_DIR)


### PR DESCRIPTION
Also compile libsaimetadata.so, so it wont be compiled as objects into saithrift server anymore, it will be used as external library