### PR TITLE
[sai-gen] Move acl table to use SaiTable annotation.

### DIFF
--- a/dash-pipeline/SAI/sai_api_gen.py
+++ b/dash-pipeline/SAI/sai_api_gen.py
@@ -117,6 +117,9 @@ class SAITypeSolver:
 
     @staticmethod
     def get_sai_type(sai_type):
+        if sai_type not in SAITypeSolver.sai_type_info_registry:
+            raise ValueError(f'sai_type={sai_type} is not supported')
+
         return SAITypeSolver.sai_type_info_registry[sai_type]
 
     @staticmethod
@@ -520,13 +523,12 @@ class SAIAPITableActionParam(SAIObject):
         self.id = p4rt_table_action_param['id']
         self.name = p4rt_table_action_param[NAME_TAG]
         self.bitwidth = p4rt_table_action_param[BITWIDTH_TAG]
-        #print("Parsing table action param: " + self.name)
+        print("Parsing table action param: " + self.name)
 
         if STRUCTURED_ANNOTATIONS_TAG in p4rt_table_action_param:
             self._parse_sai_object_annotation(p4rt_table_action_param)
         else:
             sai_type_info = SAITypeSolver.get_object_sai_type(self.bitwidth, self.name, self.name)
-            print("Parsing table action param: " + self.name + ", type: " + sai_type_info.name, ", is_enum: " + str(sai_type_info.is_enum))
             self.type, self.field = sai_type_info.name, sai_type_info.field_func_prefix
             if sai_type_info.is_enum:
                 self.default = sai_type_info.default
@@ -632,6 +634,12 @@ class SAIAPITableData(SAIObject):
                         self.is_object = kv['value']['stringValue']
                     if kv['key'] == 'ignoretable':
                         self.ignored = True
+                    if kv['key'] == 'name':
+                        self.name = kv['value']['stringValue']
+                    if kv['key'] == 'stage':
+                        self.stage = kv['value']['stringValue']
+                    if kv['key'] == 'api':
+                        self.api_name = kv['value']['stringValue']
 
         return
 

--- a/dash-pipeline/bmv2/README.md
+++ b/dash-pipeline/bmv2/README.md
@@ -42,6 +42,9 @@ Use `@SaiTable["tag"="value", ...]` format for annotating tables.
 
 Available tags are:
 
+- `name`: Specify the preferred table name in SAI API generation, e.g. `dash_acl_rule`.
+- `api`: Specify which SAI API should be used in generation, e.g. `dash_acl`.
+- `stage`: Specify which stage this table represents for the matching stage type, e.g. `acl.stage1`.
 - `isobject`: When set to "true", a top level objects in SAI that attached to switch will be generated. Otherwise, a new type of entry will be generated, if nothing else helps us to determine this table is an object table.
 - `ignoretable`: When set to "true", we skip this table in SAI API generation.
 

