### PR TITLE
[sai-gen] Add P4 counter parsing support in SAI generation script and remove mock counter attributes in DASH pipeline

### DIFF
--- a/dash-pipeline/SAI/templates/saiapi.h.j2
+++ b/dash-pipeline/SAI/templates/saiapi.h.j2
@@ -155,43 +155,43 @@ typedef enum _sai_{{ table.name }}_attr_t
 {% endfor %}
 {% endif %}
 {% endif %}
-{% for param in table.action_params %}
-{% if param.skipattr == 'true' %}
+{% for sai_attr in table.sai_attributes %}
+{% if sai_attr.skipattr == 'true' %}
 {% else %}
     /**
-     * @brief Action {% for action in param.param_actions %}{{ action }}{{ ", " if not loop.last else "" }}{% endfor %} parameter {{ param.name | upper }}
+     * @brief Action {% for action in sai_attr.param_actions %}{{ action }}{{ ", " if not loop.last else "" }}{% endfor %} parameter {{ sai_attr.name | upper }}
      *
-     * @type {{ param.type }}
-{% if param.isreadonly == 'true' %}
+     * @type {{ sai_attr.type }}
+{% if sai_attr.isreadonly == 'true' %}
      * @flags READ_ONLY
 {% else %}
      * @flags CREATE_AND_SET
 {% endif %}
-{% if param.type == 'sai_uint16_t' %}
+{% if sai_attr.type == 'sai_uint16_t' %}
      * @isvlan false
 {% endif %}
-{% if param.type == 'sai_object_id_t' %}
-     * @objects SAI_OBJECT_TYPE_{{ param.object_name | upper }}
+{% if sai_attr.type == 'sai_object_id_t' %}
+     * @objects SAI_OBJECT_TYPE_{{ sai_attr.object_name | upper }}
      * @allownull true
 {% endif %}
-{% if param.isreadonly != 'true' %}
-     * @default {{ param.default }}
+{% if sai_attr.isreadonly != 'true' %}
+     * @default {{ sai_attr.default }}
 {% endif %}
 {% if table.actions | length > 1 %}
-{% if param.param_actions | length > 0 %}
-     * @validonly {% for action in param.param_actions %}SAI_{{ table.name | upper }}_ATTR_ACTION == SAI_{{ table.name | upper }}_ACTION_{{ action | upper }}{{ " or " if not loop.last else "" }}{% endfor %}
+{% if sai_attr.param_actions | length > 0 %}
+     * @validonly {% for action in sai_attr.param_actions %}SAI_{{ table.name | upper }}_ATTR_ACTION == SAI_{{ table.name | upper }}_ACTION_{{ action | upper }}{{ " or " if not loop.last else "" }}{% endfor %}
 
 {% endif %}
 {% endif %}
-{% if param.isresourcetype == 'true' %}
+{% if sai_attr.isresourcetype == 'true' %}
      * @isresourcetype true
 {% endif %}
      */
 {% if not ns.firstattr %}
-    SAI_{{ table.name | upper }}_ATTR_{{ param.name | upper }} = SAI_{{ table.name | upper }}_ATTR_START,
+    SAI_{{ table.name | upper }}_ATTR_{{ sai_attr.name | upper }} = SAI_{{ table.name | upper }}_ATTR_START,
 {% set ns.firstattr = true %}
 {% else %}
-    SAI_{{ table.name | upper }}_ATTR_{{ param.name | upper }},
+    SAI_{{ table.name | upper }}_ATTR_{{ sai_attr.name | upper }},
 {% endif %}
 
 {% endif %}

--- a/dash-pipeline/bmv2/README.md
+++ b/dash-pipeline/bmv2/README.md
@@ -18,11 +18,7 @@ The DASH pipeline BM is written in P4<sub>16</sub> with BMv2 v1model. For specs,
 
 ### P4 annotations for SAI code generation
 
-Currently, some of the SAI generation behavior is either controlled by using the `@name` attribute with a non-formalized format, or simplifying guessing in the `sai_api_gen.py`. This is hard to maintain and extend and highly not recommended.
-
-To deprecate the complicated `@name` attribute, we are moving towards using structured annotations in P4. This annotation can apply on keys, action parameters and tables to document and provide necessary metadata for SAI API generation.
-
-The old mode is still supported, but no more new features will be added to it and it will be deprecated in the future.
+To better control the SAI API generation, we use P4 annotations to provide any additional information that generator needs.
 
 #### `@SaiVal`: Keys and action parameters
 
