### PR TITLE
[sai-gen] Use the first value of enum as default value.

### DIFF
--- a/dash-pipeline/SAI/sai_api_gen.py
+++ b/dash-pipeline/SAI/sai_api_gen.py
@@ -389,7 +389,7 @@ class SAIEnum(SAIObject):
         SAITypeSolver.register_sai_type(
             'sai_' + self.name + '_t',
             "s32",
-            default = 'SAI_' + self.name.upper() + '_INVALID',
+            default = 'SAI_' + self.name.upper() + "_" + self.members[0].name.upper(),
             is_enum = True)
 
 


### PR DESCRIPTION
No update in the generated content:

```bash
r12f@r12f-dl380:~/data/code/sonic/DASH/dash-pipeline
$ diff SAI/SAI/experimental/ ~/data/code/sonic/DASH-exp/dash-pipeline/SAI/SAI/experimental/
r12f@r12f-dl380:~/data/code/sonic/DASH/dash-pipeline
$ diff SAI/lib/ ~/data/code/sonic/DASH-exp/dash-pipeline/SAI/lib/
```