### PR TITLE
[sai-gen] Add order annotation for attributes to support ordering SAI attributes for ABI compatibility

### DIFF
--- a/dash-pipeline/bmv2/README.md
+++ b/dash-pipeline/bmv2/README.md
@@ -30,6 +30,7 @@ Available tags are:
 - `default_value`: Override the default value for this key or action parameter.
 - `isresourcetype`: When set to "true", we generate a corresponding SAI tag in SAI APIs: `@isresourcetype true`.
 - `objects`: Space separated list of SAI object type this value accepts. When set, we force this value to be a SAI object id, and generate a corresponding SAI tag in SAI APIs: `@objects <list>`.
+- `order`: Specify the order of the generated attributes in the SAI API header file. This will be particularly useful, when a table has multiple actions, and we add parameters to one of them. The new attributes might be generated in the middle of existing attributes, which breaks ABI compatibility with older version of SAI APIs.
 - `isreadonly`: When set to "true", we generate force this value to be read-only in SAI API using: `@flags READ_ONLY`, otherwise, we generate `@flags CREATE_AND_SET`.
 - `skipattr`: When set to "true", we skip this attribute in SAI API generation.
 
@@ -42,6 +43,7 @@ Available tags are:
 - `name`: Specify the preferred counter name in SAI API generation, e.g. `outbound_bytes_counter`.
 - `action_names`: The counters are usually updated in actions whenever a table is matched. However, v1model doesn't support conditional statements (if-else) in action blocks. Hence, to workaround, sometimes counters should be updated in the actions are updated in the control blocks after the action is called. This tag is used to specify the name of the actions that was supposed to update this counter. e.g. `action1,action2,...`
 - `as_attr`: When set to "true", the counters will be generated as an attribute of the SAI object. This is not a normal behavior in SAI, since SAI usually either use get stats APIs or directly use counter IDs. Currently, generating get stats APIs is not supported yet, hence when this is not set, the attribute will be ignored.
+- `order`: Specify the order of the generated attributes in the SAI API header file. This will be particularly useful, when a table has multiple actions, and we add parameters to one of them. The new attributes might be generated in the middle of existing attributes, which breaks ABI compatibility with older version of SAI APIs. When `as_attr` is set, it will be compared with the order of other attributes from match keys and action parameters in the same object too.
 
 #### `@SaiTable`: Tables
 
@@ -52,7 +54,7 @@ Available tags are:
 - `name`: Specify the preferred table name in SAI API generation, e.g. `dash_acl_rule`.
 - `api`: Specify which SAI API should be used in generation, e.g. `dash_acl`.
 - `api_type`: The type of the API. DASH contains certain tables for handling underlay actions, such as route table. We should not generate header files for these tables but only the lib files without experimental prefix. To enable this behavior, please set the API type to `underlay`.
-- `api_order`: Specify the order of the generated API in the SAI API header file. When multiple tables generates API entries in the same API set, e.g., acl group and acl rules. This explicit attribute helps us keep the order of the generated APIs to keep ABI compatibility.
+- `order`: Specify the order of the generated API in the SAI API header file. When multiple tables generates API entries in the same API set, e.g., acl group and acl rules. This explicit attribute helps us keep the order of the generated APIs to keep ABI compatibility.
 - `stage`: Specify which stage this table represents for the matching stage type, e.g. `acl.stage1`.
 - `isobject`: When set to "true", a top level objects in SAI that attached to switch will be generated. Otherwise, a new type of entry will be generated, if nothing else helps us to determine this table is an object table.
 - `ignored`: When set to "true", we skip this table in SAI API generation.

