### PR TITLE
[sai-gen] Add support of generating hit count counters

### DIFF
--- a/dash-pipeline/SAI/sai_api_gen.py
+++ b/dash-pipeline/SAI/sai_api_gen.py
@@ -516,6 +516,7 @@ class SAICounter(SAIAPITableAttribute):
         self.isreadonly: str = "true"
         self.counter_type: str = "bytes"
         self.attr_type: str = "stats"
+        self.no_suffix: bool = ""
         self.param_actions: List[str] = []
 
     def parse_p4rt(self, p4rt_counter: Dict[str, Any], var_ref_graph: P4VarRefGraph) -> None:
@@ -597,6 +598,8 @@ class SAICounter(SAIAPITableAttribute):
                         self.attr_type = str(kv['value']['stringValue'])
                         if self.attr_type not in ["counter_attr", "counter_id", "stats"]:
                             raise ValueError(f'Unknown counter attribute type: attr_type={self.attr_type}')
+                    elif kv['key'] == 'no_suffix':
+                        self.no_suffix = str(kv['value']['stringValue']) == "true"
                     else:
                         raise ValueError("Unknown attr annotation " + kv['key'])
 
@@ -613,10 +616,11 @@ class SAICounter(SAIAPITableAttribute):
                 counter = copy.deepcopy(self)
             
             counter.counter_type = counter_type
+
             if counter.attr_type == "counter_attr":
-                counter.name = f"{counter.name}_{counter.counter_type}_counter"
+                counter.name = f"{counter.name}_{counter.counter_type}_counter" if not self.no_suffix else f"{counter.name}_counter"
             else:
-                counter.name = f"{counter.name}_{counter.counter_type}"
+                counter.name = f"{counter.name}_{counter.counter_type}" if not self.no_suffix else counter.name
 
             yield counter
 

--- a/dash-pipeline/bmv2/dash_arch_specific.p4
+++ b/dash-pipeline/bmv2/dash_arch_specific.p4
@@ -44,6 +44,7 @@
     #define DEFINE_COUNTER(name, count, ...)
     #define DEFINE_PACKET_COUNTER(name, count, ...)
     #define DEFINE_BYTE_COUNTER(name, count, ...)
+    #define DEFINE_HIT_COUNTER(name, count, ...)
     #define UPDATE_COUNTER(name, index)
 
     #ifdef DPDK_SUPPORTS_DIRECT_COUNTER_ON_WILDCARD_KEY_TABLE

--- a/dash-pipeline/bmv2/dash_arch_specific.p4
+++ b/dash-pipeline/bmv2/dash_arch_specific.p4
@@ -28,6 +28,10 @@
         @SaiCounter[__VA_ARGS__] \
         counter(count, CounterType.bytes) name;
 
+    #define DEFINE_HIT_COUNTER(name, count, ...) \
+        @SaiCounter[__VA_ARGS__, no_suffix="true"] \
+        counter(count, CounterType.packets) name;
+
     #define UPDATE_COUNTER(name, index) \
         name.count((bit<32>)index)
     


### PR DESCRIPTION
## Problem

In today's DASH SAI generator, we support 3 type of counters: SAI counter ID, SAI Attributes and SAI stats. Due to the nature of P4 counters, the counters are used as packet counters or byte counters, hence all counters will either have _PACKET or _BYTES suffix.

However, we have many counters that doesn't work as packet counters, for example - how many flows is created or deleted.

## What we are doing in this change

This change updates the SAI generator to support the counters without suffix. This allows us to support generating hit-count type counters.

For example, if we have these counters defined in P4:
![image](https://github.com/sonic-net/DASH/assets/1533278/bd5cd15a-5156-48ea-8199-274642c796eb)

The following stats will be generated on the ENI:
![image](https://github.com/sonic-net/DASH/assets/1533278/512a5f0b-ce47-438b-b41b-e340e7adc9b8)
