### PR TITLE
[dash-p4] Remove original overlay IP from encap data and reuse the existing fields.

### DIFF
--- a/dash-pipeline/bmv2/dash_inbound.p4
+++ b/dash-pipeline/bmv2/dash_inbound.p4
@@ -4,6 +4,7 @@
 #include "dash_headers.p4"
 #include "dash_service_tunnel.p4"
 #include "dash_acl.p4"
+#include "routing_actions/routing_actions.p4"
 #include "dash_conntrack.p4"
 
 control inbound(inout headers_t hdr,
@@ -11,15 +12,13 @@ control inbound(inout headers_t hdr,
 {
     apply {
 #ifdef STATEFUL_P4
-            ConntrackIn.apply(0);
+        ConntrackIn.apply(0);
 #endif /* STATEFUL_P4 */
 #ifdef PNA_CONNTRACK
         ConntrackIn.apply(hdr, meta);
 
-        if (meta.encap_data.original_overlay_sip != 0) {
-            service_tunnel_decode(hdr,
-                                  meta.encap_data.original_overlay_sip,
-                                  meta.encap_data.original_overlay_dip);
+        if ((IPv4Address)meta.overlay_data.sip != 0) {
+            do_action_nat64.apply(hdr, meta);
         }
 #endif // PNA_CONNTRACK
 

--- a/dash-pipeline/bmv2/dash_metadata.p4
+++ b/dash-pipeline/bmv2/dash_metadata.p4
@@ -63,8 +63,6 @@ struct encap_data_t {
     EthernetAddress underlay_smac;
     EthernetAddress underlay_dmac;
     dash_encapsulation_t dash_encapsulation;
-    IPv4Address original_overlay_sip;
-    IPv4Address original_overlay_dip;
 }
 
 struct overlay_rewrite_data_t {

--- a/dash-pipeline/bmv2/dash_routing_types.p4
+++ b/dash-pipeline/bmv2/dash_routing_types.p4
@@ -107,9 +107,6 @@ action route_service_tunnel(
 
     meta.target_stage = dash_pipeline_stage_t.ROUTING_ACTION_APPLY;
 
-    meta.encap_data.original_overlay_dip = hdr.u0_ipv4.src_addr;
-    meta.encap_data.original_overlay_sip = hdr.u0_ipv4.dst_addr;
-
     push_action_nat46(hdr = hdr,
                     meta = meta,
                     sip = overlay_sip,
@@ -124,8 +121,8 @@ action route_service_tunnel(
                             meta = meta,
                             encap = dash_encapsulation,
                             vni = tunnel_key,
-                            underlay_sip = underlay_sip == 0 ? meta.encap_data.original_overlay_sip : (IPv4Address)underlay_sip,
-                            underlay_dip = underlay_dip == 0 ? meta.encap_data.original_overlay_dip : (IPv4Address)underlay_dip,
+                            underlay_sip = underlay_sip == 0 ? hdr.u0_ipv4.src_addr : (IPv4Address)underlay_sip,
+                            underlay_dip = underlay_dip == 0 ? hdr.u0_ipv4.dst_addr : (IPv4Address)underlay_dip,
                             overlay_dmac = hdr.u0_ethernet.dst_addr);
 
 #endif


### PR DESCRIPTION
The original overlay dip/sip looks to be redundant and can directly reuse the overlay data we already have in the metadata, hence doing this change.