### PR TITLE
Remove INVALID mode from DSCP modes

### DIFF
--- a/dash-pipeline/bmv2/dash_metadata.p4
+++ b/dash-pipeline/bmv2/dash_metadata.p4
@@ -38,9 +38,8 @@ struct conntrack_data_t {
 }
 
 enum bit<16> dash_tunnel_dscp_mode_t {
-    INVALID = 0,
-    PRESERVE_MODEL = 1,
-    PIPE_MODEL = 2
+    PRESERVE_MODEL = 0,
+    PIPE_MODEL = 1
 }
 
 struct eni_data_t {

--- a/dash-pipeline/bmv2/dash_pipeline.p4
+++ b/dash-pipeline/bmv2/dash_pipeline.p4
@@ -259,6 +259,7 @@ control dash_ingress(
         eni_lookup_stage.apply(hdr, meta);
 
         // Save the original DSCP value
+        meta.eni_data.dscp_mode = dash_tunnel_dscp_mode_t.PRESERVE_MODEL;
         meta.eni_data.dscp = (bit<6>)hdr.u0_ipv4.diffserv;
 
         if (meta.direction == dash_direction_t.OUTBOUND) {


### PR DESCRIPTION
Preserve is the default, there is no condition under which INVALID can be set.