--- a/dash-pipeline/bmv2/dash_acl.p4
+++ b/dash-pipeline/bmv2/dash_acl.p4
@@ -31,12 +31,12 @@ match_kind {
 #define str(name) #name
 
 #ifdef TARGET_BMV2_V1MODEL
-#define ACL_STAGE(table_name) \
-    direct_counter(CounterType.packets_and_bytes) ## table_name ##_counter; \
-    @name(str(table_name##:dash_acl_rule|dash_acl)) \
-    table table_name { \
+#define ACL_STAGE(stage_index) \
+    direct_counter(CounterType.packets_and_bytes) ## stage ## stage_index ##_counter; \
+    @SaiTable[name="dash_acl_rule", stage=str(acl.stage ## stage_index), api="dash_acl"] \
+    table stage ## stage_index { \
         key = { \
-            meta. ## table_name ##_dash_acl_group_id : exact @name("meta.dash_acl_group_id:dash_acl_group_id") \
+            meta.stage ## stage_index ##_dash_acl_group_id : exact @name("meta.dash_acl_group_id:dash_acl_group_id") \
             @SaiVal[type="sai_object_id_t", isresourcetype="true", objects="SAI_OBJECT_TYPE_DASH_ACL_GROUP"]; \
             meta.dst_ip_addr : LIST_MATCH @name("meta.dst_ip_addr:dip"); \
             meta.src_ip_addr : LIST_MATCH @name("meta.src_ip_addr:sip"); \
@@ -51,7 +51,7 @@ match_kind {
             deny_and_continue; \
         } \
         default_action = deny; \
-        counters = ## table_name ##_counter; \
+        counters = stage ## stage_index ##_counter; \
     }
 #endif // TARGET_BMV2_V1MODEL
 #ifdef TARGET_DPDK_PNA
@@ -63,17 +63,17 @@ match_kind {
 
 // (1) Add the following line as the first line of the definition of
 // ACL_STAGE:
-//    DirectCounter<bit<64>>(PNA_CounterType_t.PACKETS_AND_BYTES) ## table_name ##_counter; \
+//    DirectCounter<bit<64>>(PNA_CounterType_t.PACKETS_AND_BYTES) stage ## stage_index ##_counter; \
 
 // (2) Add the following line immediately after the line defining the
 // default_action of the table:
-//        pna_direct_counter = ## table_name ##_counter; \
+//        pna_direct_counter = stage ## stage_index ##_counter; \
 
-#define ACL_STAGE(table_name) \
-    @name(str(table_name##:dash_acl_rule|dash_acl)) \
-    table table_name { \
+#define ACL_STAGE(stage_index) \
+    @SaiTable[name="dash_acl_rule", stage=str(acl.stage ## stage_index), api="dash_acl"] \
+    table stage ##stage_index { \
         key = { \
-            meta. ## table_name ##_dash_acl_group_id : exact @name("meta.dash_acl_group_id:dash_acl_group_id"); \
+            meta.stage ## stage_index ##_dash_acl_group_id : exact @name("meta.dash_acl_group_id:dash_acl_group_id"); \
             meta.dst_ip_addr : LIST_MATCH @name("meta.dst_ip_addr:dip"); \
             meta.src_ip_addr : LIST_MATCH @name("meta.src_ip_addr:sip"); \
             meta.ip_protocol : LIST_MATCH @name("meta.ip_protocol:protocol"); \
@@ -90,9 +90,9 @@ match_kind {
     }
 #endif // TARGET_DPDK_PNA
 
-#define ACL_STAGE_APPLY(table_name) \
-        if ( meta. ## table_name ##_dash_acl_group_id  != 0) { \
-        switch (table_name.apply().action_run) { \
+#define ACL_STAGE_APPLY(stage_index) \
+        if ( meta.stage ## stage_index ##_dash_acl_group_id  != 0) { \
+        switch (stage ## stage_index.apply().action_run) { \
             permit: {return;} \
             deny: {return;} \
         } \
@@ -111,14 +111,14 @@ control acl(inout headers_t hdr,
     action deny() {meta.dropped = true;}
     action deny_and_continue() {meta.dropped = true;}
 
-ACL_STAGE(stage1)
-ACL_STAGE(stage2)
-ACL_STAGE(stage3)
+ACL_STAGE(1)
+ACL_STAGE(2)
+ACL_STAGE(3)
 
     apply {
-ACL_STAGE_APPLY(stage1)
-ACL_STAGE_APPLY(stage2)
-ACL_STAGE_APPLY(stage3)
+ACL_STAGE_APPLY(1)
+ACL_STAGE_APPLY(2)
+ACL_STAGE_APPLY(3)
     }
 }
 #endif /* _SIRIUS_ACL_P4_ */

--- a/dash-pipeline/bmv2/dash_outbound.p4
+++ b/dash-pipeline/bmv2/dash_outbound.p4
@@ -54,7 +54,7 @@ control outbound(inout headers_t hdr,
                                 IPv4ORv6Address underlay_dip,
                                 bit<1> underlay_sip_is_v6,
                                 IPv4ORv6Address underlay_sip,
-                                @Sai[type="sai_dash_encapsulation_t", default_value="SAI_DASH_ENCAPSULATION_VXLAN"]
+                                @SaiVal[type="sai_dash_encapsulation_t", default_value="SAI_DASH_ENCAPSULATION_VXLAN"]
                                 dash_encapsulation_t dash_encapsulation,
                                 bit<24> tunnel_key,
                                 bit<1> meter_policy_en,
@@ -120,7 +120,7 @@ control outbound(inout headers_t hdr,
     }
 
     action set_tunnel(IPv4Address underlay_dip,
-                      @Sai[type="sai_dash_encapsulation_t"] dash_encapsulation_t dash_encapsulation,
+                      @SaiVal[type="sai_dash_encapsulation_t"] dash_encapsulation_t dash_encapsulation,
                       bit<16> meter_class,
                       bit<1> meter_class_override) {
         meta.encap_data.underlay_dip = underlay_dip;
@@ -147,7 +147,7 @@ control outbound(inout headers_t hdr,
     action set_private_link_mapping(IPv4Address underlay_dip,
                                     IPv6Address overlay_sip,
                                     IPv6Address overlay_dip,
-                                    @Sai[type="sai_dash_encapsulation_t"] dash_encapsulation_t dash_encapsulation,
+                                    @SaiVal[type="sai_dash_encapsulation_t"] dash_encapsulation_t dash_encapsulation,
                                     bit<24> tunnel_key,
                                     bit<16> meter_class,
                                     bit<1> meter_class_override) {


### PR DESCRIPTION
This PR moves acl table to use `@SaiTable` annotation instead of `@name`.

After the change, SAI headers will be generated exactly the same:

```bash
r12f@r12f-dl380:~/data/code/sonic/DASH/dash-pipeline
$ diff SAI/SAI/experimental/ ~/data/code/sonic/DASH-exp/dash-pipeline/SAI/SAI/experimental/
```

However, due to name is changed in P4, the table id will be changed, but it only affects the libsai generated from DASH for testing, not any providers' implementation.

```bash
r12f@r12f-dl380:~/data/code/sonic/DASH/dash-pipeline
$ diff SAI/lib ~/data/code/sonic/DASH-exp/dash-pipeline/SAI/lib              
diff SAI/lib/saidashacl.cpp /home/r12f/data/code/sonic/DASH-exp/dash-pipeline/SAI/lib/saidashacl.cpp
211c211
<     // For stage acl.stage1
---
>     // For stage inbound_acl_stage1
213c213
<     tableId = 41950136;
---
>     tableId = 33901322;
366c366
<     // For stage acl.stage2
---
>     // For stage inbound_acl_stage2
368c368
<     tableId = 43016664;
---
>     tableId = 44184066;
521c521
<     // For stage acl.stage3
---
>     // For stage inbound_acl_stage3
523c523
<     tableId = 49695908;
---
>     tableId = 46150034;
676c676
<     // For stage acl.stage1
---
>     // For stage outbound_acl_stage1
678c678
<     tableId = 49209582;
---
>     tableId = 33810473;
831c831
<     // For stage acl.stage2
---
>     // For stage outbound_acl_stage2
833c833
<     tableId = 36478314;
---
>     tableId = 49812549;
986c986
<     // For stage acl.stage3
---
>     // For stage outbound_acl_stage3
988c988
<     tableId = 39012793;
---
>     tableId = 40782112;
```

The naming change in p4rt:

```
$ diff bmv2/dash_pipeline.bmv2/dash_pipeline_p4rt.json ~/data/code/sonic/DASH-exp/dash-pipeline/bmv2/dash_pipeline.bmv2/dash_pipeline_p4rt.json 
8,37c8,10
<     "id": 49209582,
<     "name": "dash_ingress.outbound.acl.stage1",
<     "alias": "outbound.acl.stage1",
<     "structuredAnnotations": [
...
---
>     "id": 33810473,
>     "name": "dash_ingress.outbound.acl.stage1:dash_acl_rule|dash_acl",
>     "alias": "outbound.acl.stage1:dash_acl_rule|dash_acl"
```