### PR TITLE
Rename is_*_v4_or_v6 to *_is_v6.

### DIFF
--- a/dash-pipeline/SAI/sai_api_gen.py
+++ b/dash-pipeline/SAI/sai_api_gen.py
@@ -293,9 +293,9 @@ class SAIAPITableKey(SAIObject):
         self.sai_key_name = ""
         self.match_type = ""
         self.bitwidth = 0
-        self.is_ipv6_field_id = 0
+        self.ip_is_v6_field_id = 0
 
-    def parse_p4rt(self, p4rt_table_key, is_ipv6_key_ids):
+    def parse_p4rt(self, p4rt_table_key, ip_is_v6_key_ids):
         '''
         This method parses the P4Runtime table key object and populates the SAI API table key object.
 
@@ -350,9 +350,9 @@ class SAIAPITableKey(SAIObject):
                 raise ValueError(f"match_type={self.match_type} is not supported")
 
         # If *_is_v6 key is present, save its id.
-        is_ipv6_key_name = self.sai_key_name + "_is_v6"
-        if is_ipv6_key_name in is_ipv6_key_ids:
-            self.is_ipv6_field_id = is_ipv6_key_ids[is_ipv6_key_name]
+        ip_is_v6_key_name = self.sai_key_name + "_is_v6"
+        if ip_is_v6_key_name in ip_is_v6_key_ids:
+            self.ip_is_v6_field_id = ip_is_v6_key_ids[ip_is_v6_key_name]
 
         return
 
@@ -391,16 +391,16 @@ class SAIAPITableAction(SAIObject):
             return
 
         # Save all *_is_v6 param ids.
-        is_ipv6_param_ids = dict()
+        ip_is_v6_param_ids = dict()
         for p4rt_table_action_param in p4rt_table_action[PARAMS_TAG]:
             if '_is_v6' in p4rt_table_action_param[NAME_TAG]:
-                is_ipv6_param_name = p4rt_table_action_param[NAME_TAG]
-                is_ipv6_param_ids[is_ipv6_param_name] = p4rt_table_action_param['id']
+                ip_is_v6_param_name = p4rt_table_action_param[NAME_TAG]
+                ip_is_v6_param_ids[ip_is_v6_param_name] = p4rt_table_action_param['id']
 
         # Parse all params.
         for p in p4rt_table_action[PARAMS_TAG]:
             param_name = p[NAME_TAG]
-            param = SAIAPITableActionParam.from_p4rt(p, sai_enums = sai_enums, is_ipv6_param_ids = is_ipv6_param_ids)
+            param = SAIAPITableActionParam.from_p4rt(p, sai_enums = sai_enums, ip_is_v6_param_ids = ip_is_v6_param_ids)
             self.params.append(param)
 
         return
@@ -412,10 +412,10 @@ class SAIAPITableActionParam(SAIObject):
         super().__init__()
         self.bitwidth = 0
         self.default = None
-        self.is_ipv6_field_id = 0
+        self.ip_is_v6_field_id = 0
         self.paramActions = []
 
-    def parse_p4rt(self, p4rt_table_action_param, sai_enums, is_ipv6_param_ids):
+    def parse_p4rt(self, p4rt_table_action_param, sai_enums, ip_is_v6_param_ids):
         '''
         This method parses the P4Runtime table action object and populates the SAI API table action object.
 
@@ -440,9 +440,9 @@ class SAIAPITableActionParam(SAIObject):
         self.bitwidth = p4rt_table_action_param[BITWIDTH_TAG]
 
         # If *_is_v6 key is present, save its id.
-        is_ipv6_param_name = self.name + "_is_v6"
-        if is_ipv6_param_name in is_ipv6_param_ids:
-            self.is_ipv6_field_id = is_ipv6_param_ids[is_ipv6_param_name]
+        ip_is_v6_param_name = self.name + "_is_v6"
+        if ip_is_v6_param_name in ip_is_v6_param_ids:
+            self.ip_is_v6_field_id = ip_is_v6_param_ids[ip_is_v6_param_name]
 
         return
 
@@ -530,18 +530,18 @@ class SAIAPITableData(SAIObject):
         return 'false'
 
     def __parse_table_keys(self, p4rt_table):
