### PR TITLE
[sai-gen] Deprecate the name annotations in favor of SaiTable

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -1,3 +1,4 @@
+ABI
 ABNF
 accessor
 accessors

--- a/dash-pipeline/SAI/sai_api_gen.py
+++ b/dash-pipeline/SAI/sai_api_gen.py
@@ -481,7 +481,7 @@ class SAIAPITableAction(SAIObject):
                 ]
             }
         '''
-        #print("Parsing table action: " + self.name)
+        # print("Parsing table action: " + self.name)
         _, self.name, _ = self.parse_sai_annotated_name(self.name)
         self.parse_action_params(p4rt_table_action, sai_enums)
 
@@ -523,7 +523,7 @@ class SAIAPITableActionParam(SAIObject):
         self.id = p4rt_table_action_param['id']
         self.name = p4rt_table_action_param[NAME_TAG]
         self.bitwidth = p4rt_table_action_param[BITWIDTH_TAG]
-        print("Parsing table action param: " + self.name)
+        # print("Parsing table action param: " + self.name)
 
         if STRUCTURED_ANNOTATIONS_TAG in p4rt_table_action_param:
             self._parse_sai_object_annotation(p4rt_table_action_param)
@@ -592,21 +592,16 @@ class SAIAPITableData(SAIObject):
                 "size": "1024"
             }
         '''
-        
-        # The first part of full name is the top level control block name, which is removed for showing better comments as stage.
-        self.stage, self.name, self.api_name = self.parse_sai_annotated_name(self.name, full_name_part_start = 1)
-        self.stage = self.stage.replace('.', '_')
-        if "stage" not in self.stage:
-            self.stage = None
+        self.__parse_sai_table_annotations(p4rt_table[PREAMBLE_TAG])
 
         # If tables are specified as ignored via CLI or annotations, skip them.
         if self.name in ignore_tables:
             self.ignored = True
-            return
-
-        self.__parse_sai_table_annotations(p4rt_table[PREAMBLE_TAG])
-        if self.ignored:
+        elif self.ignored:
             ignore_tables.append(self.name)
+
+        if self.ignored:
+            print("Ignoring table: " + self.name)
             return
 
         print("Parsing table: " + self.name)
@@ -634,7 +629,7 @@ class SAIAPITableData(SAIObject):
                 for kv in anno[KV_PAIR_LIST_TAG][KV_PAIRS_TAG]:
                     if kv['key'] == 'isobject':
                         self.is_object = kv['value']['stringValue']
-                    if kv['key'] == 'ignoretable':
+                    if kv['key'] == 'ignored':
                         self.ignored = True
                     if kv['key'] == 'name':
                         self.name = kv['value']['stringValue']

--- a/dash-pipeline/SAI/sai_api_gen.py
+++ b/dash-pipeline/SAI/sai_api_gen.py
@@ -750,7 +750,8 @@ class DASHSAIExtensions(SAIObject):
         actions = self.__parse_sai_table_action(program[ACTIONS_TAG], self.sai_enums)
 
         # Parse all tables into SAI API sets.
-        for table in program[TABLES_TAG]:
+        tables = sorted(program[TABLES_TAG], key=lambda k: k[PREAMBLE_TAG][NAME_TAG])
+        for table in tables:
             sai_api_table_data = SAIAPITableData.from_p4rt(table, program, actions, ignore_tables)
             if sai_api_table_data.ignored:
                 continue

--- a/dash-pipeline/bmv2/README.md
+++ b/dash-pipeline/bmv2/README.md
@@ -44,6 +44,7 @@ Available tags are:
 
 - `name`: Specify the preferred table name in SAI API generation, e.g. `dash_acl_rule`.
 - `api`: Specify which SAI API should be used in generation, e.g. `dash_acl`.
+- `api_order`: Specify the order of the generated API in the SAI API header file. When multiple tables generates API entries in the same API set, e.g., acl group and acl rules. This explicit attribute helps us keep the order of the generated APIs to keep ABI compatibility.
 - `stage`: Specify which stage this table represents for the matching stage type, e.g. `acl.stage1`.
 - `isobject`: When set to "true", a top level objects in SAI that attached to switch will be generated. Otherwise, a new type of entry will be generated, if nothing else helps us to determine this table is an object table.
 - `ignoretable`: When set to "true", we skip this table in SAI API generation.

