### PR TITLE
[docker] Change to using Docker Compose v2

### DIFF
--- a/dash-pipeline/Makefile
+++ b/dash-pipeline/Makefile
@@ -760,10 +760,3 @@ run-saichallenger-tutorials: deploy-ixiac
 	$(DOCKER_SAI_CHALLENGER_CLIENT_IMG) \
 	./run-tests.sh --setup=$(SAI_CHALLENGER_SETUP_FILE) tutorial
 
-###############################
-# ENVIRONMENT SETUP TARGETS
-###############################
-
-install-docker-compose:
-	sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$$(uname -s)-$$(uname -m)" -o /usr/local/bin/docker-compose
-	sudo chmod +x /usr/local/bin/docker-compose

--- a/dash-pipeline/README-dash-as-submodule.md
+++ b/dash-pipeline/README-dash-as-submodule.md
@@ -138,7 +138,7 @@ The community DASH bmv2 test workflow includes SW traffic-generators connected t
 
 If test ports other than `veth0/1` and `veth2/3` are used, some modifications of setup scripts may be required:
 * PTF tests using scapy for SW traffic generation can be parameterized to specify logical-to-physical port mappings.
-* Pytests using ixia-c SW traffic generator are set up using docker-compose topology files under [DASH/test/third-party/traffic_gen/deployment](https://github.com/sonic-net/DASH/tree/main/test/third-party/traffic_gen/deployment)
+* Pytests using ixia-c SW traffic generator are set up using `docker compose` topology files under [DASH/test/third-party/traffic_gen/deployment](https://github.com/sonic-net/DASH/tree/main/test/third-party/traffic_gen/deployment)
 
 ## Custom Tests
 You can use the tests under DASH by calling the appropriate DASH make targets from the parent project. You can also have private tests in your own project repository which you invoke from your Makefiles. We recommend if you write new tests which are generally applicable that you consider upstreaming to the Community repository.

--- a/dash-pipeline/README-dash-workflows.md
+++ b/dash-pipeline/README-dash-workflows.md
@@ -386,7 +386,7 @@ make undeploy-ixiac  # Stop the containers
 #### DASH-specific info
 * [../test/test-cases/bmv2_model](../test/test-cases/bmv2_model) for ixia-c test cases
 * [../test/third-party/traffic_gen/README.md](../test/third-party/traffic_gen/README.md) for ixia-c configuration info
-* [../test/third-party/traffic_gen/deployment/README.md](../test/third-party/traffic_gen/deployment/README.md) for docker-compose configuration and diagram
+* [../test/third-party/traffic_gen/deployment/README.md](../test/third-party/traffic_gen/deployment/README.md) for `docker compose` configuration and diagram
 
 ## About Git Submodules
 See also:

--- a/dash-pipeline/README.md
+++ b/dash-pipeline/README.md
@@ -30,7 +30,7 @@ This is a P4 model of the DASH overlay pipeline which uses the [bmv2](https://gi
   - [Install docker](#install-docker)
   - [Install Python 3](#install-python-3)
   - [Install pip3](#install-pip3)
-  - [Install docker-compose](#install-docker-compose)
+  - [Install docker compose](#install-docker-compose)
 
 # Known Issues
 * P4 code doesn't loop packets back to same port.
@@ -62,7 +62,7 @@ See [Installing Prerequisites](#installing-prerequisites) for details.
 * 2 CPU cores minimum, 7GB RAM, 14Gb HD; same as [free Azure 2-core GitHub runner instances](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources), we'll try to live within these limits
 * git - tested with version 2.25.1
 * docker
-* [docker-compose](#install-docker-compose) (**1.29.2 or later**)
+* [docker compose](#install-docker-compose) (**v2 required**)
 
 ## Clone this repo
 ```
@@ -136,27 +136,27 @@ Need for basically everything to build/test dash-pipeline.
 See:
 * https://docs.docker.com/desktop/linux/install/
 
-## Install docker-compose
->**NOTE** Use docker-compose 1.29.2 or later! The `.yml` file format changed. Using an older version might result in an error such as: <br/> `ERROR: Invalid interpolation format for "controller" option in service "services": "ixiacom/ixia-c-controller:${CONTROLLER_VERSION:-latest}"`
+## Install docker compose
+>**NOTE** Use docker compose version 2 or later!
 
 It is assumed you already have Docker on your system.
-The `docker-compose` command is used to orchestrate the ixia-c containers. You need to install it to run the ixia-c test scripts (`ixia-c` itself doesn't require docker-compose; it's merely convenient for instantiating it using a declarative `.yml` file).
+The `docker compose` command is used to orchestrate the ixia-c containers. You need to install it to run the ixia-c test scripts (`ixia-c` itself doesn't require `docker compose`; it's merely convenient for instantiating it using a declarative `.yml` file).
 
 See also:
-* https://www.cyberithub.com/how-to-install-docker-compose-on-ubuntu-20-04-lts-step-by-step/
+* https://docs.docker.com/compose/install/linux/
   
 
-Installation of `docker-compose` has to be done just once. You can use another technique based on your platform and preferences. The following will download and install a linux executable under `/usr/local/bin`. You should have a PATH to this directory. **You can edit the commands below to locate it somewhere else as desired; just change the path as needed.**
+Installation of `docker compose` has to be done just once. You can use another technique based on your platform and preferences. The following will download and install the `compose` CLI plugin for Docker.
 
 
 ```
-sudo mkdir -p /usr/local/bin
-sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-sudo chmod +x /usr/local/bin/docker-compose
+DOCKER_CONFIG=${DOCKER_CONFIG:-$HOME/.docker}
+mkdir -p $DOCKER_CONFIG/cli-plugins
+curl -SL https://github.com/docker/compose/releases/download/v2.24.5/docker-compose-linux-x86_64 -o $DOCKER_CONFIG/cli-plugins/docker-compose
 ```
 
 To test installation, execute the following. The output on the second line is an example, yours may differ.
 ```
-docker-compose --version
-docker-compose version 1.29.2, build 5becea4c
+docker compose version
+Docker Compose version 2.24.5
 ```

--- a/test/third-party/traffic_gen/deploy_ixiac.sh
+++ b/test/third-party/traffic_gen/deploy_ixiac.sh
@@ -1,4 +1,4 @@
 dir_path="$( dirname ${BASH_SOURCE[0]:-$0})"
 echo $dir_path
 cd $dir_path
-docker-compose -f deployment/ixia-c-deployment.yml up -d 
+docker compose -f deployment/ixia-c-deployment.yml up -d

--- a/test/third-party/traffic_gen/deployment/README.md
+++ b/test/third-party/traffic_gen/deployment/README.md
@@ -3,7 +3,7 @@
 ![ixia-c.drawio.svg](ixia-c.drawio.svg)
 
 
-Deployment is done using `docker-compose` and configuration file [ixia-c-deployment.yml](ixia-c-deployment.yml) and by setting up veth pairs (assumed already in-place by the test environment before docker-compose is called).
+Deployment is done using `docker compose` and configuration file [ixia-c-deployment.yml](ixia-c-deployment.yml) and by setting up veth pairs (assumed already in-place by the test environment before `docker compose` is called).
 
 Future considerations
  - [Containerlab](https://containerlab.dev/), a CLI for orchestrating and managing container-based networking labs.

--- a/test/third-party/traffic_gen/undeploy_ixiac.sh
+++ b/test/third-party/traffic_gen/undeploy_ixiac.sh
@@ -1,4 +1,4 @@
 dir_path="$( dirname ${BASH_SOURCE[0]:-$0})"
 echo $dir_path
 cd $dir_path
-docker-compose -f deployment/ixia-c-deployment.yml down 
+docker compose -f deployment/ixia-c-deployment.yml down


### PR DESCRIPTION
Fixes #510 

As a secondary effect this also enables the use of Podman, as it emulates `docker compose` but not `docker-compose`.