-        is_ipv6_key_ids = dict()
+        ip_is_v6_key_ids = dict()
         for p4rt_table_key in p4rt_table[MATCH_FIELDS_TAG]:
             if '_is_v6' in p4rt_table_key[NAME_TAG]:
-                _, is_ipv6_key_name = p4rt_table_key[NAME_TAG].split(':')
-                is_ipv6_key_ids[is_ipv6_key_name] = p4rt_table_key['id']
+                _, ip_is_v6_key_name = p4rt_table_key[NAME_TAG].split(':')
+                ip_is_v6_key_ids[ip_is_v6_key_name] = p4rt_table_key['id']
 
         for p4rt_table_key in p4rt_table[MATCH_FIELDS_TAG]:
             # Skip all *_is_v6 keys, as they will be linked via table key property.
             if '_is_v6' in p4rt_table_key[NAME_TAG]:
                 continue
 
-            table_key = SAIAPITableKey.from_p4rt(p4rt_table_key, is_ipv6_key_ids)
+            table_key = SAIAPITableKey.from_p4rt(p4rt_table_key, ip_is_v6_key_ids)
             self.keys.append(table_key)
 
         for p4rt_table_key in self.keys:

--- a/dash-pipeline/SAI/templates/saiapi.cpp.j2
+++ b/dash-pipeline/SAI/templates/saiapi.cpp.j2
@@ -106,11 +106,11 @@ static sai_status_t dash_sai_create_{{ table.name }}(
                 assert(mask && "SAI_{{ table.name | upper }}_ATTR_{{ key.sai_key_name | upper }}_MASK isn't provided");
                 {{key.field}}SetMask(mask->value, mf_ternary, {{key.bitwidth}});
                 {% endif %}
-                {% if key.is_ipv6_field_id != 0 %}
+                {% if key.ip_is_v6_field_id != 0 %}
                 {
-                    // set is_ipv6_field_id field
+                    // set ip_is_v6_field_id field
                     auto mf = matchActionEntry->add_match();
-                    mf->set_field_id({{key.is_ipv6_field_id}});
+                    mf->set_field_id({{key.ip_is_v6_field_id}});
                     auto mf_exact = mf->mutable_exact();
                     booldataSetVal((attr_list[i].value.ipaddr.addr_family == SAI_IP_ADDR_FAMILY_IPV4) ? 0 : 1, mf_exact, 1);
                 }
@@ -187,11 +187,11 @@ static sai_status_t dash_sai_create_{{ table.name }}(
                 param->set_param_id({{param.id}});
                 {{param.field}}SetVal(attr_list[i].value, param, {{param.bitwidth}});
                 //matchedParams++;
-                {% if param.is_ipv6_field_id != 0 %}
+                {% if param.ip_is_v6_field_id != 0 %}
                 {
-                    // set is_ipv6_field_id field
+                    // set ip_is_v6_field_id field
                     auto param2 = action->add_params();
-                    param2->set_param_id({{param.is_ipv6_field_id}});
+                    param2->set_param_id({{param.ip_is_v6_field_id}});
                     booldataSetVal((attr_list[i].value.ipaddr.addr_family == SAI_IP_ADDR_FAMILY_IPV4) ? 0 : 1, param2, 1);
                     //matchedParams++;
                 }
@@ -364,11 +364,11 @@ static sai_status_t dash_sai_create_{{ table.name }}(
         //{{key.field}}SetVal(attr_list[i].value, mf1_list, {{key.bitwidth}});
         {% endif %}
     }
-    {% if key.is_ipv6_field_id != 0 %}
+    {% if key.ip_is_v6_field_id != 0 %}
     {
-        // set is_ipv6_field_id field
+        // set ip_is_v6_field_id field
         auto mf = matchActionEntry->add_match();
-        mf->set_field_id({{key.is_ipv6_field_id}});
+        mf->set_field_id({{key.ip_is_v6_field_id}});
         auto mf_exact = mf->mutable_exact();
         booldataSetVal((tableEntry->{{ key.sai_key_name | lower }}.addr_family == SAI_IP_ADDR_FAMILY_IPV4) ? 0 : 1, mf_exact, 1);
     }
@@ -422,11 +422,11 @@ static sai_status_t dash_sai_create_{{ table.name }}(
                 param->set_param_id({{param.id}});
                 {{param.field}}SetVal(attr_list[i].value, param, {{param.bitwidth}});
                 //matchedParams++;
-                {% if param.is_ipv6_field_id != 0 %}
+                {% if param.ip_is_v6_field_id != 0 %}
                 {
-                    // set is_ipv6_field_id field
+                    // set ip_is_v6_field_id field
                     auto param2 = action->add_params();
-                    param2->set_param_id({{param.is_ipv6_field_id}});
+                    param2->set_param_id({{param.ip_is_v6_field_id}});
                     booldataSetVal((attr_list[i].value.ipaddr.addr_family == SAI_IP_ADDR_FAMILY_IPV4) ? 0 : 1, param2, 1);
                     //matchedParams++;
                 }
@@ -527,11 +527,11 @@ static sai_status_t dash_sai_remove_{{ table.name }}(
         //{{key.field}}SetVal(attr_list[i].value, mf1_list, {{key.bitwidth}});
         {% endif %}
     }
-    {% if key.is_ipv6_field_id != 0 %}
+    {% if key.ip_is_v6_field_id != 0 %}
     {
-        // set is_ipv6_field_id field
+        // set ip_is_v6_field_id field
         auto mf = matchActionEntry->add_match();
-        mf->set_field_id({{key.is_ipv6_field_id}});
+        mf->set_field_id({{key.ip_is_v6_field_id}});
         auto mf_exact = mf->mutable_exact();
         booldataSetVal((tableEntry->{{ key.sai_key_name | lower }}.addr_family == SAI_IP_ADDR_FAMILY_IPV4) ? 0 : 1, mf_exact, 1);
     }

--- a/dash-pipeline/SAI/templates/saiapi.cpp.j2
+++ b/dash-pipeline/SAI/templates/saiapi.cpp.j2
@@ -106,11 +106,11 @@ static sai_status_t dash_sai_create_{{ table.name }}(
                 assert(mask && "SAI_{{ table.name | upper }}_ATTR_{{ key.sai_key_name | upper }}_MASK isn't provided");
                 {{key.field}}SetMask(mask->value, mf_ternary, {{key.bitwidth}});
                 {% endif %}
-                {% if key.v4_or_v6_id != 0 %}
+                {% if key.is_ipv6_field_id != 0 %}
                 {
-                    // set v4_or_v6 field
+                    // set is_ipv6_field_id field
                     auto mf = matchActionEntry->add_match();
-                    mf->set_field_id({{key.v4_or_v6_id}});
+                    mf->set_field_id({{key.is_ipv6_field_id}});
                     auto mf_exact = mf->mutable_exact();
                     booldataSetVal((attr_list[i].value.ipaddr.addr_family == SAI_IP_ADDR_FAMILY_IPV4) ? 0 : 1, mf_exact, 1);
                 }
@@ -187,11 +187,11 @@ static sai_status_t dash_sai_create_{{ table.name }}(
                 param->set_param_id({{param.id}});
                 {{param.field}}SetVal(attr_list[i].value, param, {{param.bitwidth}});
                 //matchedParams++;
-                {% if param.v4_or_v6_id != 0 %}
+                {% if param.is_ipv6_field_id != 0 %}
                 {
-                    // set v4_or_v6 field
+                    // set is_ipv6_field_id field
                     auto param2 = action->add_params();
-                    param2->set_param_id({{param.v4_or_v6_id}});
+                    param2->set_param_id({{param.is_ipv6_field_id}});
                     booldataSetVal((attr_list[i].value.ipaddr.addr_family == SAI_IP_ADDR_FAMILY_IPV4) ? 0 : 1, param2, 1);
                     //matchedParams++;
                 }
@@ -364,11 +364,11 @@ static sai_status_t dash_sai_create_{{ table.name }}(
         //{{key.field}}SetVal(attr_list[i].value, mf1_list, {{key.bitwidth}});
         {% endif %}
     }
-    {% if key.v4_or_v6_id != 0 %}
+    {% if key.is_ipv6_field_id != 0 %}
     {
-        // set v4_or_v6 field
+        // set is_ipv6_field_id field
         auto mf = matchActionEntry->add_match();
-        mf->set_field_id({{key.v4_or_v6_id}});
+        mf->set_field_id({{key.is_ipv6_field_id}});
         auto mf_exact = mf->mutable_exact();
         booldataSetVal((tableEntry->{{ key.sai_key_name | lower }}.addr_family == SAI_IP_ADDR_FAMILY_IPV4) ? 0 : 1, mf_exact, 1);
     }
@@ -422,11 +422,11 @@ static sai_status_t dash_sai_create_{{ table.name }}(
                 param->set_param_id({{param.id}});
                 {{param.field}}SetVal(attr_list[i].value, param, {{param.bitwidth}});
                 //matchedParams++;
-                {% if param.v4_or_v6_id != 0 %}
+                {% if param.is_ipv6_field_id != 0 %}
                 {
-                    // set v4_or_v6 field
+                    // set is_ipv6_field_id field
                     auto param2 = action->add_params();
-                    param2->set_param_id({{param.v4_or_v6_id}});
+                    param2->set_param_id({{param.is_ipv6_field_id}});
                     booldataSetVal((attr_list[i].value.ipaddr.addr_family == SAI_IP_ADDR_FAMILY_IPV4) ? 0 : 1, param2, 1);
                     //matchedParams++;
                 }
@@ -527,11 +527,11 @@ static sai_status_t dash_sai_remove_{{ table.name }}(
         //{{key.field}}SetVal(attr_list[i].value, mf1_list, {{key.bitwidth}});
         {% endif %}
     }
-    {% if key.v4_or_v6_id != 0 %}
+    {% if key.is_ipv6_field_id != 0 %}
     {
-        // set v4_or_v6 field
+        // set is_ipv6_field_id field
         auto mf = matchActionEntry->add_match();
-        mf->set_field_id({{key.v4_or_v6_id}});
+        mf->set_field_id({{key.is_ipv6_field_id}});
         auto mf_exact = mf->mutable_exact();
         booldataSetVal((tableEntry->{{ key.sai_key_name | lower }}.addr_family == SAI_IP_ADDR_FAMILY_IPV4) ? 0 : 1, mf_exact, 1);
     }

--- a/dash-pipeline/bmv2/dash_outbound.p4
+++ b/dash-pipeline/bmv2/dash_outbound.p4
@@ -22,13 +22,13 @@ control outbound(inout headers_t hdr,
     }
 
     action route_vnet_direct(bit<16> dst_vnet_id,
-                             bit<1> is_overlay_ip_v4_or_v6,
+                             bit<1> overlay_ip_is_v6,
                              IPv4ORv6Address overlay_ip,
                              bit<1> meter_policy_en,
                              bit<16> meter_class) {
         meta.dst_vnet_id = dst_vnet_id;
         meta.lkup_dst_ip_addr = overlay_ip;
-        meta.is_lkup_dst_ip_v6 = is_overlay_ip_v4_or_v6;
+        meta.is_lkup_dst_ip_v6 = overlay_ip_is_v6;
         set_route_meter_attrs(meter_policy_en, meter_class);
     }
 
@@ -42,26 +42,26 @@ control outbound(inout headers_t hdr,
         meta.dropped = true;
     }
 
-    action route_service_tunnel(bit<1> is_overlay_dip_v4_or_v6,
+    action route_service_tunnel(bit<1> overlay_dip_is_v6,
                                 IPv4ORv6Address overlay_dip,
-                                bit<1> is_overlay_dip_mask_v4_or_v6,
+                                bit<1> overlay_dip_mask_is_v6,
                                 IPv4ORv6Address overlay_dip_mask,
-                                bit<1> is_overlay_sip_v4_or_v6,
+                                bit<1> overlay_sip_is_v6,
                                 IPv4ORv6Address overlay_sip,
-                                bit<1> is_overlay_sip_mask_v4_or_v6,
+                                bit<1> overlay_sip_mask_is_v6,
                                 IPv4ORv6Address overlay_sip_mask,
-                                bit<1> is_underlay_dip_v4_or_v6,
+                                bit<1> underlay_dip_is_v6,
                                 IPv4ORv6Address underlay_dip,
-                                bit<1> is_underlay_sip_v4_or_v6,
+                                bit<1> underlay_sip_is_v6,
                                 IPv4ORv6Address underlay_sip,
                                 dash_encapsulation_t dash_encapsulation,
                                 bit<24> tunnel_key,
                                 bit<1> meter_policy_en,
                                 bit<16> meter_class) {
         /* Assume the overlay addresses provided are always IPv6 and the original are IPv4 */
-        /* assert(is_overlay_dip_v4_or_v6 == 1 && is_overlay_sip_v4_or_v6 == 1);
-        assert(is_overlay_dip_mask_v4_or_v6 == 1 && is_overlay_sip_mask_v4_or_v6 == 1);
-        assert(is_underlay_dip_v4_or_v6 != 1 && is_underlay_sip_v4_or_v6 != 1); */
+        /* assert(overlay_dip_is_v6 == 1 && overlay_sip_is_v6 == 1);
+        assert(overlay_dip_mask_is_v6 == 1 && overlay_sip_mask_is_v6 == 1);
+        assert(underlay_dip_is_v6 != 1 && underlay_sip_is_v6 != 1); */
         meta.encap_data.original_overlay_dip = hdr.ipv4.src_addr;
         meta.encap_data.original_overlay_sip = hdr.ipv4.dst_addr;
 
@@ -95,7 +95,7 @@ control outbound(inout headers_t hdr,
     table routing {
         key = {
             meta.eni_id : exact @name("meta.eni_id:eni_id");
-            meta.is_overlay_ip_v6 : exact @name("meta.is_overlay_ip_v6:is_destination_v4_or_v6");
+            meta.is_overlay_ip_v6 : exact @name("meta.is_overlay_ip_v6:destination_is_v6");
             meta.dst_ip_addr : lpm @name("meta.dst_ip_addr:destination");
         }
 
@@ -179,7 +179,7 @@ control outbound(inout headers_t hdr,
         key = {
             /* Flow for express route */
             meta.dst_vnet_id: exact @name("meta.dst_vnet_id:dst_vnet_id");
-            meta.is_lkup_dst_ip_v6 : exact @name("meta.is_lkup_dst_ip_v6:is_dip_v4_or_v6");
+            meta.is_lkup_dst_ip_v6 : exact @name("meta.is_lkup_dst_ip_v6:dip_is_v6");
             meta.lkup_dst_ip_addr : exact @name("meta.lkup_dst_ip_addr:dip");
         }
 


### PR DESCRIPTION
This makes code more explicit on 0 = v4 and 1 = v6.

This change will not change any generated code. Here is the diff for proof. Only comment update after make:

```bash
r12f@r12f-dl380:~/data/code/sonic/DASH/dash-pipeline
$ diff SAI/SAI/experimental/ ~/data/code/sonic/DASH-exp/dash-pipeline/SAI/SAI/experimental/

$ diff SAI/lib ~/data/code/sonic/DASH-exp/dash-pipeline/SAI/lib/
diff SAI/lib/saidashoutboundcatopa.cpp /home/r12f/data/code/sonic/DASH-exp/dash-pipeline/SAI/lib/saidashoutboundcatopa.cpp
47c47
<         // set is_ipv6_field_id field
---
>         // set v4_or_v6 field
241c241
<         // set is_ipv6_field_id field
---
>         // set v4_or_v6 field
diff SAI/lib/saidashoutboundrouting.cpp /home/r12f/data/code/sonic/DASH-exp/dash-pipeline/SAI/lib/saidashoutboundrouting.cpp
45c45
<         // set is_ipv6_field_id field
---
>         // set v4_or_v6 field
136c136
<                     // set is_ipv6_field_id field
---
>                     // set v4_or_v6 field
151c151
<                     // set is_ipv6_field_id field
---
>                     // set v4_or_v6 field
166c166
<                     // set is_ipv6_field_id field
---
>                     // set v4_or_v6 field
181c181
<                     // set is_ipv6_field_id field
---
>                     // set v4_or_v6 field
196c196
<                     // set is_ipv6_field_id field
---
>                     // set v4_or_v6 field
211c211
<                     // set is_ipv6_field_id field
---
>                     // set v4_or_v6 field
226c226
<                     // set is_ipv6_field_id field
---
>                     // set v4_or_v6 field
328c328
<         // set is_ipv6_field_id field
---
>         // set v4_or_v6 field
```