@@ -36,6 +32,16 @@ Available tags are:
 - `objects`: Space separated list of SAI object type this value accepts. When set, we force this value to be a SAI object id, and generate a corresponding SAI tag in SAI APIs: `@objects <list>`.
 - `isreadonly`: When set to "true", we generate force this value to be read-only in SAI API using: `@flags READ_ONLY`, otherwise, we generate `@flags CREATE_AND_SET`.
 - `skipattr`: When set to "true", we skip this attribute in SAI API generation.
+
+#### `@SaiCounter`: Counters
+
+Use `@SaiCounter["tag"="value", ...]` format for annotating counters.
+
+Available tags are:
+
+- `name`: Specify the preferred counter name in SAI API generation, e.g. `outbound_bytes_counter`.
+- `action_names`: The counters are usually updated in actions whenever a table is matched. However, v1model doesn't support conditional statements (if-else) in action blocks. Hence, to workaround, sometimes counters should be updated in the actions are updated in the control blocks after the action is called. This tag is used to specify the name of the actions that was supposed to update this counter. e.g. `action1,action2,...`
+- `as_attr`: When set to "true", the counters will be generated as an attribute of the SAI object. This is not a normal behavior in SAI, since SAI usually either use get stats APIs or directly use counter IDs. Currently, generating get stats APIs is not supported yet, hence when this is not set, the attribute will be ignored.
 
 #### `@SaiTable`: Tables
 

