### PR TITLE
[sai-gen] Update ACL tables type and match type annotations for SAI header generation

### DIFF
--- a/dash-pipeline/SAI/sai_api_gen.py
+++ b/dash-pipeline/SAI/sai_api_gen.py
@@ -155,9 +155,9 @@ class SAITypeSolver:
         elif match_type == 'list':
             return SAITypeSolver.__get_list_match_key_sai_type(key_size)
         elif match_type == 'range':
-            return SAITypeSolver.__get_range_sai_type(key_size)
+            return SAITypeSolver.__get_range_match_key_sai_type(key_size)
         elif match_type == 'range_list':
-            return SAITypeSolver.__get_range_list_sai_type(key_size)
+            return SAITypeSolver.__get_range_list_match_key_sai_type(key_size)
         else:
             raise ValueError(f"match_type={match_type} is not supported")
 
@@ -191,7 +191,7 @@ class SAITypeSolver:
         return SAITypeSolver.get_sai_type(sai_type_name)
 
     @staticmethod
-    def __get_range_sai_type(key_size):
+    def __get_range_match_key_sai_type(key_size):
         sai_type_name = ""
 
         # In SAI, all ranges that having smaller size than 32-bits are passed as 32-bits, such as port ranges and etc.
@@ -204,7 +204,7 @@ class SAITypeSolver:
         return SAITypeSolver.get_sai_type(sai_type_name)
 
     @staticmethod
-    def __get_range_list_sai_type(key_size):
+    def __get_range_list_match_key_sai_type(key_size):
         sai_type_name = ""
 
         if key_size <= 8:

--- a/dash-pipeline/SAI/sai_api_gen.py
+++ b/dash-pipeline/SAI/sai_api_gen.py
@@ -236,6 +236,7 @@ class SAIObject:
         self.skipattr = None
         self.field = None
         self.default = None
+        self.match_type = ""
 
     def parse_basic_info_if_exists(self, p4rt_object):
         '''
@@ -300,6 +301,8 @@ class SAIObject:
                         self.object_name = kv['value']['stringValue']
                     elif kv['key'] == 'skipattr':
                         self.skipattr = kv['value']['stringValue']
+                    elif kv['key'] == 'match_type':
+                        self.match_type = kv['value']['stringValue']
                     else:
                         raise ValueError("Unknown attr annotation " + kv['key'])
 
@@ -381,7 +384,6 @@ class SAIAPITableKey(SAIObject):
     '''
     def __init__(self):
         super().__init__()
-        self.match_type = ""
         self.bitwidth = 0
         self.ip_is_v6_field_id = 0
 

