### PR TITLE
[sai-gen] Deprecate name attribute for all match keys and action parameters, remove type guessing heuristics on object parent names.

### DIFF
--- a/dash-pipeline/SAI/sai_api_gen.py
+++ b/dash-pipeline/SAI/sai_api_gen.py
@@ -158,56 +158,51 @@ class SAITypeSolver:
         if match_type == 'exact' or match_type == 'optional' or match_type == 'ternary':
             return  SAITypeSolver.get_object_sai_type(key_size, key_parent_name, key_name)
         elif match_type == 'lpm':
-            return SAITypeSolver.__get_lpm_match_key_sai_type(key_size, key_parent_name, key_name)
+            return SAITypeSolver.__get_lpm_match_key_sai_type(key_size)
         elif match_type == 'list':
-            return SAITypeSolver.__get_list_match_key_sai_type(key_size, key_parent_name, key_name)
+            return SAITypeSolver.__get_list_match_key_sai_type(key_size)
         elif match_type == 'range_list':
-            return SAITypeSolver.__get_range_list_sai_type(key_size, key_parent_name, key_name)
+            return SAITypeSolver.__get_range_list_sai_type(key_size)
         else:
             raise ValueError(f"match_type={match_type} is not supported")
 
     @staticmethod
-    def __get_lpm_match_key_sai_type(key_size, key_parent_name, key_name):
+    def __get_lpm_match_key_sai_type(key_size):
         sai_type_name = ""
 
-        if key_size == 32 and ('addr' in key_name or 'ip' in key_parent_name):
+        # LPM match key should always be converted into IP prefix.
+        if key_size == 32:
             sai_type_name = 'sai_ip_prefix_t'
-        elif key_size == 128 and ('addr' in key_name or 'ip' in key_parent_name):
+        elif key_size == 128:
             sai_type_name = 'sai_ip_prefix_t'
-        else:
-            raise ValueError(f'key_size={key_size}, key_header={key_parent_name}, and key_field={key_name} is not supported')
-
-        return SAITypeSolver.get_sai_type(sai_type_name)
-
-    @staticmethod
-    def __get_list_match_key_sai_type(key_size, key_header, key_field):
-        sai_type_name = ""
-
-        if key_size <= 8:
-            sai_type_name = 'sai_u8_list_t'
-        elif key_size <= 16:
-            sai_type_name = 'sai_u16_list_t'
-        elif key_size == 32 and ('addr' in key_field or 'ip' in key_header):
-            sai_type_name = 'sai_ip_prefix_list_t'
-        elif key_size <= 32:
-            sai_type_name = 'sai_u32_list_t'
-        elif key_size == 128 and ('addr' in key_field or 'ip' in key_header):
-            sai_type_name = 'sai_ip_prefix_list_t'
         else:
             raise ValueError(f'key_size={key_size} is not supported')
 
         return SAITypeSolver.get_sai_type(sai_type_name)
 
     @staticmethod
-    def __get_range_list_sai_type(key_size, key_header, key_field):
+    def __get_list_match_key_sai_type(key_size):
+        sai_type_name = ""
+
+        if key_size <= 8:
+            sai_type_name = 'sai_u8_list_t'
+        elif key_size <= 16:
+            sai_type_name = 'sai_u16_list_t'
+        elif key_size <= 32:
+            sai_type_name = 'sai_u32_list_t'
+        else:
+            raise ValueError(f'key_size={key_size} is not supported')
+
+        return SAITypeSolver.get_sai_type(sai_type_name)
+
+    @staticmethod
+    def __get_range_list_sai_type(key_size):
         sai_type_name = ""
 
         if key_size <= 8:
             sai_type_name = 'sai_u8_range_list_t'
         elif key_size <= 16:
             sai_type_name = 'sai_u16_range_list_t'
-        elif key_size == 32 and ('addr' in key_field or 'ip' in key_header):
-            sai_type_name = 'sai_ipaddr_range_list_t'
         elif key_size <= 32:
             sai_type_name = 'sai_u32_range_list_t'
         elif key_size <= 64:

--- a/dash-pipeline/SAI/sai_api_gen.py
+++ b/dash-pipeline/SAI/sai_api_gen.py
@@ -123,7 +123,7 @@ class SAITypeSolver:
         return SAITypeSolver.sai_type_info_registry[sai_type]
 
     @staticmethod
-    def get_object_sai_type(object_size, object_parent_name, object_name):
+    def get_object_sai_type(object_size, object_name):
         sai_type_name = ""
 
         if object_size == 1:
@@ -136,13 +136,13 @@ class SAITypeSolver:
             sai_type_name = 'sai_uint16_t'
         elif object_size == 32 and ('ip_addr_family' in object_name):
             sai_type_name = 'sai_ip_addr_family_t'
-        elif object_size == 32 and ('addr' in object_name or 'ip' in object_parent_name):
+        elif object_size == 32 and ('ip' in object_name):
             sai_type_name = 'sai_ip_address_t'
         elif object_size == 32 and ('_id' in object_name):
             sai_type_name = 'sai_object_id_t'
         elif object_size <= 32:
             sai_type_name = 'sai_uint32_t'
-        elif object_size == 48 and ('addr' in object_name or 'mac' in object_parent_name):
+        elif object_size == 48 and ('mac' in object_name):
             sai_type_name = 'sai_mac_t'
         elif object_size <= 64:
             sai_type_name = 'sai_uint64_t'
@@ -151,12 +151,13 @@ class SAITypeSolver:
         else:
             raise ValueError(f'key_size={object_size} is not supported')
 
+        print("object name = " + object_name + ", object size = " + str(object_size) + ", sai_type_name = " + sai_type_name)
         return SAITypeSolver.get_sai_type(sai_type_name)
 
     @staticmethod
-    def get_match_key_sai_type(match_type, key_size, key_parent_name, key_name):
+    def get_match_key_sai_type(match_type, key_size, key_name):
         if match_type == 'exact' or match_type == 'optional' or match_type == 'ternary':
-            return  SAITypeSolver.get_object_sai_type(key_size, key_parent_name, key_name)
+            return  SAITypeSolver.get_object_sai_type(key_size, key_name)
         elif match_type == 'lpm':
             return SAITypeSolver.__get_lpm_match_key_sai_type(key_size)
         elif match_type == 'list':
@@ -432,8 +433,7 @@ class SAIAPITableKey(SAIObject):
         self.bitwidth = p4rt_table_key[BITWIDTH_TAG]
         # print("Parsing table key: " + self.name)
 
-        full_key_name, self.name, _ = self.parse_sai_annotated_name(self.name, full_name_part_start = -2)
-        key_header, key_field = full_key_name.split('.')
+        _, self.name, _ = self.parse_sai_annotated_name(self.name, full_name_part_start = -2)
 
         if OTHER_MATCH_TYPE_TAG in p4rt_table_key:
             self.match_type =  p4rt_table_key[OTHER_MATCH_TYPE_TAG].lower()
