### PR TITLE
[build] Switch BMv2 p4 compiler from p4c to p4c-bm2-ss.

### DIFF
--- a/dash-pipeline/Makefile
+++ b/dash-pipeline/Makefile
@@ -116,12 +116,12 @@ $(P4_OUTDIR)/dash_pipeline_p4rt.txt: $(P4_SRC)
 	$(DOCKER_FLAGS) \
 	-v $(PWD)/bmv2:/bmv2 \
 	-w / \
-	$(DOCKER_P4C_BMV2_IMG) p4c \
+	$(DOCKER_P4C_BMV2_IMG) p4c-bm2-ss \
 		-DTARGET_BMV2_V1MODEL \
 	    $(P4_MAIN) \
-		-b bmv2 \
-		-o $(P4_OUTDIR) \
-	    --p4runtime-files $(P4_OUTDIR)/dash_pipeline_p4rt.json,$(P4_OUTDIR)/dash_pipeline_p4rt.txt
+        -o $(P4_OUTDIR)/dash_pipeline.json \
+	    --p4runtime-files $(P4_OUTDIR)/dash_pipeline_p4rt.json,$(P4_OUTDIR)/dash_pipeline_p4rt.txt \
+        --toJSON $(P4_OUTDIR)/dash_pipeline_ir.json
 
 # DPDK - experimental/WIP
 


### PR DESCRIPTION
p4c-bm2-ss is a dedicated compiler built for building bmv2 code. Unlike p4c-ss and p4c-bm, this compiler is using the latest code, directly built from the p4c backend. 

Switching to this compiler will not change the generated content, but it will give us more access on more command line options instead of being limited to the small set of the parameters provided by p4c, e.g. dumping IRs, which may give us more information for generating SAI in a more smarter way.

Similarly, we are already doing it for DPDK - using p4c-dpdk instead of p4c -b dpdk.