### PR TITLE
Add capability model for DASH pipeline and matching stages.

### DIFF
--- a/documentation/general/dash-sai-pipeline-packet-flow.md
+++ b/documentation/general/dash-sai-pipeline-packet-flow.md
@@ -38,9 +38,11 @@
       5. [5.9.5. Metadata publishing](#595-metadata-publishing)
    10. [5.10. Action apply](#510-action-apply)
    11. [5.11. Meter update](#511-meter-update)
-6. [6. Matching stage capability](#6-matching-stage-capability)
-   1. [6.1. Metadata capability](#61-metadata-capability)
-   2. [6.2. Routing action capability](#62-routing-action-capability)
+6. [6. DASH pipeline capability model](#6-dash-pipeline-capability-model)
+   1. [6.1. Matching stage capability](#61-matching-stage-capability)
+      1. [6.1.1. Matching stage metadata capability](#611-matching-stage-metadata-capability)
+   2. [6.2. Pipeline capability](#62-pipeline-capability)
+      1. [6.2.1. Routing action capability](#621-routing-action-capability)
 7. [7. Examples](#7-examples)
    1. [7.1. VNET routing](#71-vnet-routing)
    2. [7.2. VM level public IP inbound (L3 DNAT)](#72-vm-level-public-ip-inbound-l3-dnat)
@@ -721,13 +723,15 @@ After all matching stages are done, we will start applying all the actions. All 
 
 After all actions are applied, post-pipeline ACLs are passed, we will update the metering counters if any metering class is specified.
 
-## 6. Matching stage capability
+## 6. DASH pipeline capability model
 
 Although, the logical pipeline or behavior model allows us to set any metadata in any stage or doing any routing actions that we want, the ASIC can have certain limitations, either the functionality or the resource. So, we should allow technology providers to tell the user what is supported via capability.
 
 Because the underlying pipeline shall be initialized, when SAI create switch function call completes with specified profile. The capability of all stages will be known by then.
 
-### 6.1. Metadata capability
+### 6.1. Matching stage capability
+
+#### 6.1.1. Matching stage metadata capability
 
 First capability is the metadata capability.
 
@@ -752,7 +756,9 @@ typedef struct _sai_dash_stage_capability_t
 
 At this moment, DASH doesn't have a dedicated type for modeling the stages, hence the capabilities are exposed via SAI switch extensions.
 
-### 6.2. Routing action capability
+### 6.2. Pipeline capability
+
+#### 6.2.1. Routing action capability
 
 Similar to metadata capability, we should also allow technology providers to tell the user which routing actions are supported by the ASIC via capability, which can be defined as below in high level:
 

--- a/documentation/general/dash-sai-pipeline-packet-flow.md
+++ b/documentation/general/dash-sai-pipeline-packet-flow.md
@@ -36,6 +36,7 @@
          3. [5.9.3.3. Multi-stage chaining](#5933-multi-stage-chaining)
       4. [5.9.4. Action publishing](#594-action-publishing)
       5. [5.9.5. Metadata publishing](#595-metadata-publishing)
+      6. [5.9.6. Routing active capability](#596-routing-active-capability)
    10. [5.10. Action apply](#510-action-apply)
    11. [5.11. Meter update](#511-meter-update)
 6. [6. Examples](#6-examples)
@@ -490,7 +491,7 @@ flowchart LR
 
 To transit between stages, we use `transition` field to specify the transition routing type.
 
-A transition routing type is a special type of [Routing Type](#572-routing-type):
+A transition routing type is a special type of [Routing Type](#582-routing-type):
 
 1. Each transition routing type can only have one single routing action.
 2. Only a special list of routing actions will take effect in the routing types, which are all related to stage transitions, as listed below.
@@ -613,7 +614,7 @@ Or, with a slight change, we can implement another routing policy to enable a tu
 
 #### 5.9.4. Action publishing
 
-Each entry in the matching stages can specify a [routing type](#572-routing-type) that specifies the routing actions for specifying the packet transformations. When an entry is matched in the matching stages, the actions will be populated into the metadata bus, and the actions will be applied when the packet reaches the action apply stage.
+Each entry in the matching stages can specify a [routing type](#582-routing-type) that specifies the routing actions for specifying the packet transformations. When an entry is matched in the matching stages, the actions will be populated into the metadata bus, and the actions will be applied when the packet reaches the action apply stage.
 
 Populating the actions into the metadata bus are straightforward, which can be illustrated by the P4 code below:
 
@@ -725,6 +726,8 @@ For example, say, we have a network with this policy: all traffic that sends to 
     "DASH_SAI_ROUTING_TYPE_TABLE|firewalltunnel": [ { "action_type": "tunnel", "target": "underlay1" } ]
 }
 ```
+
+#### 5.9.6. Routing active capability
 
 ### 5.10. Action apply
 

--- a/documentation/general/dash-sai-pipeline-packet-flow.md
+++ b/documentation/general/dash-sai-pipeline-packet-flow.md
@@ -618,7 +618,7 @@ Or, with a slight change, we can implement another routing policy to enable a tu
 
 #### 5.9.4. Action publishing
 
-Each entry in the matching stages can specify a [routing type](#582-routing-type) that contains a list of the routing actions for specifying the packet transformations. Since each action is designed to be independent, the routing types can be defined as a bitset, where every bit is a different type of action. When an entry is matched in the matching stages, the actions will be merged into the metadata bus, and the actions will be applied when the packet reaches the action apply stage.
+Each entry in the matching stages can specify a [routing type](#582-routing-type) that contains a list of the routing actions for specifying the packet transformations. Since each action is designed to be independent, the routing types can be defined as a bit set, where every bit is a different type of action. When an entry is matched in the matching stages, the actions will be merged into the metadata bus, and the actions will be applied when the packet reaches the action apply stage.
 
 Populating the actions into the metadata bus are straightforward, which can be illustrated by the P4 code below:
 


### PR DESCRIPTION
This change is a follow up update for the new packet flow.

Although, the logical pipeline or behavior model allows us to set any metadata in any stage or doing any routing actions that we want, the ASIC can have certain limitations, either the functionality or the resource. So, we should allow technology providers to tell the user what is supported via capability.