--- a/dash-pipeline/SAI/templates/saiapi.cpp.j2
+++ b/dash-pipeline/SAI/templates/saiapi.cpp.j2
@@ -88,6 +88,7 @@ static sai_status_t dash_sai_create_{{ table.name }}(
                 {% elif key.match_type == 'list' %}
                 // BMv2 doesn't support "list" match type, and we are using "optional" match in v1model as our implementation.
                 // Hence, here we only take the first item from the list and program it as optional match.
+                assert(attr_list[i].value.{{key.field}}.count == 1 && "BMv2 only supports one item in list match type");
                 auto mf_optional = mf->mutable_optional();
                 sai_attribute_value_t attr_val;
                     {% if key.field == 'ipprefixlist' %}
@@ -101,6 +102,7 @@ static sai_status_t dash_sai_create_{{ table.name }}(
                 {% elif key.match_type == 'range_list' %}
                 // BMv2 doesn't support "range_list" match type, and we are using "optional" match in v1model as our implementation.
                 // Hence, here we only take the first item from the list and program it as optional match.
+                assert(attr_list[i].value.{{key.field}}.count == 1 && "BMv2 only supports one item in list match type");
                 auto mf_optional = mf->mutable_optional();
                 {{ key.field | replace('rangelist', '') }}SetVal(attr_list[i].value.{{key.field}}.list[0].min, mf_optional, {{key.bitwidth}});
                 {% elif key.match_type == 'optional' %}
@@ -361,6 +363,7 @@ static sai_status_t dash_sai_create_{{ table.name }}(
         {% elif key.match_type == 'list' %}
         // BMv2 doesn't support "list" match type, and we are using "optional" match in v1model as our implementation.
         // Hence, here we only take the first item from the list and program it as optional match.
+        assert(attr_list[i].value.{{key.field}}.count == 1 && "BMv2 only supports one item in list match type");
         auto mf_optional = mf->mutable_optional();
         sai_attribute_value_t attr_val;
             {% if key.field == 'ipprefixlist' %}
@@ -374,6 +377,7 @@ static sai_status_t dash_sai_create_{{ table.name }}(
         {% elif key.field == 'range_list' %}
         // BMv2 doesn't support "range_list" match type, and we are using "optional" match in v1model as our implementation.
         // Hence, here we only take the first item from the list and program the range start as optional match.
+        assert(attr_list[i].value.{{key.field}}.count == 1 && "BMv2 only supports one item in list match type");
         auto mf_optional = mf->mutable_optional();
         {{ key.field | replace('rangelist', '') }}SetVal(attr_list[i].value.{{key.field}}.list[0].min, mf_optional, {{key.bitwidth}});
         {% endif %}
@@ -532,6 +536,7 @@ static sai_status_t dash_sai_remove_{{ table.name }}(
         {% elif key.match_type == 'list' %}
         // BMv2 doesn't support "list" match type, and we are using "optional" match in v1model as our implementation.
         // Hence, here we only take the first item from the list and program it as optional match.
+        assert(attr_list[i].value.{{key.field}}.count == 1 && "BMv2 only supports one item in list match type");
         auto mf_optional = mf->mutable_optional();
         sai_attribute_value_t attr_val;
             {% if key.field == 'ipprefixlist' %}
@@ -545,6 +550,7 @@ static sai_status_t dash_sai_remove_{{ table.name }}(
         {% elif key.match_type == 'range_list' %}
         // BMv2 doesn't support "range_list" match type, and we are using "optional" match in v1model as our implementation.
         // Hence, here we only take the first item from the list and program it as optional match.
+        assert(attr_list[i].value.{{key.field}}.count == 1 && "BMv2 only supports one item in list match type");
         auto mf_optional = mf->mutable_optional();
         {{ key.field | replace('rangelist', '') }}SetVal(attr_list[i].value.{{key.field}}.list[0].min, mf_optional, {{key.bitwidth}});
         {% endif %}

--- a/dash-pipeline/SAI/templates/saiapi.cpp.j2
+++ b/dash-pipeline/SAI/templates/saiapi.cpp.j2
@@ -86,16 +86,23 @@ static sai_status_t dash_sai_create_{{ table.name }}(
                 auto mf_lpm = mf->mutable_lpm();
                 {{key.field}}SetVal(attr_list[i].value, mf_lpm, {{key.bitwidth}});
                 {% elif key.match_type == 'list' %}
-                assert(0 && "mutable_list is not supported");
-                goto ErrRet;
-                // auto mf1_list = mf1->mutable_xxx();
-                //{{key.field}}SetVal(attr_list[i].value, mf1_list, {{key.bitwidth}});
+                // BMv2 doesn't support "list" match type, and we are using "optional" match in v1model as our implementation.
+                // Hence, here we only take the first item from the list and program it as optional match.
+                auto mf_optional = mf->mutable_optional();
+                sai_attribute_value_t attr_val;
+                    {% if key.field == 'ipprefixlist' %}
+                attr_val.ipaddr.addr_family = attr_list[i].value.ipprefixlist.list[0].addr_family;
+                attr_val.ipaddr.addr = attr_list[i].value.ipprefixlist.list[0].addr;
+                ipaddrSetVal(attr_val, mf_optional, {{key.bitwidth}});
+                    {% else %}
+                attr_val.{{ key.field | replace('list', '') }} = attr_list[i].value.{{key.field}}.list[0];
+                {{ key.field | replace('list', '') }}SetVal(attr_val, mf_optional, {{key.bitwidth}});
+                    {% endif %}
                 {% elif key.match_type == 'range_list' %}
-                goto ErrRet;
-                assert(0 && "range_list is not supported");
-                // TODO: if it is ternary, need to set the mask
-                // auto mf1_list = mf1->mutable_xxx();
-                //{{key.field}}SetVal(attr_list[i].value, mf1_list, {{key.bitwidth}});
+                // BMv2 doesn't support "range_list" match type, and we are using "optional" match in v1model as our implementation.
+                // Hence, here we only take the first item from the list and program it as optional match.
+                auto mf_optional = mf->mutable_optional();
+                {{ key.field | replace('rangelist', '') }}SetVal(attr_list[i].value.{{key.field}}.list[0].min, mf_optional, {{key.bitwidth}});
                 {% elif key.match_type == 'optional' %}
                 auto mf_optional = mf->mutable_optional();
                 {{key.field}}SetVal(attr_list[i].value, mf_optional, {{key.bitwidth}});
@@ -352,16 +359,23 @@ static sai_status_t dash_sai_create_{{ table.name }}(
         auto mf_lpm = mf->mutable_lpm();
         {{key.field}}SetVal(tableEntry->{{ key.name | lower }}, mf_lpm, {{key.bitwidth}});
         {% elif key.match_type == 'list' %}
-        assert(0 && "mutable_list is not supported");
-        goto ErrRet;
-        // auto mf1_list = mf1->mutable_xxx();
-        //{{key.field}}SetVal(attr_list[i].value, mf1_list, {{key.bitwidth}});
-        {% elif key.match_type == 'range_list' %}
-        assert(0 && "range_list is not supported");
-        goto ErrRet;
-        // TODO: if it is ternary, need to set the mask
-        // auto mf1_list = mf1->mutable_xxx();
-        //{{key.field}}SetVal(attr_list[i].value, mf1_list, {{key.bitwidth}});
+        // BMv2 doesn't support "list" match type, and we are using "optional" match in v1model as our implementation.
+        // Hence, here we only take the first item from the list and program it as optional match.
+        auto mf_optional = mf->mutable_optional();
+        sai_attribute_value_t attr_val;
+            {% if key.field == 'ipprefixlist' %}
+        attr_val.ipaddr.addr_family = attr_list[i].value.ipprefixlist.list[0].addr_family;
+        attr_val.ipaddr.addr = attr_list[i].value.ipprefixlist.list[0].addr;
+        ipaddrSetVal(attr_val, mf_optional, {{key.bitwidth}});
+            {% else %}
+        attr_val.{{ key.field | replace('list', '') }} = attr_list[i].value.{{key.field}}.list[0];
+        {{ key.field | replace('list', '') }}SetVal(attr_val, mf_optional, {{key.bitwidth}});
+            {% endif %}
+        {% elif key.field == 'range_list' %}
+        // BMv2 doesn't support "range_list" match type, and we are using "optional" match in v1model as our implementation.
+        // Hence, here we only take the first item from the list and program the range start as optional match.
+        auto mf_optional = mf->mutable_optional();
+        {{ key.field | replace('rangelist', '') }}SetVal(attr_list[i].value.{{key.field}}.list[0].min, mf_optional, {{key.bitwidth}});
         {% endif %}
     }
     {% if key.ip_is_v6_field_id != 0 %}
@@ -516,15 +530,23 @@ static sai_status_t dash_sai_remove_{{ table.name }}(
         auto mf_lpm = mf->mutable_lpm();
         {{key.field}}SetVal(tableEntry->{{ key.name | lower }}, mf_lpm, {{key.bitwidth}});
         {% elif key.match_type == 'list' %}
-        assert(0 && "mutable_list is not supported");
-        goto ErrRet;
-        // auto mf1_list = mf1->mutable_xxx();
-        //{{key.field}}SetVal(attr_list[i].value, mf1_list, {{key.bitwidth}});
+        // BMv2 doesn't support "list" match type, and we are using "optional" match in v1model as our implementation.
+        // Hence, here we only take the first item from the list and program it as optional match.
+        auto mf_optional = mf->mutable_optional();
+        sai_attribute_value_t attr_val;
+            {% if key.field == 'ipprefixlist' %}
+        attr_val.ipaddr.addr_family = attr_list[i].value.ipprefixlist.list[0].addr_family;
+        attr_val.ipaddr.addr = attr_list[i].value.ipprefixlist.list[0].addr;
+        ipaddrSetVal(attr_val, mf_optional, {{key.bitwidth}});
+            {% else %}
+        attr_val.{{ key.field | replace('list', '') }} = attr_list[i].value.{{key.field}}.list[0];
+        {{ key.field | replace('list', '') }}SetVal(attr_val, mf_optional, {{key.bitwidth}});
+            {% endif %}
         {% elif key.match_type == 'range_list' %}
-        assert(0 && "range_list is not supported");
-        goto ErrRet;
-        // auto mf1_list = mf1->mutable_xxx();
-        //{{key.field}}SetVal(attr_list[i].value, mf1_list, {{key.bitwidth}});
+        // BMv2 doesn't support "range_list" match type, and we are using "optional" match in v1model as our implementation.
+        // Hence, here we only take the first item from the list and program it as optional match.
+        auto mf_optional = mf->mutable_optional();
+        {{ key.field | replace('rangelist', '') }}SetVal(attr_list[i].value.{{key.field}}.list[0].min, mf_optional, {{key.bitwidth}});
         {% endif %}
     }
     {% if key.ip_is_v6_field_id != 0 %}

--- a/dash-pipeline/bmv2/README.md
+++ b/dash-pipeline/bmv2/README.md
@@ -50,6 +50,7 @@ Available tags are:
 - `stage`: Specify which stage this table represents for the matching stage type, e.g. `acl.stage1`.
 - `isobject`: When set to "true", a top level objects in SAI that attached to switch will be generated. Otherwise, a new type of entry will be generated, if nothing else helps us to determine this table is an object table.
 - `ignored`: When set to "true", we skip this table in SAI API generation.
+- `match_type`: Some match kinds used in DASH might not be supported by BMv2, such as `list` and `range_list`. In BMv2, we use `optional` to make the P4 compiler happy. However, we still want to generate the correct SAI API. This tag is used to specify the match type in SAI API generation.
 
 For more details, please check the SAI API generation script: [sai_api_gen.py](../SAI/sai_api_gen.py).
 

--- a/dash-pipeline/bmv2/dash_acl.p4
+++ b/dash-pipeline/bmv2/dash_acl.p4
@@ -38,11 +38,11 @@ match_kind {
         key = { \
             meta.stage ## stage_index ##_dash_acl_group_id : exact \
             @SaiVal[name = "dash_acl_group_id", type="sai_object_id_t", isresourcetype="true", objects="SAI_OBJECT_TYPE_DASH_ACL_GROUP"]; \
-            meta.dst_ip_addr : LIST_MATCH @SaiVal[name = "dip", type = "sai_ip_prefix_list_t"]; \
-            meta.src_ip_addr : LIST_MATCH @SaiVal[name = "sip", type = "sai_ip_prefix_list_t"]; \
-            meta.ip_protocol : LIST_MATCH @SaiVal[name = "protocol", type = "sai_u8_list_t"]; \
-            meta.src_l4_port : RANGE_LIST_MATCH @SaiVal[name = "src_port", type = "sai_u16_range_list_t"]; \
-            meta.dst_l4_port : RANGE_LIST_MATCH @SaiVal[name = "dst_port", type = "sai_u16_range_list_t"]; \
+            meta.dst_ip_addr : LIST_MATCH @SaiVal[name = "dip", type = "sai_ip_prefix_list_t", match_type = "list"]; \
+            meta.src_ip_addr : LIST_MATCH @SaiVal[name = "sip", type = "sai_ip_prefix_list_t", match_type = "list"]; \
+            meta.ip_protocol : LIST_MATCH @SaiVal[name = "protocol", type = "sai_u8_list_t", match_type = "list"]; \
+            meta.src_l4_port : RANGE_LIST_MATCH @SaiVal[name = "src_port", type = "sai_u16_range_list_t", match_type = "range_list"]; \
+            meta.dst_l4_port : RANGE_LIST_MATCH @SaiVal[name = "dst_port", type = "sai_u16_range_list_t", match_type = "range_list"]; \
         } \
         actions = { \
             permit; \

--- a/dash-pipeline/bmv2/dash_acl.p4
+++ b/dash-pipeline/bmv2/dash_acl.p4
@@ -38,11 +38,11 @@ match_kind {
         key = { \
             meta.stage ## stage_index ##_dash_acl_group_id : exact \
             @SaiVal[name = "dash_acl_group_id", type="sai_object_id_t", isresourcetype="true", objects="SAI_OBJECT_TYPE_DASH_ACL_GROUP"]; \
-            meta.dst_ip_addr : LIST_MATCH @SaiVal[name = "dip"]; \
-            meta.src_ip_addr : LIST_MATCH @SaiVal[name = "sip"]; \
-            meta.ip_protocol : LIST_MATCH @SaiVal[name = "protocol"]; \
-            meta.src_l4_port : RANGE_LIST_MATCH @SaiVal[name = "src_port"]; \
-            meta.dst_l4_port : RANGE_LIST_MATCH @SaiVal[name = "dst_port"]; \
+            meta.dst_ip_addr : LIST_MATCH @SaiVal[name = "dip", type = "sai_ip_prefix_list_t"]; \
+            meta.src_ip_addr : LIST_MATCH @SaiVal[name = "sip", type = "sai_ip_prefix_list_t"]; \
+            meta.ip_protocol : LIST_MATCH @SaiVal[name = "protocol", type = "sai_u8_list_t"]; \
+            meta.src_l4_port : RANGE_LIST_MATCH @SaiVal[name = "src_port", type = "sai_u16_range_list_t"]; \
+            meta.dst_l4_port : RANGE_LIST_MATCH @SaiVal[name = "dst_port", type = "sai_u16_range_list_t"]; \
         } \
         actions = { \
             permit; \
@@ -74,11 +74,11 @@ match_kind {
     table stage ##stage_index { \
         key = { \
             meta.stage ## stage_index ##_dash_acl_group_id : exact @SaiVal[name = "dash_acl_group_id"]; \
-            meta.dst_ip_addr : LIST_MATCH @SaiVal[name = "dip"]; \
-            meta.src_ip_addr : LIST_MATCH @SaiVal[name = "sip"]; \
-            meta.ip_protocol : LIST_MATCH @SaiVal[name = "protocol"]; \
-            meta.src_l4_port : RANGE_LIST_MATCH @SaiVal[name = "src_port"]; \
-            meta.dst_l4_port : RANGE_LIST_MATCH @SaiVal[name = "dst_port"]; \
+            meta.dst_ip_addr : LIST_MATCH @SaiVal[name = "dip", type = "sai_ip_prefix_list_t"]; \
+            meta.src_ip_addr : LIST_MATCH @SaiVal[name = "sip", type = "sai_ip_prefix_list_t"]; \
+            meta.ip_protocol : LIST_MATCH @SaiVal[name = "protocol", type = "sai_u8_list_t"]; \
+            meta.src_l4_port : RANGE_LIST_MATCH @SaiVal[name = "src_port", type = "sai_u16_range_list_t"]; \
+            meta.dst_l4_port : RANGE_LIST_MATCH @SaiVal[name = "dst_port", type = "sai_u16_range_list_t"]; \
         } \
         actions = { \
             permit; \

--- a/test/test-cases/functional/ptf/saidashacl.py
+++ b/test/test-cases/functional/ptf/saidashacl.py
@@ -31,30 +31,38 @@ class AclRuleTest(object):
         self.src_port = src_port
         self.dst_port = dst_port
         if self.dip:
-            dip = sai_thrift_ip_address_t(addr_family=SAI_IP_ADDR_FAMILY_IPV4,
-                                            addr=sai_thrift_ip_addr_t(ip4=self.dip))
+            dip_prefix = sai_thrift_ip_prefix_t(addr_family=SAI_IP_ADDR_FAMILY_IPV4, addr=sai_thrift_ip_addr_t(ip4=self.dip), mask=sai_thrift_ip_addr_t(ip4="255.255.255.0"))
+            dip_prefix_list = sai_thrift_ip_prefix_list_t(count=1, prefixlist=[dip_prefix])
+
         if self.sip:
-            sip = sai_thrift_ip_address_t(addr_family=SAI_IP_ADDR_FAMILY_IPV4,
-                                        addr=sai_thrift_ip_addr_t(ip4=self.sip))
+            sip_prefix = sai_thrift_ip_prefix_t(addr_family=SAI_IP_ADDR_FAMILY_IPV4, addr=sai_thrift_ip_addr_t(ip4=self.sip), mask=sai_thrift_ip_addr_t(ip4="255.255.255.0"))
+            sip_prefix_list = sai_thrift_ip_prefix_list_t(count=1, prefixlist=[sip_prefix])
+
         if self.acl_group is not None:
+            protocols = sai_thrift_u8_list_t(count=1, uint8list=[self.protocol])
+            src_ports = sai_thrift_u16_range_list_t(count=1, rangelist=[sai_thrift_u16_range_t(min=self.src_port, max=self.src_port)])
+            dst_ports = sai_thrift_u16_range_list_t(count=1, rangelist=[sai_thrift_u16_range_t(min=self.dst_port, max=self.dst_port)])
             self.saithrift.create_obj(sai_thrift_create_dash_acl_rule,
                                       sai_thrift_remove_dash_acl_rule,
                                       dash_acl_group_id=self.acl_group,
-                                      protocol=self.protocol,
-                                      sip=sip,
-                                      dip=dip,
-                                      src_port = self.src_port,
-                                      dst_port = self.dst_port,
+                                      protocol=protocols,
+                                      sip=sip_prefix_list,
+                                      dip=dip_prefix_list,
+                                      src_port=src_ports,
+                                      dst_port=dst_ports,
                                       priority=self.priority,
                                       action=self.action)
+
         if test_sip:
             self.test_sip = test_sip
         else:
             self.test_sip = self.sip
+
         if test_dip:
             self.test_dip = test_dip
         else:
             self.test_dip = self.dip
+
         self.meta = copy.copy(self.__dict__)
         del self.meta["saithrift"]
 


### PR DESCRIPTION
This PR changes 3 things:

1. Update the type annotation of ACL table match keys, so we can generate the right types for ACLs.
2. Add `match_type` annotation for match keys, so we can fix the `optional` match kind that we use to make P4 compiler happy.
3. Update SAI header generation script to handle the new annotation.

The end results is shown as below. The comment and type are now updated to the same as opencompute SAI:

![image](https://github.com/sonic-net/DASH/assets/1533278/eef6a6a7-c705-43a8-a602-c9c6a03f6123)
(no changes showing up in git diff)

To compare with previous generated content:

- Header files:
    
    ```bash
    r12f@r12f-dl380:~/data/code/sonic/DASH/dash-pipeline
    $ diff SAI/SAI/experimental/ ~/data/code/sonic/DASH-exp/dash-pipeline/SAI/SAI/experimental/
    diff SAI/SAI/experimental/saiexperimentaldashacl.h /home/r12f/data/code/sonic/DASH-exp/dash-pipeline/SAI/SAI/experimental/saiexperimentaldashacl.h
    114c114
    <      * @brief List matched key dip
    ---
    >      * @brief Optional matched key dip
    ...
    ```
    
    ![image](https://github.com/sonic-net/DASH/assets/1533278/a5bdc81d-1c15-4689-90c3-35325fa0cb83)

- libsai (creating adapter that converts list / range list to optional for bmv2):

    ![image](https://github.com/sonic-net/DASH/assets/1533278/19538646-59e8-431c-ba07-232a205039ee)