--- a/dash-pipeline/bmv2/README.md
+++ b/dash-pipeline/bmv2/README.md
@@ -48,6 +48,6 @@ Available tags are:
 - `api_order`: Specify the order of the generated API in the SAI API header file. When multiple tables generates API entries in the same API set, e.g., acl group and acl rules. This explicit attribute helps us keep the order of the generated APIs to keep ABI compatibility.
 - `stage`: Specify which stage this table represents for the matching stage type, e.g. `acl.stage1`.
 - `isobject`: When set to "true", a top level objects in SAI that attached to switch will be generated. Otherwise, a new type of entry will be generated, if nothing else helps us to determine this table is an object table.
-- `ignoretable`: When set to "true", we skip this table in SAI API generation.
+- `ignored`: When set to "true", we skip this table in SAI API generation.
 
 For more details, please check the SAI API generation script: [sai_api_gen.py](../SAI/sai_api_gen.py).

--- a/dash-pipeline/bmv2/README.md
+++ b/dash-pipeline/bmv2/README.md
@@ -44,6 +44,7 @@ Available tags are:
 
 - `name`: Specify the preferred table name in SAI API generation, e.g. `dash_acl_rule`.
 - `api`: Specify which SAI API should be used in generation, e.g. `dash_acl`.
+- `api_type`: The type of the API. DASH contains certain tables for handling underlay actions, such as route table. We should not generate header files for these tables but only the lib files without experimental prefix. To enable this behavior, please set the API type to `underlay`.
 - `api_order`: Specify the order of the generated API in the SAI API header file. When multiple tables generates API entries in the same API set, e.g., acl group and acl rules. This explicit attribute helps us keep the order of the generated APIs to keep ABI compatibility.
 - `stage`: Specify which stage this table represents for the matching stage type, e.g. `acl.stage1`.
 - `isobject`: When set to "true", a top level objects in SAI that attached to switch will be generated. Otherwise, a new type of entry will be generated, if nothing else helps us to determine this table is an object table.