--- a/dash-pipeline/bmv2/dash_acl.p4
+++ b/dash-pipeline/bmv2/dash_acl.p4
@@ -33,7 +33,7 @@ match_kind {
 #ifdef TARGET_BMV2_V1MODEL
 #define ACL_STAGE(stage_index) \
     direct_counter(CounterType.packets_and_bytes) ## stage ## stage_index ##_counter; \
-    @SaiTable[name="dash_acl_rule", stage=str(acl.stage ## stage_index), api="dash_acl", api_order=1, isobject="true"] \
+    @SaiTable[name="dash_acl_rule", stage=str(acl.stage ## stage_index), api="dash_acl", order=1, isobject="true"] \
     table stage ## stage_index { \
         key = { \
             meta.stage ## stage_index ##_dash_acl_group_id : exact \

--- a/dash-pipeline/bmv2/dash_pipeline.p4
+++ b/dash-pipeline/bmv2/dash_pipeline.p4
@@ -153,7 +153,7 @@ control dash_ingress(
         }
     }
 
-    @SaiTable[name = "eni", api = "dash_eni", api_order=1, isobject="true"]
+    @SaiTable[name = "eni", api = "dash_eni", order=1, isobject="true"]
     table eni {
         key = {
             meta.eni_id : exact @SaiVal[type="sai_object_id_t"];
@@ -255,7 +255,7 @@ control dash_ingress(
         }
     }
 
-    @SaiTable[name = "meter_policy", api = "dash_meter", api_order = 1, isobject="true"]
+    @SaiTable[name = "meter_policy", api = "dash_meter", order = 1, isobject="true"]
     table meter_policy {
         key = {
             meta.meter_policy_id : exact;
@@ -269,7 +269,7 @@ control dash_ingress(
         meta.policy_meter_class = meter_class;
     }
 
-    @SaiTable[name = "meter_rule", api = "dash_meter", api_order = 2, isobject="true"]
+    @SaiTable[name = "meter_rule", api = "dash_meter", order = 2, isobject="true"]
     table meter_rule {
         key = {
             meta.meter_policy_id: exact @SaiVal[type="sai_object_id_t", isresourcetype="true", objects="METER_POLICY"];
@@ -295,7 +295,7 @@ control dash_ingress(
         meta.meter_bucket_index = meter_bucket_index;
     }
 
-    @SaiTable[name = "meter_bucket", api = "dash_meter", api_order = 0, isobject="true"]
+    @SaiTable[name = "meter_bucket", api = "dash_meter", order = 0, isobject="true"]
     table meter_bucket {
         key = {
             meta.eni_id: exact @SaiVal[type="sai_object_id_t"];
@@ -312,7 +312,7 @@ control dash_ingress(
         meta.eni_id = eni_id;
     }
 
-    @SaiTable[name = "eni_ether_address_map", api = "dash_eni", api_order=0]
+    @SaiTable[name = "eni_ether_address_map", api = "dash_eni", order=0]
     table eni_ether_address_map {
         key = {
             meta.eni_addr : exact @SaiVal[name = "address", type = "sai_mac_t"];
@@ -337,7 +337,7 @@ control dash_ingress(
         }
     }
 
-    @SaiTable[name = "dash_acl_group", api = "dash_acl", api_order = 0, isobject="true"]
+    @SaiTable[name = "dash_acl_group", api = "dash_acl", order = 0, isobject="true"]
     table acl_group {
         key = {
             meta.stage1_dash_acl_group_id : exact @SaiVal[name = "dash_acl_group_id"];


### PR DESCRIPTION
## Problem 

Currently, DASH SAI attributes are generated based on the order of table keys and action parameters. When multiple types of objects are mixed together, adding a new attributes could cause new SAI attributes being inserted in the middle of the attribute list and breaks the ABI compatibility.

## What are we doing in this change

This change introduces 2 things:

- adds `order` attribute in `@SaiVal` annotation, so we could sort the attributes in the way that keeps the ABI compatibility.
- renames `api_order` to `order` in `@SaiTable` annotation, to keep the naming the same way.

The current change will not change the generated content today, as screenshot shows below:
![image](https://github.com/sonic-net/DASH/assets/1533278/5c153fef-cf03-47c8-a28c-83e6d2ef5c7c)
