### PR TITLE
Fix set_private_link_mapping

### DIFF
--- a/dash-pipeline/bmv2/dash_outbound.p4
+++ b/dash-pipeline/bmv2/dash_outbound.p4
@@ -158,7 +158,7 @@ control outbound(inout headers_t hdr,
         service_tunnel_encode(hdr,
                               overlay_dip,
                               0xffffffffffffffffffffffff,
-                              (overlay_sip & ~meta.eni_data.pl_sip_mask) | meta.eni_data.pl_sip | (IPv6Address)hdr.ipv4.dst_addr,
+                              (overlay_sip & ~meta.eni_data.pl_sip_mask) | meta.eni_data.pl_sip | (IPv6Address)hdr.ipv4.src_addr,
                               0xffffffffffffffffffffffff);
 
         set_tunnel(underlay_dip,


### PR DESCRIPTION
Replace dst_addr with src_addr as a sip parameter.