--- a/dash-pipeline/bmv2/dash_acl.p4
+++ b/dash-pipeline/bmv2/dash_acl.p4
@@ -33,7 +33,7 @@ match_kind {
 #ifdef TARGET_BMV2_V1MODEL
 #define ACL_STAGE(stage_index) \
     direct_counter(CounterType.packets_and_bytes) ## stage ## stage_index ##_counter; \
-    @SaiTable[name="dash_acl_rule", stage=str(acl.stage ## stage_index), api="dash_acl"] \
+    @SaiTable[name="dash_acl_rule", stage=str(acl.stage ## stage_index), api="dash_acl", api_order=1] \
     table stage ## stage_index { \
         key = { \
             meta.stage ## stage_index ##_dash_acl_group_id : exact @name("meta.dash_acl_group_id:dash_acl_group_id") \

--- a/dash-pipeline/bmv2/dash_outbound.p4
+++ b/dash-pipeline/bmv2/dash_outbound.p4
@@ -92,7 +92,7 @@ control outbound(inout headers_t hdr,
 #endif  // DPDK_SUPPORTS_DIRECT_COUNTER_ON_WILDCARD_KEY_TABLE
 #endif  // TARGET_DPDK_PNA
 
-    @name("outbound_routing|dash_outbound_routing")
+    @SaiTable[name = "outbound_routing", api = "dash_outbound_routing"]
     table routing {
         key = {
             meta.eni_id : exact @name("meta.eni_id:eni_id");
@@ -175,7 +175,7 @@ control outbound(inout headers_t hdr,
 #endif  // DPDK_SUPPORTS_DIRECT_COUNTER_ON_WILDCARD_KEY_TABLE
 #endif  // TARGET_DPDK_PNA
 
-    @name("outbound_ca_to_pa|dash_outbound_ca_to_pa")
+    @SaiTable[name = "outbound_ca_to_pa", api = "dash_outbound_ca_to_pa"]
     table ca_to_pa {
         key = {
             /* Flow for express route */
@@ -205,7 +205,7 @@ control outbound(inout headers_t hdr,
         meta.encap_data.vni = vni;
     }
 
-    @name("vnet|dash_vnet")
+    @SaiTable[name = "vnet", api = "dash_vnet"]
     table vnet {
         key = {
             meta.vnet_id : exact @name("meta.vnet_id:vnet_id");

--- a/dash-pipeline/bmv2/dash_pipeline.p4
+++ b/dash-pipeline/bmv2/dash_pipeline.p4
@@ -39,7 +39,7 @@ control dash_ingress(
     action accept() {
     }
 
-    @name("vip|dash_vip")
+    @SaiTable[name = "vip", api = "dash_vip"]
     table vip {
         key = {
             hdr.ipv4.dst_addr : exact @name("hdr.ipv4.dst_addr:VIP");
@@ -61,7 +61,7 @@ control dash_ingress(
         meta.direction = dash_direction_t.INBOUND;
     }
 
-    @name("direction_lookup|dash_direction_lookup")
+    @SaiTable[name = "direction_lookup", api = "dash_direction_lookup"]
     table direction_lookup {
         key = {
             hdr.vxlan.vni : exact @name("hdr.vxlan.vni:VNI");
@@ -153,7 +153,7 @@ control dash_ingress(
         }
     }
 
-    @name("eni|dash_eni")
+    @SaiTable[name = "eni", api = "dash_eni", api_order=1]
     table eni {
         key = {
             meta.eni_id : exact @name("meta.eni_id:eni_id");
@@ -211,7 +211,7 @@ control dash_ingress(
         meta.vnet_id = src_vnet_id;
     }
 
-    @name("pa_validation|dash_pa_validation")
+    @SaiTable[name = "pa_validation", api = "dash_pa_validation"]
     table pa_validation {
         key = {
             meta.vnet_id: exact @name("meta.vnet_id:vnet_id");
@@ -226,7 +226,7 @@ control dash_ingress(
         const default_action = deny;
     }
 
-    @name("inbound_routing|dash_inbound_routing")
+    @SaiTable[name = "inbound_routing", api = "dash_inbound_routing"]
     table inbound_routing {
         key = {
             meta.eni_id: exact @name("meta.eni_id:eni_id");
@@ -254,8 +254,7 @@ control dash_ingress(
         }
     }
 
-    @name("meter_policy|dash_meter")
-    @SaiTable[isobject="true"]
+    @SaiTable[name = "meter_policy", api = "dash_meter", api_order = 1, isobject="true"]
     table meter_policy {
         key = {
             meta.meter_policy_id : exact @name("meta.meter_policy_id:meter_policy_id");
@@ -269,8 +268,7 @@ control dash_ingress(
         meta.policy_meter_class = meter_class;
     }
 
-    @name("meter_rule|dash_meter")
-    @SaiTable[isobject="true"]
+    @SaiTable[name = "meter_rule", api = "dash_meter", api_order = 2, isobject="true"]
     table meter_rule {
         key = {
             meta.meter_policy_id: exact @name("meta.meter_policy_id:meter_policy_id") @SaiVal[type="sai_object_id_t", isresourcetype="true", objects="METER_POLICY"];
@@ -298,8 +296,7 @@ control dash_ingress(
         meta.meter_bucket_index = meter_bucket_index;
     }
 
-    @name("meter_bucket|dash_meter")
-    @SaiTable[isobject="true"]
+    @SaiTable[name = "meter_bucket", api = "dash_meter", api_order = 0, isobject="true"]
     table meter_bucket {
         key = {
             meta.eni_id: exact @name("meta.eni_id:eni_id");
@@ -316,7 +313,7 @@ control dash_ingress(
         meta.eni_id = eni_id;
     }
 
-    @name("eni_ether_address_map|dash_eni")
+    @SaiTable[name = "eni_ether_address_map", api = "dash_eni", api_order=0]
     table eni_ether_address_map {
         key = {
             meta.eni_addr : exact @name("meta.eni_addr:address");
@@ -341,7 +338,7 @@ control dash_ingress(
         }
     }
 
-    @name("dash_acl_group|dash_acl")
+    @SaiTable[name = "dash_acl_group", api = "dash_acl", api_order = 0]
     table acl_group {
         key = {
             meta.stage1_dash_acl_group_id : exact @name("meta.stage1_dash_acl_group_id:dash_acl_group_id");

--- a/dash-pipeline/bmv2/dash_pipeline.p4
+++ b/dash-pipeline/bmv2/dash_pipeline.p4
@@ -82,6 +82,7 @@ control dash_ingress(
     }
 
     /* This table API should be implemented manually using underlay SAI */
+    @SaiTable[ignored = "true"]
     table appliance {
         key = {
             meta.appliance_id : ternary @name("meta.appliance_id:appliance_id");
@@ -185,6 +186,7 @@ control dash_ingress(
 #endif // DPDK_SUPPORTS_DIRECT_COUNTER_ON_WILDCARD_KEY_TABLE
 #endif // TARGET_DPDK_PNA
 
+    @SaiTable[ignored = "true"]
     table eni_meter {
         key = {
             meta.eni_id : exact @name("meta.eni_id:eni_id");

--- a/dash-pipeline/bmv2/underlay.p4
+++ b/dash-pipeline/bmv2/underlay.p4
@@ -68,8 +68,8 @@ control underlay(
 #endif // TARGET_DPDK_PNA
     }
 
-    @name("route|route")
-    // TODO: To add structural annotations (example: @SaiTable[skipHeaderGen=true])
+    @SaiTable[name = "route", api = "route"]
+    // TODO: To add structural annotations (example: @SaiTable[skipHeaderGen=true]]
     table underlay_routing {
         key = {
             meta.dst_ip_addr : lpm @name("meta.dst_ip_addr:destination");

--- a/dash-pipeline/bmv2/underlay.p4
+++ b/dash-pipeline/bmv2/underlay.p4
@@ -69,7 +69,6 @@ control underlay(
     }
 
     @SaiTable[name = "route", api = "route", api_type="underlay"]
-    // TODO: To add structural annotations (example: @SaiTable[skipHeaderGen=true]]
     table underlay_routing {
         key = {
             meta.dst_ip_addr : lpm @name("meta.dst_ip_addr:destination");

--- a/dash-pipeline/bmv2/underlay.p4
+++ b/dash-pipeline/bmv2/underlay.p4
@@ -68,7 +68,7 @@ control underlay(
 #endif // TARGET_DPDK_PNA
     }
 
-    @SaiTable[name = "route", api = "route"]
+    @SaiTable[name = "route", api = "route", api_type="underlay"]
     // TODO: To add structural annotations (example: @SaiTable[skipHeaderGen=true]]
     table underlay_routing {
         key = {


### PR DESCRIPTION
This PR has 2 updates:

1. Deprecate the `@name` annotations in favor of `@SaiTable`.
2. Add `api_order` attribute in `@SaiTable` annotation to help us enforce the order of the generated APIs.

The second change is a must have, otherwise for any API set that contains multiple type of entries (generated from multiple tables), the order could be changed between changes and break the ABI compatibility as the screenshot shows below:

![Snipaste_2023-12-12_12-24-41](https://github.com/sonic-net/DASH/assets/1533278/efbe64a2-ac7c-485a-8739-9fe7ff14e51b)

The doc is also updated to capture the use of this new attribute.

For generated content updates:

1. No updates on SAI header files:

    ```bash
    r12f@r12f-dl380:~/data/code/sonic/DASH/dash-pipeline
    $ diff SAI/SAI/experimental/ ~/data/code/sonic/DASH-exp/dash-pipeline/SAI/SAI/experimental/
    r12f@r12f-dl380:~/data/code/sonic/DASH/dash-pipeline
    ```

2. For libsai, table id will be updated as previous change. 

    ```bash
    r12f@r12f-dl380:~/data/code/sonic/DASH/dash-pipeline
    $ diff SAI/SAI/experimental/ ~/data/code/sonic/DASH-exp/dash-pipeline/SAI/SAI/experimental/
    r12f@r12f-dl380:~/data/code/sonic/DASH/dash-pipeline
    $ diff SAI/lib/ ~/data/code/sonic/DASH-exp/dash-pipeline/SAI/lib/
    diff SAI/lib/saidashacl.cpp /home/r12f/data/code/sonic/DASH-exp/dash-pipeline/SAI/lib/saidashacl.cpp
    31c31
    <     tableId = 50200087;
    ---
    >     tableId = 45323240;
    diff SAI/lib/saidashdirectionlookup.cpp /home/r12f/data/code/sonic/DASH-exp/dash-pipeline/SAI/lib/saidashdirectionlookup.cpp
    19c19
    <     pi_p4_id_t tableId = 45670434;
    ---
    >     pi_p4_id_t tableId = 38960243;
    110c110
    <     pi_p4_id_t tableId = 45670434;
    ---
    >     pi_p4_id_t tableId = 38960243;
    diff SAI/lib/saidasheni.cpp /home/r12f/data/code/sonic/DASH-exp/dash-pipeline/SAI/lib/saidasheni.cpp
    19c19
    <     pi_p4_id_t tableId = 46804748;
    ---
    >     pi_p4_id_t tableId = 38612462;
    118c118
    <     pi_p4_id_t tableId = 46804748;
    ---
    >     pi_p4_id_t tableId = 38612462;
    212c212
    <     tableId = 45859274;
    ---
    >     tableId = 47336097;
    diff SAI/lib/saidashinboundrouting.cpp /home/r12f/data/code/sonic/DASH-exp/dash-pipeline/SAI/lib/saidashinboundrouting.cpp
    19c19
    <     pi_p4_id_t tableId = 38920290;
    ---
    >     pi_p4_id_t tableId = 42758350;
    152c152
    <     pi_p4_id_t tableId = 38920290;
    ---
    >     pi_p4_id_t tableId = 42758350;
    diff SAI/lib/saidashmeter.cpp /home/r12f/data/code/sonic/DASH-exp/dash-pipeline/SAI/lib/saidashmeter.cpp
    31c31
    <     tableId = 38547152;
    ---
    >     tableId = 49926129;
    244c244
    <     tableId = 39168708;
    ---
    >     tableId = 48776568;
    425c425
    <     tableId = 34535910;
    ---
    >     tableId = 47787652;
    diff SAI/lib/saidashoutboundcatopa.cpp /home/r12f/data/code/sonic/DASH-exp/dash-pipeline/SAI/lib/saidashoutboundcatopa.cpp
    19c19
    <     pi_p4_id_t tableId = 39175949;
    ---
    >     pi_p4_id_t tableId = 48860231;
    219c219
    <     pi_p4_id_t tableId = 39175949;
    ---
    >     pi_p4_id_t tableId = 48860231;
    diff SAI/lib/saidashoutboundrouting.cpp /home/r12f/data/code/sonic/DASH-exp/dash-pipeline/SAI/lib/saidashoutboundrouting.cpp
    19c19
    <     pi_p4_id_t tableId = 44067785;
    ---
    >     pi_p4_id_t tableId = 42788937;
    308c308
    <     pi_p4_id_t tableId = 44067785;
    ---
    >     pi_p4_id_t tableId = 42788937;
    diff SAI/lib/saidashpavalidation.cpp /home/r12f/data/code/sonic/DASH-exp/dash-pipeline/SAI/lib/saidashpavalidation.cpp
    19c19
    <     pi_p4_id_t tableId = 35526612;
    ---
    >     pi_p4_id_t tableId = 48948181;
    118c118
    <     pi_p4_id_t tableId = 35526612;
    ---
    >     pi_p4_id_t tableId = 48948181;
    diff SAI/lib/saidashvip.cpp /home/r12f/data/code/sonic/DASH-exp/dash-pipeline/SAI/lib/saidashvip.cpp
    19c19
    <     pi_p4_id_t tableId = 45245089;
    ---
    >     pi_p4_id_t tableId = 38937816;
    110c110
    <     pi_p4_id_t tableId = 45245089;
    ---
    >     pi_p4_id_t tableId = 38937816;
    diff SAI/lib/saidashvnet.cpp /home/r12f/data/code/sonic/DASH-exp/dash-pipeline/SAI/lib/saidashvnet.cpp
    31c31
    <     tableId = 34815711;
    ---
    >     tableId = 34579306;
    diff SAI/lib/sairoute.cpp /home/r12f/data/code/sonic/DASH-exp/dash-pipeline/SAI/lib/sairoute.cpp
    19c19
    <     pi_p4_id_t tableId = 49279256;
    ---
    >     pi_p4_id_t tableId = 36513740;
    124c124
    <     pi_p4_id_t tableId = 49279256;
    ---
    >     pi_p4_id_t tableId = 36513740;
    ```