@@ -449,7 +449,7 @@ class SAIAPITableKey(SAIObject):
         if self.type != None:
             sai_type_info = SAITypeSolver.get_sai_type(self.type)
         else:
-            sai_type_info = SAITypeSolver.get_match_key_sai_type(self.match_type, self.bitwidth, key_header, key_field)
+            sai_type_info = SAITypeSolver.get_match_key_sai_type(self.match_type, self.bitwidth, self.name)
             self.type = sai_type_info.name
 
         self.field = sai_type_info.field_func_prefix
@@ -530,7 +530,7 @@ class SAIAPITableActionParam(SAIObject):
         if self.type != None:
             sai_type_info = SAITypeSolver.get_sai_type(self.type)
         else:
-            sai_type_info = SAITypeSolver.get_object_sai_type(self.bitwidth, self.name, self.name)
+            sai_type_info = SAITypeSolver.get_object_sai_type(self.bitwidth, self.name)
             self.type = sai_type_info.name
 
         self.field = sai_type_info.field_func_prefix

--- a/dash-pipeline/SAI/sai_api_gen.py
+++ b/dash-pipeline/SAI/sai_api_gen.py
@@ -153,7 +153,6 @@ class SAITypeSolver:
         else:
             raise ValueError(f'key_size={object_size} is not supported')
 
-        print("object name = " + object_name + ", object size = " + str(object_size) + ", sai_type_name = " + sai_type_name)
         return SAITypeSolver.get_sai_type(sai_type_name)
 
     @staticmethod

--- a/dash-pipeline/SAI/sai_api_gen.py
+++ b/dash-pipeline/SAI/sai_api_gen.py
@@ -124,6 +124,8 @@ class SAITypeSolver:
 
     @staticmethod
     def get_object_sai_type(object_size, object_name):
+        object_name = object_name.lower()
+
         sai_type_name = ""
 
         if object_size == 1:

--- a/dash-pipeline/SAI/sai_api_gen.py
+++ b/dash-pipeline/SAI/sai_api_gen.py
@@ -313,7 +313,9 @@ class SAIObject:
         for anno in p4rt_anno_list[STRUCTURED_ANNOTATIONS_TAG]:
             if anno[NAME_TAG] == SAI_VAL_TAG:
                 for kv in anno[KV_PAIR_LIST_TAG][KV_PAIRS_TAG]:
-                    if kv['key'] == 'type':
+                    if kv['key'] == 'name':
+                        self.name = kv['value']['stringValue']
+                    elif kv['key'] == 'type':
                         self.type = kv['value']['stringValue']
                     elif kv['key'] == 'default_value':  # "default" is a reserved keyword and cannot be used.
                         self.default = kv['value']['stringValue']

