### PR TITLE
[sai-gen] Add support to packets and packet_and_bytes counters, also make counter generation to be adaptive to its type.

### DIFF
--- a/dash-pipeline/bmv2/dash_pipeline.p4
+++ b/dash-pipeline/bmv2/dash_pipeline.p4
@@ -286,9 +286,9 @@ control dash_ingress(
     // MAX_METER_BUCKET = MAX_ENI(64) * NUM_BUCKETS_PER_ENI(4096)
     #define MAX_METER_BUCKETS 262144
 #ifdef TARGET_BMV2_V1MODEL
-    @SaiCounter[name="outbound_bytes_counter", action_names="meter_bucket_action", as_attr="true"]
+    @SaiCounter[name="outbound", action_names="meter_bucket_action", as_attr="true"]
     counter(MAX_METER_BUCKETS, CounterType.bytes) meter_bucket_outbound;
-    @SaiCounter[name="inbound_bytes_counter", action_names="meter_bucket_action", as_attr="true"]
+    @SaiCounter[name="inbound", action_names="meter_bucket_action", as_attr="true"]
     counter(MAX_METER_BUCKETS, CounterType.bytes) meter_bucket_inbound;
 #endif // TARGET_BMV2_V1MODEL
     action meter_bucket_action(@SaiVal[type="sai_uint32_t", skipattr="true"] bit<32> meter_bucket_index) {


### PR DESCRIPTION
## Problem

Currently, SAI API generation is not leveraging the counter type information, but blindly use whatever specified in the `name` annotation. This leads to 2 problems:

1. We could accidentally generate incorrect SAI headers, e.g. name says it is a byte counter, but in fact it is a packet counter in our BM. 
2. We could not support counters that tracks multiple things, i.e. packets and bytes.

## What we are doing in this change

This change uses the type info in the counter to generate the correct SAI attributes, also fork the counter when the single counter in BM tracks multiple things.

As the screenshot shows below, after the change, if we change the counter type of the meter_bucket_outbound, a new SAI attribute will be created for it.

![image](https://github.com/sonic-net/DASH/assets/1533278/2e635c5d-76e8-4b57-8c4b-7866a4e40b45)

This change will not change any of existing SAI header files that we generated, but can be used for future scenarios.