--- a/dash-pipeline/bmv2/dash_pipeline.p4
+++ b/dash-pipeline/bmv2/dash_pipeline.p4
@@ -291,8 +291,7 @@ control dash_ingress(
     @SaiCounter[name="inbound_bytes_counter", action_names="meter_bucket_action", as_attr="true"]
     counter(MAX_METER_BUCKETS, CounterType.bytes) meter_bucket_inbound;
 #endif // TARGET_BMV2_V1MODEL
-    action meter_bucket_action(
-            @SaiVal[type="sai_uint32_t", skipattr="true"] bit<32> meter_bucket_index) {
+    action meter_bucket_action(@SaiVal[type="sai_uint32_t", skipattr="true"] bit<32> meter_bucket_index) {
         meta.meter_bucket_index = meter_bucket_index;
     }
 

--- a/dash-pipeline/bmv2/dash_pipeline.p4
+++ b/dash-pipeline/bmv2/dash_pipeline.p4
@@ -286,7 +286,9 @@ control dash_ingress(
     // MAX_METER_BUCKET = MAX_ENI(64) * NUM_BUCKETS_PER_ENI(4096)
     #define MAX_METER_BUCKETS 262144
 #ifdef TARGET_BMV2_V1MODEL
+    @SaiCounter[table_name="meter_bucket"]
     counter(MAX_METER_BUCKETS, CounterType.bytes) meter_bucket_inbound;
+    @SaiCounter[table_name="meter_bucket"]
     counter(MAX_METER_BUCKETS, CounterType.bytes) meter_bucket_outbound;
 #endif // TARGET_BMV2_V1MODEL
     action meter_bucket_action(

--- a/dash-pipeline/bmv2/dash_pipeline.p4
+++ b/dash-pipeline/bmv2/dash_pipeline.p4
@@ -286,9 +286,9 @@ control dash_ingress(
     // MAX_METER_BUCKET = MAX_ENI(64) * NUM_BUCKETS_PER_ENI(4096)
     #define MAX_METER_BUCKETS 262144
 #ifdef TARGET_BMV2_V1MODEL
-    @SaiCounter[name="outbound_bytes_counter", action_name="meter_bucket_action", as_attr="true"]
+    @SaiCounter[name="outbound_bytes_counter", action_names="meter_bucket_action", as_attr="true"]
     counter(MAX_METER_BUCKETS, CounterType.bytes) meter_bucket_outbound;
-    @SaiCounter[name="inbound_bytes_counter", action_name="meter_bucket_action", as_attr="true"]
+    @SaiCounter[name="inbound_bytes_counter", action_names="meter_bucket_action", as_attr="true"]
     counter(MAX_METER_BUCKETS, CounterType.bytes) meter_bucket_inbound;
 #endif // TARGET_BMV2_V1MODEL
     action meter_bucket_action(

--- a/dash-pipeline/bmv2/dash_pipeline.p4
+++ b/dash-pipeline/bmv2/dash_pipeline.p4
@@ -286,16 +286,13 @@ control dash_ingress(
     // MAX_METER_BUCKET = MAX_ENI(64) * NUM_BUCKETS_PER_ENI(4096)
     #define MAX_METER_BUCKETS 262144
 #ifdef TARGET_BMV2_V1MODEL
-    @SaiCounter[table_name="meter_bucket"]
-    counter(MAX_METER_BUCKETS, CounterType.bytes) meter_bucket_inbound;
-    @SaiCounter[table_name="meter_bucket"]
+    @SaiCounter[name="outbound_bytes_counter", action_name="meter_bucket_action", as_attr="true"]
     counter(MAX_METER_BUCKETS, CounterType.bytes) meter_bucket_outbound;
+    @SaiCounter[name="inbound_bytes_counter", action_name="meter_bucket_action", as_attr="true"]
+    counter(MAX_METER_BUCKETS, CounterType.bytes) meter_bucket_inbound;
 #endif // TARGET_BMV2_V1MODEL
     action meter_bucket_action(
-            @SaiVal[type="sai_uint64_t", isreadonly="true"] bit<64> outbound_bytes_counter,
-            @SaiVal[type="sai_uint64_t", isreadonly="true"] bit<64> inbound_bytes_counter,
             @SaiVal[type="sai_uint32_t", skipattr="true"] bit<32> meter_bucket_index) {
-        // read only counters for SAI api generation only
         meta.meter_bucket_index = meter_bucket_index;
     }
 


### PR DESCRIPTION
## Problem

Today, how DASH generates SAI API for counters is via mock action parameters.

One example is shown as below, where the counters are not updated by the meter_bucket_action, however we need to generate SAI APIs for fetching these counters. Hence, 2 action parameters that is marked as readonly are added for this purpose.

```c
    #define MAX_METER_BUCKETS 262144
#ifdef TARGET_BMV2_V1MODEL
    counter(MAX_METER_BUCKETS, CounterType.bytes) meter_bucket_inbound;
    counter(MAX_METER_BUCKETS, CounterType.bytes) meter_bucket_outbound;
#endif // TARGET_BMV2_V1MODEL
    action meter_bucket_action(
            @SaiVal[type="sai_uint64_t", isreadonly="true"] bit<64> outbound_bytes_counter,
            @SaiVal[type="sai_uint64_t", isreadonly="true"] bit<64> inbound_bytes_counter,
            @SaiVal[type="sai_uint32_t", skipattr="true"] bit<32> meter_bucket_index) {
        // read only counters for SAI api generation only
        meta.meter_bucket_index = meter_bucket_index;
    }
```

However, this creates 2 problems:

1. Obviously, these 2 parameters are never used and confusing in P4 code. However, they cannot be removed.
2. In libsai, we will generate code for setting these parameters, which is not needed and also should not do.

## Solution

This change adds counter parsing support in the SAI generation script, which,
1. Gains the knowledge of the actual counters.
2. Recreates the relationships between the counter and the actions.

Then we use this info to generate the correct SAI headers and libsai. Here is the P4 code after this change, the unused action parameters can be removed:

```c
    #define MAX_METER_BUCKETS 262144
#ifdef TARGET_BMV2_V1MODEL
    @SaiCounter[name="outbound_bytes_counter", action_names="meter_bucket_action", as_attr="true"]
    counter(MAX_METER_BUCKETS, CounterType.bytes) meter_bucket_outbound;
    @SaiCounter[name="inbound_bytes_counter", action_names="meter_bucket_action", as_attr="true"]
    counter(MAX_METER_BUCKETS, CounterType.bytes) meter_bucket_inbound;
#endif // TARGET_BMV2_V1MODEL
    action meter_bucket_action(
            @SaiVal[type="sai_uint32_t", skipattr="true"] bit<32> meter_bucket_index) {
        meta.meter_bucket_index = meter_bucket_index;
    }
```

As the diff shows below, we will be able maintain the SAI header unchanged, also removing the unwanted code in libsai:

```
$ diff SAI/lib/ ~/data/code/sonic/DASH-exp/dash-pipeline/SAI/lib/
diff SAI/lib/saidashmeter.cpp /home/r12f/data/code/sonic/DASH-exp/dash-pipeline/SAI/lib/saidashmeter.cpp
82c82
<     //expectedParams = 1;
---
>     //expectedParams = 3;
93a94,109
>             case SAI_METER_BUCKET_ATTR_OUTBOUND_BYTES_COUNTER:
>             {
>                 auto param = action->add_params();
>                 param->set_param_id(1);
>                 u64SetVal(attr_list[i].value, param, 64);
>                 //matchedParams++;
>                 break;
>             }
>             case SAI_METER_BUCKET_ATTR_INBOUND_BYTES_COUNTER:
>             {
>                 auto param = action->add_params();
>                 param->set_param_id(2);
>                 u64SetVal(attr_list[i].value, param, 64);
>                 //matchedParams++;
>                 break;
>             }
```

## Future works

As we will be adding more counters later, for features like [HA](https://github.com/sonic-net/SONiC/blob/master/doc/smart-switch/high-availability/smart-switch-ha-detailed-design.md). This will become particularly helpful, since we don't have to abuse the action parameters with unused code anymore.