### PR TITLE
[sai-gen] Move default value from template to SAI generation script.

### DIFF
--- a/dash-pipeline/SAI/sai_api_gen.py
+++ b/dash-pipeline/SAI/sai_api_gen.py
@@ -91,26 +91,26 @@ class SAITypeInfo:
 
 class SAITypeSolver:
     sai_type_info_registry: Dict[str, SAITypeInfo] = {
-        "bool": SAITypeInfo("bool", "booldata"),
-        "sai_uint8_t": SAITypeInfo("sai_uint8_t", "u8"),
-        "sai_object_id_t": SAITypeInfo("sai_object_id_t", "u16"),
-        "sai_uint16_t": SAITypeInfo("sai_uint16_t", "u16"),
-        "sai_ip_address_t": SAITypeInfo("sai_ip_address_t", "ipaddr"),
-        "sai_ip_addr_family_t": SAITypeInfo("sai_ip_addr_family_t", "u32"),
-        "sai_uint32_t": SAITypeInfo("sai_uint32_t", "u32"),
-        "sai_uint64_t": SAITypeInfo("sai_uint64_t", "u64"),
-        "sai_mac_t": SAITypeInfo("sai_mac_t", "mac"),
-        "sai_ip_prefix_t": SAITypeInfo("sai_ip_prefix_t", "ipPrefix"),
-        "sai_u8_list_t": SAITypeInfo("sai_u8_list_t", "u8list"),
-        "sai_u16_list_t": SAITypeInfo("sai_u16_list_t", "u16list"),
-        "sai_u32_list_t": SAITypeInfo("sai_u32_list_t", "u32list"),
-        "sai_ip_prefix_list_t": SAITypeInfo("sai_ip_prefix_list_t", "ipprefixlist"),
-        "sai_u32_range_t": SAITypeInfo("sai_u32_range_t", "u32range"),
-        "sai_u8_range_list_t": SAITypeInfo("sai_u8_range_list_t", "u8rangelist"),
-        "sai_u16_range_list_t": SAITypeInfo("sai_u16_range_list_t", "u16rangelist"),
-        "sai_u32_range_list_t": SAITypeInfo("sai_u32_range_list_t", "u32rangelist"),
-        "sai_u64_range_list_t": SAITypeInfo("sai_u64_range_list_t", "u64rangelist"),
-        "sai_ipaddr_range_list_t": SAITypeInfo("sai_ipaddr_range_list_t", "ipaddrrangelist"),
+        "bool": SAITypeInfo("bool", "booldata", default="false"),
+        "sai_uint8_t": SAITypeInfo("sai_uint8_t", "u8", default="0"),
+        "sai_object_id_t": SAITypeInfo("sai_object_id_t", "u16", default="SAI_NULL_OBJECT_ID"),
+        "sai_uint16_t": SAITypeInfo("sai_uint16_t", "u16", default="0"),
+        "sai_ip_address_t": SAITypeInfo("sai_ip_address_t", "ipaddr", default="0.0.0.0"),
+        "sai_ip_addr_family_t": SAITypeInfo("sai_ip_addr_family_t", "u32", default="SAI_IP_ADDR_FAMILY_IPV4"),
+        "sai_uint32_t": SAITypeInfo("sai_uint32_t", "u32", default="0"),
+        "sai_uint64_t": SAITypeInfo("sai_uint64_t", "u64", default="0"),
+        "sai_mac_t": SAITypeInfo("sai_mac_t", "mac", default="0:0:0:0:0:0"),
+        "sai_ip_prefix_t": SAITypeInfo("sai_ip_prefix_t", "ipPrefix", default="0"),
+        "sai_u8_list_t": SAITypeInfo("sai_u8_list_t", "u8list", default="empty"),
+        "sai_u16_list_t": SAITypeInfo("sai_u16_list_t", "u16list", default="empty"),
+        "sai_u32_list_t": SAITypeInfo("sai_u32_list_t", "u32list", default="empty"),
+        "sai_ip_prefix_list_t": SAITypeInfo("sai_ip_prefix_list_t", "ipprefixlist", default="empty"),
+        "sai_u32_range_t": SAITypeInfo("sai_u32_range_t", "u32range", default="empty"),
+        "sai_u8_range_list_t": SAITypeInfo("sai_u8_range_list_t", "u8rangelist", default="empty"),
+        "sai_u16_range_list_t": SAITypeInfo("sai_u16_range_list_t", "u16rangelist", default="empty"),
+        "sai_u32_range_list_t": SAITypeInfo("sai_u32_range_list_t", "u32rangelist", default="empty"),
+        "sai_u64_range_list_t": SAITypeInfo("sai_u64_range_list_t", "u64rangelist", default="empty"),
+        "sai_ipaddr_range_list_t": SAITypeInfo("sai_ipaddr_range_list_t", "ipaddrrangelist", default="empty"),
     }
 
     @staticmethod
@@ -417,7 +417,7 @@ class SAIAPITableKey(SAIObject):
             self.type = sai_type_info.name
 
         self.field = sai_type_info.field_func_prefix
-        if self.default == None and sai_type_info.is_enum:
+        if self.default == None:
             self.default = sai_type_info.default
 
         return
@@ -495,7 +495,7 @@ class SAIAPITableActionParam(SAIObject):
             self.type = sai_type_info.name
 
         self.field = sai_type_info.field_func_prefix
-        if self.default == None and sai_type_info.is_enum:
+        if self.default == None:
             self.default = sai_type_info.default
 
         return

--- a/dash-pipeline/SAI/templates/saiapi.h.j2
+++ b/dash-pipeline/SAI/templates/saiapi.h.j2
@@ -170,26 +170,12 @@ typedef enum _sai_{{ table.name }}_attr_t
 {% if param.type == 'sai_uint16_t' %}
      * @isvlan false
 {% endif %}
-{% if param.type == 'sai_ip_address_t' %}
-     * @default 0.0.0.0
-{% elif param.type == 'sai_ip_addr_family_t' %}
-     * @default SAI_IP_ADDR_FAMILY_IPV4
-{% elif param.type == 'sai_mac_t' %}
-     * @default 0:0:0:0:0:0
-{% elif param.type == 'bool' %}
-     * @default false
-{% elif param.type == 'sai_object_id_t' %}
+{% if param.type == 'sai_object_id_t' %}
      * @objects SAI_OBJECT_TYPE_{{ param.object_name | upper }}
      * @allownull true
-     * @default SAI_NULL_OBJECT_ID
-{% elif param.field == 's32' %}
-     * @default {{ param.default }}
-{% elif param.type == 'sai_ip_prefix_list_t' %}
-     * @default empty
-{% else %}
-{% if param.isreadonly != 'true' %}
-     * @default 0
 {% endif %}
+{% if param.isreadonly != 'true' %}
+     * @default {{ param.default }}
 {% endif %}
 {% if table.actions | length > 1 %}
 {% if param.param_actions | length > 0 %}


### PR DESCRIPTION
Currently, the default value of each SAI attribute is specified in saiapi.h.j2 template, using if-else. This can be simplified by directly using the default value from the type info in SAI generation script.

This change also makes adding more SAI types easier in the future, for both existing types or new types (just like new enums today, we only need to register it to type registry, then everything else will be taken care of).