### PR TITLE
[sai-gen] Fix missing empty lines when generating new SAI API type and object types

### DIFF
--- a/dash-pipeline/SAI/sai_api_gen.py
+++ b/dash-pipeline/SAI/sai_api_gen.py
@@ -880,14 +880,14 @@ class SAIGenerator:
         self.generated_header_file_names.append(sai_header_file_name)
 
         # Gather SAI API extension name and object types
-        self.generated_sai_api_extension_names.append('    SAI_API_' + sai_api.app_name.upper() + ',')
+        self.generated_sai_api_extension_names.append('    SAI_API_' + sai_api.app_name.upper() + ',\n')
 
         for table in sai_api.tables:
-            self.generated_sai_type_extension_names.append('    SAI_OBJECT_TYPE_' + table.name.upper() + ',')
+            self.generated_sai_type_extension_names.append('    SAI_OBJECT_TYPE_' + table.name.upper() + ',\n')
 
             if table.is_object == 'false':
                 self.generated_sai_object_entry_extension_names.append('    /** @validonly object_type == SAI_OBJECT_TYPE_' + table.name.upper() + ' */')
-                self.generated_sai_object_entry_extension_names.append('    sai_' + table.name + '_t ' + table.name + ';')
+                self.generated_sai_object_entry_extension_names.append('    sai_' + table.name + '_t ' + table.name + ';\n')
 
         return
 


### PR DESCRIPTION
The following highlighted empty lines are missing for new types:

![image](https://github.com/sonic-net/DASH/assets/1533278/98a0136d-2fff-40a0-8114-89a93da902a5)

Fix is straightforward, simply adding a line break in. The newly added line break will be ignored when checking the existing ones, which is already handled by existing code. Only the line break is missing.