### PR TITLE
[sai-gen] Make SAI generator understand P4 IR to fetch counter references / callers.

### DIFF
--- a/dash-pipeline/SAI/Makefile
+++ b/dash-pipeline/SAI/Makefile
@@ -2,6 +2,7 @@
 all: copysrc
 	./sai_api_gen.py \
 		/bmv2/dash_pipeline.bmv2/dash_pipeline_p4rt.json \
+		--ir /bmv2/dash_pipeline.bmv2/dash_pipeline_ir.json \
 		--ignore-tables=appliance,eni_meter,slb_decap \
 		dash
 

--- a/dash-pipeline/dockerfiles/Dockerfile.saithrift-bldr
+++ b/dash-pipeline/dockerfiles/Dockerfile.saithrift-bldr
@@ -27,7 +27,7 @@ ENV DASH_SAIGEN_DEPS python3 python3-pip
 
 RUN apt-get update -q && \
     apt-get install -y --no-install-recommends $SAI_PTF_DEPS $DASH_SAIGEN_DEPS && \
-    pip3 install ctypesgen jinja2
+    pip3 install ctypesgen jinja2 jsonpath-ng
 
 ENV SAI_THRIFT_DEPS automake bison flex g++ git libboost-all-dev libevent-dev libssl-dev libtool make pkg-config
 


### PR DESCRIPTION
## Problem

Currently, the SAI attributes will be generated from table keys, action parameters and counters. Table keys and action parameters are naturally connected to the tables directly or indirectly in the P4 runtime json. However, counters are not, so we don't have enough information to find which SAI API we should add the attribute.

To solve this, we have already added an annotation in SaiCounter, to specify the action names, so we can correlate the counters and its tables. However, this is tedious to do, if we have a lot of counters to add.

## What are we doing in this change

This change parses the P4 IR json file to find which action this counter has been called to, so we can associate the counters and its action and tables automatically. 

Take an example, say we add a new counter in the metering action to calculate total bytes:

![image](https://github.com/sonic-net/DASH/assets/1533278/30762751-c5ce-4550-8151-d0d87c73da75)

And without specifying the action names, like the other counters, the SAI attribute will be generated in the right place, because we now understand the program.

![image](https://github.com/sonic-net/DASH/assets/1533278/dc29db67-5bcb-4dec-9142-aaa1fbbc8a40)

We choose the P4 IR as the input instead of the bmv2 json, because this approach is backend independent, and can apply to other backends too, such as dpdk, p4tc and etc, just like the p4 runtime json. So, if we decide to change our BM from BMv2 to other implementation, this program will still work.

This change will help us add more counter for future scenarios, such as HA.