--- a/dash-pipeline/SAI/templates/saiapi.cpp.j2
+++ b/dash-pipeline/SAI/templates/saiapi.cpp.j2
@@ -75,7 +75,7 @@ static sai_status_t dash_sai_create_{{ table.name }}(
         switch(attr_list[i].id)
         {
             {% for key in table['keys'] %}
-            case SAI_{{ table.name | upper }}_ATTR_{{ key.sai_key_name | upper }}:
+            case SAI_{{ table.name | upper }}_ATTR_{{ key.name | upper }}:
             {
                 auto mf = matchActionEntry->add_match();
                 mf->set_field_id({{key.id}});
@@ -102,8 +102,8 @@ static sai_status_t dash_sai_create_{{ table.name }}(
                 {% elif key.match_type == 'ternary' %}
                 auto mf_ternary = mf->mutable_ternary();
                 {{key.field}}SetVal(attr_list[i].value, mf_ternary, {{key.bitwidth}});
-                auto mask = getMaskAttr(SAI_{{ table.name | upper }}_ATTR_{{ key.sai_key_name | upper }}_MASK, attr_count, attr_list);
-                assert(mask && "SAI_{{ table.name | upper }}_ATTR_{{ key.sai_key_name | upper }}_MASK isn't provided");
+                auto mask = getMaskAttr(SAI_{{ table.name | upper }}_ATTR_{{ key.name | upper }}_MASK, attr_count, attr_list);
+                assert(mask && "SAI_{{ table.name | upper }}_ATTR_{{ key.name | upper }}_MASK isn't provided");
                 {{key.field}}SetMask(mask->value, mf_ternary, {{key.bitwidth}});
                 {% endif %}
                 {% if key.ip_is_v6_field_id != 0 %}
@@ -340,17 +340,17 @@ static sai_status_t dash_sai_create_{{ table.name }}(
         mf->set_field_id({{key.id}});
         {% if key.match_type == 'exact' %}
         auto mf_exact = mf->mutable_exact();
-        //{{key.field}}SetVal(tableEntry->{{ key.sai_key_name | lower }}, mf_exact, {{key.bitwidth}});
+        //{{key.field}}SetVal(tableEntry->{{ key.name | lower }}, mf_exact, {{key.bitwidth}});
         {% set keyfield = key.field %}
         {% set bitwidth = key.bitwidth %}
         {% if keyfield in ['ipaddr','mac'] or bitwidth in [24] %} 
-          {{key.field}}SetVal(tableEntry->{{ key.sai_key_name | lower }}, mf_exact, {{key.bitwidth}});
+          {{key.field}}SetVal(tableEntry->{{ key.name | lower }}, mf_exact, {{key.bitwidth}});
         {% else %} 
-          {{key.field}}SetVal(static_cast<uint{{key.bitwidth}}_t>(tableEntry->{{ key.sai_key_name | lower }}), mf_exact, {{key.bitwidth}});
+          {{key.field}}SetVal(static_cast<uint{{key.bitwidth}}_t>(tableEntry->{{ key.name | lower }}), mf_exact, {{key.bitwidth}});
         {% endif %}
         {% elif key.match_type == 'lpm' %}
         auto mf_lpm = mf->mutable_lpm();
-        {{key.field}}SetVal(tableEntry->{{ key.sai_key_name | lower }}, mf_lpm, {{key.bitwidth}});
+        {{key.field}}SetVal(tableEntry->{{ key.name | lower }}, mf_lpm, {{key.bitwidth}});
         {% elif key.match_type == 'list' %}
         assert(0 && "mutable_list is not supported");
         goto ErrRet;
@@ -370,7 +370,7 @@ static sai_status_t dash_sai_create_{{ table.name }}(
         auto mf = matchActionEntry->add_match();
         mf->set_field_id({{key.ip_is_v6_field_id}});
         auto mf_exact = mf->mutable_exact();
-        booldataSetVal((tableEntry->{{ key.sai_key_name | lower }}.addr_family == SAI_IP_ADDR_FAMILY_IPV4) ? 0 : 1, mf_exact, 1);
+        booldataSetVal((tableEntry->{{ key.name | lower }}.addr_family == SAI_IP_ADDR_FAMILY_IPV4) ? 0 : 1, mf_exact, 1);
     }
     {% endif %}
     {% endfor %}
@@ -507,14 +507,14 @@ static sai_status_t dash_sai_remove_{{ table.name }}(
         {% set keyfield = key.field %}
         {% set bitwidth = key.bitwidth %}
         {% if keyfield in ['ipaddr','mac'] or bitwidth in [24] %}
-           {{key.field}}SetVal(tableEntry->{{ key.sai_key_name | lower }}, mf_exact, {{key.bitwidth}});
+           {{key.field}}SetVal(tableEntry->{{ key.name | lower }}, mf_exact, {{key.bitwidth}});
         {% else %}
-          {{key.field}}SetVal(static_cast<uint{{key.bitwidth}}_t>(tableEntry->{{ key.sai_key_name | lower }}), mf_exact, {{key.bitwidth}});
+          {{key.field}}SetVal(static_cast<uint{{key.bitwidth}}_t>(tableEntry->{{ key.name | lower }}), mf_exact, {{key.bitwidth}});
         {% endif %}  
-        //{{key.field}}SetVal(tableEntry->{{ key.sai_key_name | lower }}, mf_exact, {{key.bitwidth}});
+        //{{key.field}}SetVal(tableEntry->{{ key.name | lower }}, mf_exact, {{key.bitwidth}});
         {% elif key.match_type == 'lpm' %}
         auto mf_lpm = mf->mutable_lpm();
-        {{key.field}}SetVal(tableEntry->{{ key.sai_key_name | lower }}, mf_lpm, {{key.bitwidth}});
+        {{key.field}}SetVal(tableEntry->{{ key.name | lower }}, mf_lpm, {{key.bitwidth}});
         {% elif key.match_type == 'list' %}
         assert(0 && "mutable_list is not supported");
         goto ErrRet;
@@ -533,7 +533,7 @@ static sai_status_t dash_sai_remove_{{ table.name }}(
         auto mf = matchActionEntry->add_match();
         mf->set_field_id({{key.ip_is_v6_field_id}});
         auto mf_exact = mf->mutable_exact();
-        booldataSetVal((tableEntry->{{ key.sai_key_name | lower }}.addr_family == SAI_IP_ADDR_FAMILY_IPV4) ? 0 : 1, mf_exact, 1);
+        booldataSetVal((tableEntry->{{ key.name | lower }}.addr_family == SAI_IP_ADDR_FAMILY_IPV4) ? 0 : 1, mf_exact, 1);
     }
     {% endif %}
     {% endfor %}

--- a/dash-pipeline/SAI/templates/saiapi.h.j2
+++ b/dash-pipeline/SAI/templates/saiapi.h.j2
@@ -64,19 +64,19 @@ typedef struct _sai_{{ table.name }}_t
 
 {% for key in table['keys'] %}
     /**
-     * @brief {{ key.match_type | capitalize | replace('Lpm', 'LPM') }} matched key {{ key.sai_key_name }}
+     * @brief {{ key.match_type | capitalize | replace('Lpm', 'LPM') }} matched key {{ key.name }}
 {% if key.type == 'sai_object_id_t' %}
      *
      * @objects SAI_OBJECT_TYPE_{{ key.object_name | upper }}
 {% endif %}
      */
-    {{ key.type }} {{ key.sai_key_name | lower }};
+    {{ key.type }} {{ key.name | lower }};
 
 {% if key.match_type == 'ternary' %}
     /**
-     * @brief Ternary key {{ key.sai_key_name }} mask
+     * @brief Ternary key {{ key.name }} mask
      */
-    {{ key.type }} {{ key.sai_key_name | lower }}_mask;
+    {{ key.type }} {{ key.name | lower }}_mask;
 
 {% endif %}
 {% endfor %}
@@ -120,7 +120,7 @@ typedef enum _sai_{{ table.name }}_attr_t
 {% for key in table['keys'] %}
 {% if key.isattribute != 'false' %}
     /**
-     * @brief {{ key.match_type | capitalize | replace('Lpm', 'LPM') }} matched key {{ key.sai_key_name }}
+     * @brief {{ key.match_type | capitalize | replace('Lpm', 'LPM') }} matched key {{ key.name }}
      *
      * @type {{ key.type }}
      * @flags MANDATORY_ON_CREATE | CREATE_ONLY
@@ -128,27 +128,27 @@ typedef enum _sai_{{ table.name }}_attr_t
      * @isvlan false
 {% endif %}
 {% if key.type == 'sai_object_id_t' %}
-     * @objects SAI_OBJECT_TYPE_{{ key.sai_key_name | replace('_id', '') | upper }}
+     * @objects SAI_OBJECT_TYPE_{{ key.name | replace('_id', '') | upper }}
 {% endif %}
 {% if key.isresourcetype == 'true' %}
      * @isresourcetype true
 {% endif %}
      */
 {% if not ns.firstattr %}
-    SAI_{{ table.name | upper }}_ATTR_{{ key.sai_key_name | upper }} = SAI_{{ table.name | upper }}_ATTR_START,
+    SAI_{{ table.name | upper }}_ATTR_{{ key.name | upper }} = SAI_{{ table.name | upper }}_ATTR_START,
 {% set ns.firstattr = true %}
 {% else %}
-    SAI_{{ table.name | upper }}_ATTR_{{ key.sai_key_name | upper }},
+    SAI_{{ table.name | upper }}_ATTR_{{ key.name | upper }},
 {% endif %}
 
 {% if key.match_type == 'ternary' %}
     /**
-     * @brief Ternary matched mask {{ key.sai_key_name }}
+     * @brief Ternary matched mask {{ key.name }}
      *
      * @type {{ key.type }}
      * @flags MANDATORY_ON_CREATE | CREATE_ONLY
      */
-    SAI_{{ table.name | upper }}_ATTR_{{ key.sai_key_name | upper }}_MASK,
+    SAI_{{ table.name | upper }}_ATTR_{{ key.name | upper }}_MASK,
 
 {% endif %}
 {% endif %}

--- a/dash-pipeline/bmv2/README.md
+++ b/dash-pipeline/bmv2/README.md
@@ -31,6 +31,7 @@ Use `@SaiVal["tag"="value", ...]` format for annotating keys and action paramete
 Available tags are:
 
 - `type`: Specify which SAI object type should be used in generation, e.g. `sai_uint32_t`.
+- `default_value`: Override the default value for this key or action parameter.
 - `isresourcetype`: When set to "true", we generate a corresponding SAI tag in SAI APIs: `@isresourcetype true`.
 - `objects`: Space separated list of SAI object type this value accepts. When set, we force this value to be a SAI object id, and generate a corresponding SAI tag in SAI APIs: `@objects <list>`.
 - `isreadonly`: When set to "true", we generate force this value to be read-only in SAI API using: `@flags READ_ONLY`, otherwise, we generate `@flags CREATE_AND_SET`.

--- a/dash-pipeline/bmv2/dash_acl.p4
+++ b/dash-pipeline/bmv2/dash_acl.p4
@@ -36,13 +36,13 @@ match_kind {
     @SaiTable[name="dash_acl_rule", stage=str(acl.stage ## stage_index), api="dash_acl", api_order=1] \
     table stage ## stage_index { \
         key = { \
-            meta.stage ## stage_index ##_dash_acl_group_id : exact @name("meta.dash_acl_group_id:dash_acl_group_id") \
+            meta.stage ## stage_index ##_dash_acl_group_id : exact @SaiVal(name = "dash_acl_group_id") \
             @SaiVal[type="sai_object_id_t", isresourcetype="true", objects="SAI_OBJECT_TYPE_DASH_ACL_GROUP"]; \
-            meta.dst_ip_addr : LIST_MATCH @name("meta.dst_ip_addr:dip"); \
-            meta.src_ip_addr : LIST_MATCH @name("meta.src_ip_addr:sip"); \
-            meta.ip_protocol : LIST_MATCH @name("meta.ip_protocol:protocol"); \
-            meta.src_l4_port : RANGE_LIST_MATCH @name("meta.src_l4_port:src_port"); \
-            meta.dst_l4_port : RANGE_LIST_MATCH @name("meta.dst_l4_port:dst_port"); \
+            meta.dst_ip_addr : LIST_MATCH @SaiVal(name = "dip"); \
+            meta.src_ip_addr : LIST_MATCH @SaiVal(name = "sip"); \
+            meta.ip_protocol : LIST_MATCH @SaiVal(name = "protocol"); \
+            meta.src_l4_port : RANGE_LIST_MATCH @SaiVal(name = "src_port"); \
+            meta.dst_l4_port : RANGE_LIST_MATCH @SaiVal(name = "dst_port"); \
         } \
         actions = { \
             permit; \
@@ -73,12 +73,12 @@ match_kind {
     @SaiTable[name="dash_acl_rule", stage=str(acl.stage ## stage_index), api="dash_acl"] \
     table stage ##stage_index { \
         key = { \
-            meta.stage ## stage_index ##_dash_acl_group_id : exact @name("meta.dash_acl_group_id:dash_acl_group_id"); \
-            meta.dst_ip_addr : LIST_MATCH @name("meta.dst_ip_addr:dip"); \
-            meta.src_ip_addr : LIST_MATCH @name("meta.src_ip_addr:sip"); \
-            meta.ip_protocol : LIST_MATCH @name("meta.ip_protocol:protocol"); \
-            meta.src_l4_port : RANGE_LIST_MATCH @name("meta.src_l4_port:src_port"); \
-            meta.dst_l4_port : RANGE_LIST_MATCH @name("meta.dst_l4_port:dst_port"); \
+            meta.stage ## stage_index ##_dash_acl_group_id : exact @SaiVal(name = "dash_acl_group_id"); \
+            meta.dst_ip_addr : LIST_MATCH @SaiVal(name = "dip"); \
+            meta.src_ip_addr : LIST_MATCH @SaiVal(name = "sip"); \
+            meta.ip_protocol : LIST_MATCH @SaiVal(name = "protocol"); \
+            meta.src_l4_port : RANGE_LIST_MATCH @SaiVal(name = "src_port"); \
+            meta.dst_l4_port : RANGE_LIST_MATCH @SaiVal(name = "dst_port"); \
         } \
         actions = { \
             permit; \

--- a/dash-pipeline/bmv2/dash_acl.p4
+++ b/dash-pipeline/bmv2/dash_acl.p4
@@ -36,13 +36,13 @@ match_kind {
     @SaiTable[name="dash_acl_rule", stage=str(acl.stage ## stage_index), api="dash_acl", api_order=1] \
     table stage ## stage_index { \
         key = { \
-            meta.stage ## stage_index ##_dash_acl_group_id : exact @SaiVal(name = "dash_acl_group_id") \
-            @SaiVal[type="sai_object_id_t", isresourcetype="true", objects="SAI_OBJECT_TYPE_DASH_ACL_GROUP"]; \
-            meta.dst_ip_addr : LIST_MATCH @SaiVal(name = "dip"); \
-            meta.src_ip_addr : LIST_MATCH @SaiVal(name = "sip"); \
-            meta.ip_protocol : LIST_MATCH @SaiVal(name = "protocol"); \
-            meta.src_l4_port : RANGE_LIST_MATCH @SaiVal(name = "src_port"); \
-            meta.dst_l4_port : RANGE_LIST_MATCH @SaiVal(name = "dst_port"); \
+            meta.stage ## stage_index ##_dash_acl_group_id : exact \
+            @SaiVal[name = "dash_acl_group_id", type="sai_object_id_t", isresourcetype="true", objects="SAI_OBJECT_TYPE_DASH_ACL_GROUP"]; \
+            meta.dst_ip_addr : LIST_MATCH @SaiVal[name = "dip"]; \
+            meta.src_ip_addr : LIST_MATCH @SaiVal[name = "sip"]; \
+            meta.ip_protocol : LIST_MATCH @SaiVal[name = "protocol"]; \
+            meta.src_l4_port : RANGE_LIST_MATCH @SaiVal[name = "src_port"]; \
+            meta.dst_l4_port : RANGE_LIST_MATCH @SaiVal[name = "dst_port"]; \
         } \
         actions = { \
             permit; \
@@ -73,12 +73,12 @@ match_kind {
     @SaiTable[name="dash_acl_rule", stage=str(acl.stage ## stage_index), api="dash_acl"] \
     table stage ##stage_index { \
         key = { \
-            meta.stage ## stage_index ##_dash_acl_group_id : exact @SaiVal(name = "dash_acl_group_id"); \
-            meta.dst_ip_addr : LIST_MATCH @SaiVal(name = "dip"); \
-            meta.src_ip_addr : LIST_MATCH @SaiVal(name = "sip"); \
-            meta.ip_protocol : LIST_MATCH @SaiVal(name = "protocol"); \
-            meta.src_l4_port : RANGE_LIST_MATCH @SaiVal(name = "src_port"); \
-            meta.dst_l4_port : RANGE_LIST_MATCH @SaiVal(name = "dst_port"); \
+            meta.stage ## stage_index ##_dash_acl_group_id : exact @SaiVal[name = "dash_acl_group_id"]; \
+            meta.dst_ip_addr : LIST_MATCH @SaiVal[name = "dip"]; \
+            meta.src_ip_addr : LIST_MATCH @SaiVal[name = "sip"]; \
+            meta.ip_protocol : LIST_MATCH @SaiVal[name = "protocol"]; \
+            meta.src_l4_port : RANGE_LIST_MATCH @SaiVal[name = "src_port"]; \
+            meta.dst_l4_port : RANGE_LIST_MATCH @SaiVal[name = "dst_port"]; \
         } \
         actions = { \
             permit; \

--- a/dash-pipeline/bmv2/dash_conntrack.p4
+++ b/dash-pipeline/bmv2/dash_conntrack.p4
@@ -68,14 +68,14 @@ control ConntrackIn(inout headers_t hdr,
   table conntrackIn {
       key = {
           directionNeutralAddr(meta.direction, hdr.ipv4.src_addr, hdr.ipv4.dst_addr):
-              exact @SaiVal[name = "ipv4_addr1"];
+              exact @name("ipv4_addr1") @SaiVal[name = "ipv4_addr1"];
           directionNeutralAddr(meta.direction, hdr.ipv4.dst_addr, hdr.ipv4.src_addr):
-              exact @SaiVal[name = "ipv4_addr2"];
+              exact @name("ipv4_addr2") @SaiVal[name = "ipv4_addr2"];
           hdr.ipv4.protocol : exact;
           directionNeutralPort(meta.direction, hdr.tcp.src_port, hdr.tcp.dst_port):
-              exact @SaiVal[name = "tcp_port1"];
+              exact @name("tcp_port1") @SaiVal[name = "tcp_port1"];
           directionNeutralPort(meta.direction, hdr.tcp.dst_port, hdr.tcp.src_port):
-              exact @SaiVal[name = "tcp_port2"];
+              exact @name("tcp_port2") @SaiVal[name = "tcp_port2"];
           meta.eni_id : exact;
       }
       actions = {
@@ -121,14 +121,14 @@ control ConntrackOut(inout headers_t hdr,
   table conntrackOut {
       key = {
           directionNeutralAddr(meta.direction, hdr.ipv4.src_addr, hdr.ipv4.dst_addr):
-              exact @SaiVal[name = "ipv4_addr1"];
+              exact @name("ipv4_addr1") @SaiVal[name = "ipv4_addr1"];
           directionNeutralAddr(meta.direction, hdr.ipv4.dst_addr, hdr.ipv4.src_addr):
-              exact @SaiVal[name = "ipv4_addr2"];
+              exact @name("ipv4_addr2") @SaiVal[name = "ipv4_addr2"];
           hdr.ipv4.protocol : exact;
           directionNeutralPort(meta.direction, hdr.tcp.src_port, hdr.tcp.dst_port):
-              exact @SaiVal[name = "tcp_port1"];
+              exact @name("tcp_port1") @SaiVal[name = "tcp_port1"];
           directionNeutralPort(meta.direction, hdr.tcp.dst_port, hdr.tcp.src_port):
-              exact @SaiVal[name = "tcp_port2"];
+              exact @name("tcp_port2") @SaiVal[name = "tcp_port2"];
           meta.eni_id : exact;
       }
       actions = {

--- a/dash-pipeline/bmv2/dash_conntrack.p4
+++ b/dash-pipeline/bmv2/dash_conntrack.p4
@@ -68,14 +68,14 @@ control ConntrackIn(inout headers_t hdr,
   table conntrackIn {
       key = {
           directionNeutralAddr(meta.direction, hdr.ipv4.src_addr, hdr.ipv4.dst_addr):
-              exact @name("ipv4_addr1");
+              exact @SaiVal[name = "ipv4_addr1"];
           directionNeutralAddr(meta.direction, hdr.ipv4.dst_addr, hdr.ipv4.src_addr):
-              exact @name("ipv4_addr2");
+              exact @SaiVal[name = "ipv4_addr2"];
           hdr.ipv4.protocol : exact;
           directionNeutralPort(meta.direction, hdr.tcp.src_port, hdr.tcp.dst_port):
-              exact @name("tcp_port1");
+              exact @SaiVal[name = "tcp_port1"];
           directionNeutralPort(meta.direction, hdr.tcp.dst_port, hdr.tcp.src_port):
-              exact @name("tcp_port2");
+              exact @SaiVal[name = "tcp_port2"];
           meta.eni_id : exact;
       }
       actions = {
@@ -121,14 +121,14 @@ control ConntrackOut(inout headers_t hdr,
   table conntrackOut {
       key = {
           directionNeutralAddr(meta.direction, hdr.ipv4.src_addr, hdr.ipv4.dst_addr):
-              exact @name("ipv4_addr1");
+              exact @SaiVal[name = "ipv4_addr1"];
           directionNeutralAddr(meta.direction, hdr.ipv4.dst_addr, hdr.ipv4.src_addr):
-              exact @name("ipv4_addr2");
+              exact @SaiVal[name = "ipv4_addr2"];
           hdr.ipv4.protocol : exact;
           directionNeutralPort(meta.direction, hdr.tcp.src_port, hdr.tcp.dst_port):
-              exact @name("tcp_port1");
+              exact @SaiVal[name = "tcp_port1"];
           directionNeutralPort(meta.direction, hdr.tcp.dst_port, hdr.tcp.src_port):
-              exact @name("tcp_port2");
+              exact @SaiVal[name = "tcp_port2"];
           meta.eni_id : exact;
       }
       actions = {

--- a/dash-pipeline/bmv2/dash_outbound.p4
+++ b/dash-pipeline/bmv2/dash_outbound.p4
@@ -95,9 +95,9 @@ control outbound(inout headers_t hdr,
     @SaiTable[name = "outbound_routing", api = "dash_outbound_routing"]
     table routing {
         key = {
-            meta.eni_id : exact @name("meta.eni_id:eni_id");
-            meta.is_overlay_ip_v6 : exact @name("meta.is_overlay_ip_v6:destination_is_v6");
-            meta.dst_ip_addr : lpm @name("meta.dst_ip_addr:destination");
+            meta.eni_id : exact @SaiVal(name = "eni_id");
+            meta.is_overlay_ip_v6 : exact @SaiVal(name = "destination_is_v6");
+            meta.dst_ip_addr : lpm @SaiVal(name = "destination");
         }
 
         actions = {
@@ -179,9 +179,9 @@ control outbound(inout headers_t hdr,
     table ca_to_pa {
         key = {
             /* Flow for express route */
-            meta.dst_vnet_id: exact @name("meta.dst_vnet_id:dst_vnet_id");
-            meta.is_lkup_dst_ip_v6 : exact @name("meta.is_lkup_dst_ip_v6:dip_is_v6");
-            meta.lkup_dst_ip_addr : exact @name("meta.lkup_dst_ip_addr:dip");
+            meta.dst_vnet_id: exact @SaiVal(name = "dst_vnet_id");
+            meta.is_lkup_dst_ip_v6 : exact @SaiVal(name = "dip_is_v6");
+            meta.lkup_dst_ip_addr : exact @SaiVal(name = "dip");
         }
 
         actions = {
@@ -208,7 +208,7 @@ control outbound(inout headers_t hdr,
     @SaiTable[name = "vnet", api = "dash_vnet"]
     table vnet {
         key = {
-            meta.vnet_id : exact @name("meta.vnet_id:vnet_id");
+            meta.vnet_id : exact @SaiVal(name = "vnet_id");
         }
 
         actions = {

--- a/dash-pipeline/bmv2/dash_outbound.p4
+++ b/dash-pipeline/bmv2/dash_outbound.p4
@@ -95,9 +95,9 @@ control outbound(inout headers_t hdr,
     @SaiTable[name = "outbound_routing", api = "dash_outbound_routing"]
     table routing {
         key = {
-            meta.eni_id : exact @SaiVal(name = "eni_id");
-            meta.is_overlay_ip_v6 : exact @SaiVal(name = "destination_is_v6");
-            meta.dst_ip_addr : lpm @SaiVal(name = "destination");
+            meta.eni_id : exact @SaiVal[name = "eni_id"];
+            meta.is_overlay_ip_v6 : exact @SaiVal[name = "destination_is_v6"];
+            meta.dst_ip_addr : lpm @SaiVal[name = "destination"];
         }
 
         actions = {
@@ -179,9 +179,9 @@ control outbound(inout headers_t hdr,
     table ca_to_pa {
         key = {
             /* Flow for express route */
-            meta.dst_vnet_id: exact @SaiVal(name = "dst_vnet_id");
-            meta.is_lkup_dst_ip_v6 : exact @SaiVal(name = "dip_is_v6");
-            meta.lkup_dst_ip_addr : exact @SaiVal(name = "dip");
+            meta.dst_vnet_id: exact @SaiVal[name = "dst_vnet_id"];
+            meta.is_lkup_dst_ip_v6 : exact @SaiVal[name = "dip_is_v6"];
+            meta.lkup_dst_ip_addr : exact @SaiVal[name = "dip"];
         }
 
         actions = {
@@ -208,7 +208,7 @@ control outbound(inout headers_t hdr,
     @SaiTable[name = "vnet", api = "dash_vnet"]
     table vnet {
         key = {
-            meta.vnet_id : exact @SaiVal(name = "vnet_id");
+            meta.vnet_id : exact @SaiVal[name = "vnet_id"];
         }
 
         actions = {

--- a/dash-pipeline/bmv2/dash_pipeline.p4
+++ b/dash-pipeline/bmv2/dash_pipeline.p4
@@ -42,7 +42,7 @@ control dash_ingress(
     @SaiTable[name = "vip", api = "dash_vip"]
     table vip {
         key = {
-            hdr.ipv4.dst_addr : exact @name("hdr.ipv4.dst_addr:VIP");
+            hdr.ipv4.dst_addr : exact @SaiVal(name = "VIP");
         }
 
         actions = {
@@ -64,7 +64,7 @@ control dash_ingress(
     @SaiTable[name = "direction_lookup", api = "dash_direction_lookup"]
     table direction_lookup {
         key = {
-            hdr.vxlan.vni : exact @name("hdr.vxlan.vni:VNI");
+            hdr.vxlan.vni : exact @SaiVal(name = "VNI");
         }
 
         actions = {
@@ -85,7 +85,7 @@ control dash_ingress(
     @SaiTable[ignored = "true"]
     table appliance {
         key = {
-            meta.appliance_id : ternary @name("meta.appliance_id:appliance_id");
+            meta.appliance_id : ternary @SaiVal(name = "appliance_id");
         }
 
         actions = {
@@ -157,7 +157,7 @@ control dash_ingress(
     @SaiTable[name = "eni", api = "dash_eni", api_order=1]
     table eni {
         key = {
-            meta.eni_id : exact @name("meta.eni_id:eni_id");
+            meta.eni_id : exact @SaiVal(name = "eni_id");
         }
 
         actions = {
@@ -189,9 +189,9 @@ control dash_ingress(
     @SaiTable[ignored = "true"]
     table eni_meter {
         key = {
-            meta.eni_id : exact @name("meta.eni_id:eni_id");
-            meta.direction : exact @name("meta.direction:direction");
-            meta.dropped : exact @name("meta.dropped:dropped");
+            meta.eni_id : exact @SaiVal(name = "eni_id");
+            meta.direction : exact @SaiVal(name = "direction");
+            meta.dropped : exact @SaiVal(name = "dropped");
         }
 
         actions = { NoAction; }
@@ -216,8 +216,8 @@ control dash_ingress(
     @SaiTable[name = "pa_validation", api = "dash_pa_validation"]
     table pa_validation {
         key = {
-            meta.vnet_id: exact @name("meta.vnet_id:vnet_id");
-            hdr.ipv4.src_addr : exact @name("hdr.ipv4.src_addr:sip");
+            meta.vnet_id: exact @SaiVal(name = "vnet_id");
+            hdr.ipv4.src_addr : exact @SaiVal(name = "sip");
         }
 
         actions = {
@@ -231,9 +231,9 @@ control dash_ingress(
     @SaiTable[name = "inbound_routing", api = "dash_inbound_routing"]
     table inbound_routing {
         key = {
-            meta.eni_id: exact @name("meta.eni_id:eni_id");
-            hdr.vxlan.vni : exact @name("hdr.vxlan.vni:VNI");
-            hdr.ipv4.src_addr : ternary @name("hdr.ipv4.src_addr:sip");
+            meta.eni_id: exact @SaiVal(name = "eni_id");
+            hdr.vxlan.vni : exact @SaiVal(name = "VNI");
+            hdr.ipv4.src_addr : ternary @SaiVal(name = "sip");
         }
         actions = {
             vxlan_decap(hdr);
@@ -259,7 +259,7 @@ control dash_ingress(
     @SaiTable[name = "meter_policy", api = "dash_meter", api_order = 1, isobject="true"]
     table meter_policy {
         key = {
-            meta.meter_policy_id : exact @name("meta.meter_policy_id:meter_policy_id");
+            meta.meter_policy_id : exact @SaiVal(name = "meter_policy_id");
         }
         actions = {
             check_ip_addr_family;
@@ -273,8 +273,8 @@ control dash_ingress(
     @SaiTable[name = "meter_rule", api = "dash_meter", api_order = 2, isobject="true"]
     table meter_rule {
         key = {
-            meta.meter_policy_id: exact @name("meta.meter_policy_id:meter_policy_id") @SaiVal[type="sai_object_id_t", isresourcetype="true", objects="METER_POLICY"];
-            hdr.ipv4.dst_addr : ternary @name("hdr.ipv4.dst_addr:dip");
+            meta.meter_policy_id: exact @SaiVal(name = "meter_policy_id") @SaiVal[type="sai_object_id_t", isresourcetype="true", objects="METER_POLICY"];
+            hdr.ipv4.dst_addr : ternary @SaiVal(name = "dip");
         }
 
      actions = {
@@ -301,8 +301,8 @@ control dash_ingress(
     @SaiTable[name = "meter_bucket", api = "dash_meter", api_order = 0, isobject="true"]
     table meter_bucket {
         key = {
-            meta.eni_id: exact @name("meta.eni_id:eni_id");
-            meta.meter_class: exact @name("meta.meter_class:meter_class");
+            meta.eni_id: exact @SaiVal(name = "eni_id");
+            meta.meter_class: exact @SaiVal(name = "meter_class");
         }
         actions = {
             meter_bucket_action;
@@ -318,7 +318,7 @@ control dash_ingress(
     @SaiTable[name = "eni_ether_address_map", api = "dash_eni", api_order=0]
     table eni_ether_address_map {
         key = {
-            meta.eni_addr : exact @name("meta.eni_addr:address");
+            meta.eni_addr : exact @SaiVal(name = "address");
         }
 
         actions = {
@@ -343,7 +343,7 @@ control dash_ingress(
     @SaiTable[name = "dash_acl_group", api = "dash_acl", api_order = 0]
     table acl_group {
         key = {
-            meta.stage1_dash_acl_group_id : exact @name("meta.stage1_dash_acl_group_id:dash_acl_group_id");
+            meta.stage1_dash_acl_group_id : exact @SaiVal(name = "dash_acl_group_id");
         }
         actions = {
             set_acl_group_attrs();

--- a/dash-pipeline/bmv2/dash_pipeline.p4
+++ b/dash-pipeline/bmv2/dash_pipeline.p4
@@ -244,7 +244,7 @@ control dash_ingress(
         const default_action = deny;
     }
 
-    action check_ip_addr_family(@SaiVal[type="sai_ip_addr_family_t", isresourcetype="true"] bit<32> ip_addr_family] {
+    action check_ip_addr_family(@SaiVal[type="sai_ip_addr_family_t", isresourcetype="true"] bit<32> ip_addr_family) {
         if (ip_addr_family == 0) /* SAI_IP_ADDR_FAMILY_IPV4 */ {
             if (meta.is_overlay_ip_v6 == 1) {
                 meta.dropped = true;
@@ -293,7 +293,7 @@ control dash_ingress(
     action meter_bucket_action(
             @SaiVal[type="sai_uint64_t", isreadonly="true"] bit<64> outbound_bytes_counter,
             @SaiVal[type="sai_uint64_t", isreadonly="true"] bit<64> inbound_bytes_counter,
-            @SaiVal[type="sai_uint32_t", skipattr="true"] bit<32> meter_bucket_index] {
+            @SaiVal[type="sai_uint32_t", skipattr="true"] bit<32> meter_bucket_index) {
         // read only counters for SAI api generation only
         meta.meter_bucket_index = meter_bucket_index;
     }
@@ -328,7 +328,7 @@ control dash_ingress(
         const default_action = deny;
     }
 
-    action set_acl_group_attrs(@SaiVal[type="sai_ip_addr_family_t", isresourcetype="true"] bit<32> ip_addr_family] {
+    action set_acl_group_attrs(@SaiVal[type="sai_ip_addr_family_t", isresourcetype="true"] bit<32> ip_addr_family) {
         if (ip_addr_family == 0) /* SAI_IP_ADDR_FAMILY_IPV4 */ {
             if (meta.is_overlay_ip_v6 == 1) {
                 meta.dropped = true;

--- a/dash-pipeline/bmv2/dash_pipeline.p4
+++ b/dash-pipeline/bmv2/dash_pipeline.p4
@@ -42,7 +42,7 @@ control dash_ingress(
     @SaiTable[name = "vip", api = "dash_vip"]
     table vip {
         key = {
-            hdr.ipv4.dst_addr : exact @SaiVal(name = "VIP");
+            hdr.ipv4.dst_addr : exact @SaiVal[name = "VIP"];
         }
 
         actions = {
@@ -64,7 +64,7 @@ control dash_ingress(
     @SaiTable[name = "direction_lookup", api = "dash_direction_lookup"]
     table direction_lookup {
         key = {
-            hdr.vxlan.vni : exact @SaiVal(name = "VNI");
+            hdr.vxlan.vni : exact @SaiVal[name = "VNI"];
         }
 
         actions = {
@@ -85,7 +85,7 @@ control dash_ingress(
     @SaiTable[ignored = "true"]
     table appliance {
         key = {
-            meta.appliance_id : ternary @SaiVal(name = "appliance_id");
+            meta.appliance_id : ternary @SaiVal[name = "appliance_id"];
         }
 
         actions = {
@@ -157,7 +157,7 @@ control dash_ingress(
     @SaiTable[name = "eni", api = "dash_eni", api_order=1]
     table eni {
         key = {
-            meta.eni_id : exact @SaiVal(name = "eni_id");
+            meta.eni_id : exact @SaiVal[name = "eni_id"];
         }
 
         actions = {
@@ -189,9 +189,9 @@ control dash_ingress(
     @SaiTable[ignored = "true"]
     table eni_meter {
         key = {
-            meta.eni_id : exact @SaiVal(name = "eni_id");
-            meta.direction : exact @SaiVal(name = "direction");
-            meta.dropped : exact @SaiVal(name = "dropped");
+            meta.eni_id : exact @SaiVal[name = "eni_id"];
+            meta.direction : exact @SaiVal[name = "direction"];
+            meta.dropped : exact @SaiVal[name = "dropped"];
         }
 
         actions = { NoAction; }
@@ -216,8 +216,8 @@ control dash_ingress(
     @SaiTable[name = "pa_validation", api = "dash_pa_validation"]
     table pa_validation {
         key = {
-            meta.vnet_id: exact @SaiVal(name = "vnet_id");
-            hdr.ipv4.src_addr : exact @SaiVal(name = "sip");
+            meta.vnet_id: exact @SaiVal[name = "vnet_id"];
+            hdr.ipv4.src_addr : exact @SaiVal[name = "sip"];
         }
 
         actions = {
@@ -231,9 +231,9 @@ control dash_ingress(
     @SaiTable[name = "inbound_routing", api = "dash_inbound_routing"]
     table inbound_routing {
         key = {
-            meta.eni_id: exact @SaiVal(name = "eni_id");
-            hdr.vxlan.vni : exact @SaiVal(name = "VNI");
-            hdr.ipv4.src_addr : ternary @SaiVal(name = "sip");
+            meta.eni_id: exact @SaiVal[name = "eni_id"];
+            hdr.vxlan.vni : exact @SaiVal[name = "VNI"];
+            hdr.ipv4.src_addr : ternary @SaiVal[name = "sip"];
         }
         actions = {
             vxlan_decap(hdr);
@@ -244,7 +244,7 @@ control dash_ingress(
         const default_action = deny;
     }
 
-    action check_ip_addr_family(@SaiVal[type="sai_ip_addr_family_t", isresourcetype="true"] bit<32> ip_addr_family) {
+    action check_ip_addr_family(@SaiVal[type="sai_ip_addr_family_t", isresourcetype="true"] bit<32> ip_addr_family] {
         if (ip_addr_family == 0) /* SAI_IP_ADDR_FAMILY_IPV4 */ {
             if (meta.is_overlay_ip_v6 == 1) {
                 meta.dropped = true;
@@ -259,7 +259,7 @@ control dash_ingress(
     @SaiTable[name = "meter_policy", api = "dash_meter", api_order = 1, isobject="true"]
     table meter_policy {
         key = {
-            meta.meter_policy_id : exact @SaiVal(name = "meter_policy_id");
+            meta.meter_policy_id : exact @SaiVal[name = "meter_policy_id"];
         }
         actions = {
             check_ip_addr_family;
@@ -273,8 +273,8 @@ control dash_ingress(
     @SaiTable[name = "meter_rule", api = "dash_meter", api_order = 2, isobject="true"]
     table meter_rule {
         key = {
-            meta.meter_policy_id: exact @SaiVal(name = "meter_policy_id") @SaiVal[type="sai_object_id_t", isresourcetype="true", objects="METER_POLICY"];
-            hdr.ipv4.dst_addr : ternary @SaiVal(name = "dip");
+            meta.meter_policy_id: exact @SaiVal[name = "meter_policy_id", type="sai_object_id_t", isresourcetype="true", objects="METER_POLICY"];
+            hdr.ipv4.dst_addr : ternary @SaiVal[name = "dip"];
         }
 
      actions = {
@@ -293,7 +293,7 @@ control dash_ingress(
     action meter_bucket_action(
             @SaiVal[type="sai_uint64_t", isreadonly="true"] bit<64> outbound_bytes_counter,
             @SaiVal[type="sai_uint64_t", isreadonly="true"] bit<64> inbound_bytes_counter,
-            @SaiVal[type="sai_uint32_t", skipattr="true"] bit<32> meter_bucket_index) {
+            @SaiVal[type="sai_uint32_t", skipattr="true"] bit<32> meter_bucket_index] {
         // read only counters for SAI api generation only
         meta.meter_bucket_index = meter_bucket_index;
     }
@@ -301,8 +301,8 @@ control dash_ingress(
     @SaiTable[name = "meter_bucket", api = "dash_meter", api_order = 0, isobject="true"]
     table meter_bucket {
         key = {
-            meta.eni_id: exact @SaiVal(name = "eni_id");
-            meta.meter_class: exact @SaiVal(name = "meter_class");
+            meta.eni_id: exact @SaiVal[name = "eni_id"];
+            meta.meter_class: exact @SaiVal[name = "meter_class"];
         }
         actions = {
             meter_bucket_action;
@@ -318,7 +318,7 @@ control dash_ingress(
     @SaiTable[name = "eni_ether_address_map", api = "dash_eni", api_order=0]
     table eni_ether_address_map {
         key = {
-            meta.eni_addr : exact @SaiVal(name = "address");
+            meta.eni_addr : exact @SaiVal[name = "address"];
         }
 
         actions = {
@@ -328,7 +328,7 @@ control dash_ingress(
         const default_action = deny;
     }
 
-    action set_acl_group_attrs(@SaiVal[type="sai_ip_addr_family_t", isresourcetype="true"] bit<32> ip_addr_family) {
+    action set_acl_group_attrs(@SaiVal[type="sai_ip_addr_family_t", isresourcetype="true"] bit<32> ip_addr_family] {
         if (ip_addr_family == 0) /* SAI_IP_ADDR_FAMILY_IPV4 */ {
             if (meta.is_overlay_ip_v6 == 1) {
                 meta.dropped = true;
@@ -343,7 +343,7 @@ control dash_ingress(
     @SaiTable[name = "dash_acl_group", api = "dash_acl", api_order = 0]
     table acl_group {
         key = {
-            meta.stage1_dash_acl_group_id : exact @SaiVal(name = "dash_acl_group_id");
+            meta.stage1_dash_acl_group_id : exact @SaiVal[name = "dash_acl_group_id"];
         }
         actions = {
             set_acl_group_attrs();

--- a/dash-pipeline/bmv2/dash_pipeline.p4
+++ b/dash-pipeline/bmv2/dash_pipeline.p4
@@ -42,7 +42,7 @@ control dash_ingress(
     @SaiTable[name = "vip", api = "dash_vip"]
     table vip {
         key = {
-            hdr.ipv4.dst_addr : exact @SaiVal[name = "VIP"];
+            hdr.ipv4.dst_addr : exact @SaiVal[name = "vip"];
         }
 
         actions = {
@@ -64,7 +64,7 @@ control dash_ingress(
     @SaiTable[name = "direction_lookup", api = "dash_direction_lookup"]
     table direction_lookup {
         key = {
-            hdr.vxlan.vni : exact @SaiVal[name = "VNI"];
+            hdr.vxlan.vni : exact @SaiVal[name = "vni"];
         }
 
         actions = {
@@ -318,7 +318,7 @@ control dash_ingress(
     @SaiTable[name = "eni_ether_address_map", api = "dash_eni", api_order=0]
     table eni_ether_address_map {
         key = {
-            meta.eni_addr : exact @SaiVal[name = "address"];
+            meta.eni_addr : exact @SaiVal[name = "address", type = "sai_mac_t"];
         }
 
         actions = {

--- a/dash-pipeline/bmv2/dash_pipeline.p4
+++ b/dash-pipeline/bmv2/dash_pipeline.p4
@@ -42,7 +42,7 @@ control dash_ingress(
     @SaiTable[name = "vip", api = "dash_vip"]
     table vip {
         key = {
-            hdr.ipv4.dst_addr : exact @SaiVal[name = "vip"];
+            hdr.ipv4.dst_addr : exact @SaiVal[name = "VIP"];
         }
 
         actions = {
@@ -64,7 +64,7 @@ control dash_ingress(
     @SaiTable[name = "direction_lookup", api = "dash_direction_lookup"]
     table direction_lookup {
         key = {
-            hdr.vxlan.vni : exact @SaiVal[name = "vni"];
+            hdr.vxlan.vni : exact @SaiVal[name = "VNI"];
         }
 
         actions = {

--- a/dash-pipeline/bmv2/underlay.p4
+++ b/dash-pipeline/bmv2/underlay.p4
@@ -71,7 +71,7 @@ control underlay(
     @SaiTable[name = "route", api = "route", api_type="underlay"]
     table underlay_routing {
         key = {
-            meta.dst_ip_addr : lpm @name("meta.dst_ip_addr:destination");
+            meta.dst_ip_addr : lpm @SaiVal(name = "destination");
         }
 
         actions = {

--- a/dash-pipeline/bmv2/underlay.p4
+++ b/dash-pipeline/bmv2/underlay.p4
@@ -71,7 +71,7 @@ control underlay(
     @SaiTable[name = "route", api = "route", api_type="underlay"]
     table underlay_routing {
         key = {
-            meta.dst_ip_addr : lpm @SaiVal(name = "destination");
+            meta.dst_ip_addr : lpm @SaiVal[name = "destination"];
         }
 
         actions = {


### PR DESCRIPTION
This change is based on #479 , hence including all changes in the PR.

No update on SAI headers after this change:

```bash
r12f@r12f-dl380:~/data/code/sonic/DASH/dash-pipeline
$ diff SAI/SAI/experimental/ ~/data/code/sonic/DASH-exp/dash-pipeline/SAI/SAI/experimental/
```

2 comments are updated in lib file, but looks like the previous result is wrong:
![image](https://github.com/sonic-net/DASH/assets/1533278/5d861063-38de-4c3e-aeff-6fd70e4fffca)

Take route_vnet as an example, it indeed only take 4 parameters, as ip_is_v6 field doesn't count:
![image](https://github.com/sonic-net/DASH/assets/1533278/612703c0-6973-45fe-9631-90289dbf1e44)

