### PR TITLE
[dash-p4] Fix incorrect service tunnel key assignment.

### DIFF
--- a/dash-pipeline/bmv2/dash_metadata.p4
+++ b/dash-pipeline/bmv2/dash_metadata.p4
@@ -12,7 +12,6 @@ struct encap_data_t {
     EthernetAddress underlay_dmac;
     EthernetAddress overlay_dmac;
     dash_encapsulation_t dash_encapsulation;
-    bit<24> service_tunnel_key;
     IPv4Address original_overlay_sip;
     IPv4Address original_overlay_dip;
 }

--- a/dash-pipeline/bmv2/dash_outbound.p4
+++ b/dash-pipeline/bmv2/dash_outbound.p4
@@ -83,7 +83,7 @@ control outbound(inout headers_t hdr,
 #endif
         meta.encap_data.overlay_dmac = hdr.u0_ethernet.dst_addr;
         meta.encap_data.dash_encapsulation = dash_encapsulation;
-        meta.encap_data.service_tunnel_key = tunnel_key;
+        meta.encap_data.vni = tunnel_key;
         set_route_meter_attrs(meter_policy_en, meter_class);
     }
 


### PR DESCRIPTION
The service tunnel key is a dead code and never used in building the encapsulation.

Assign the tunnel key to VNI will fix this issue.