### PR TITLE
[sai-gen] Remove SAI object guessing logic based on number of match keys.

### DIFF
--- a/dash-pipeline/SAI/sai_api_gen.py
+++ b/dash-pipeline/SAI/sai_api_gen.py
@@ -563,13 +563,8 @@ class SAIAPITableData(SAIObject):
         self.__parse_table_actions(p4rt_table, all_actions)
 
         if self.is_object == None:
-            if len(self.keys) == 1 and self.keys[0].name.endswith(self.name.split('.')[-1] + '_id'):
-                self.is_object = 'true'
-            elif len(self.keys) > 5:
-                self.is_object = 'true'
-            else:
-                self.is_object = 'false'
-                self.name = self.name + '_entry'
+            self.is_object = 'false'
+            self.name = self.name + '_entry'
 
         return
 

--- a/dash-pipeline/SAI/sai_api_gen.py
+++ b/dash-pipeline/SAI/sai_api_gen.py
@@ -562,8 +562,7 @@ class SAIAPITableData(SAIObject):
         self.__parse_table_keys(p4rt_table)
         self.__parse_table_actions(p4rt_table, all_actions)
 
-        if self.is_object == None:
-            self.is_object = 'false'
+        if self.is_object == "false":
             self.name = self.name + '_entry'
 
         return
@@ -589,6 +588,9 @@ class SAIAPITableData(SAIObject):
                         self.api_type = kv['value']['stringValue']
                     if kv['key'] == 'api_order':
                         self.api_order = kv['value']['int64Value']
+
+        if self.is_object == None:
+            self.is_object = 'false'
 
         return
 

--- a/dash-pipeline/bmv2/dash_acl.p4
+++ b/dash-pipeline/bmv2/dash_acl.p4
@@ -33,7 +33,7 @@ match_kind {
 #ifdef TARGET_BMV2_V1MODEL
 #define ACL_STAGE(stage_index) \
     direct_counter(CounterType.packets_and_bytes) ## stage ## stage_index ##_counter; \
-    @SaiTable[name="dash_acl_rule", stage=str(acl.stage ## stage_index), api="dash_acl", api_order=1] \
+    @SaiTable[name="dash_acl_rule", stage=str(acl.stage ## stage_index), api="dash_acl", api_order=1, isobject="true"] \
     table stage ## stage_index { \
         key = { \
             meta.stage ## stage_index ##_dash_acl_group_id : exact \
@@ -70,7 +70,7 @@ match_kind {
 //        pna_direct_counter = stage ## stage_index ##_counter; \
 
 #define ACL_STAGE(stage_index) \
-    @SaiTable[name="dash_acl_rule", stage=str(acl.stage ## stage_index), api="dash_acl"] \
+    @SaiTable[name="dash_acl_rule", stage=str(acl.stage ## stage_index), api="dash_acl", isobject="true"] \
     table stage ##stage_index { \
         key = { \
             meta.stage ## stage_index ##_dash_acl_group_id : exact @SaiVal[name = "dash_acl_group_id"]; \

--- a/dash-pipeline/bmv2/dash_outbound.p4
+++ b/dash-pipeline/bmv2/dash_outbound.p4
@@ -206,7 +206,7 @@ control outbound(inout headers_t hdr,
         meta.encap_data.vni = vni;
     }
 
-    @SaiTable[name = "vnet", api = "dash_vnet"]
+    @SaiTable[name = "vnet", api = "dash_vnet", isobject="true"]
     table vnet {
         key = {
             meta.vnet_id : exact @SaiVal[type="sai_object_id_t"];

--- a/dash-pipeline/bmv2/dash_pipeline.p4
+++ b/dash-pipeline/bmv2/dash_pipeline.p4
@@ -153,7 +153,7 @@ control dash_ingress(
         }
     }
 
-    @SaiTable[name = "eni", api = "dash_eni", api_order=1]
+    @SaiTable[name = "eni", api = "dash_eni", api_order=1, isobject="true"]
     table eni {
         key = {
             meta.eni_id : exact @SaiVal[type="sai_object_id_t"];
@@ -339,7 +339,7 @@ control dash_ingress(
         }
     }
 
-    @SaiTable[name = "dash_acl_group", api = "dash_acl", api_order = 0]
+    @SaiTable[name = "dash_acl_group", api = "dash_acl", api_order = 0, isobject="true"]
     table acl_group {
         key = {
             meta.stage1_dash_acl_group_id : exact @SaiVal[name = "dash_acl_group_id"];


### PR DESCRIPTION
Moved this logic to use "isobject" annotation explicitly.

As all previous sai generator changes, no update on the generated contents:

![image](https://github.com/sonic-net/DASH/assets/1533278/863024a3-b5ca-442f-aad3-8272533d33a5)
