### PR TITLE
misc: Fix compiling issue in local environment

### DIFF
--- a/dash-pipeline/SAI/src/Makefile
+++ b/dash-pipeline/SAI/src/Makefile
@@ -43,6 +43,7 @@ CXXFLAGS_COMMON+= -Wno-switch-default
 CXXFLAGS_COMMON+= -Wconversion
 CXXFLAGS_COMMON+= -Wno-psabi
 CXXFLAGS_COMMON+= -Wno-unused-label
+CXXFLAGS_COMMON+= -Wno-unused-result
 
 # Sources from OCP SAI Repo:
 SAI_DIR=../SAI/meta/

--- a/dash-pipeline/SAI/src/objectidmanager.h
+++ b/dash-pipeline/SAI/src/objectidmanager.h
@@ -7,6 +7,7 @@ extern "C" {
 
 #include <set>
 #include <map>
+#include <string>
 
 namespace dash
 {


### PR DESCRIPTION
Got the following compiling errors in a local environment
```
g++ -I../SAI/meta -I../SAI/inc -I../SAI/experimental  -ansi -fPIC -pipe -std=c++11 -Wall -Wcast-align -Wcast-qual -Wconversion -Wdisabled-optimization -Werror -Wextra -Wfloat-equal -Wformat=2 -Wformat-non
literal -Wformat-security -Wformat-y2k -Wimport -Winit-self -Wno-inline -Winvalid-pch -Wmissing-field-initializers -Wmissing-format-attribute -Wmissing-include-dirs -Wmissing-noreturn -Wno-aggregate-retur
n -Wno-padded -Wno-switch-enum -Wno-unused-parameter -Wpacked -Wpointer-arith -Wredundant-decls -Wshadow -Wstack-protector -Wstrict-aliasing=3 -Wswitch -Wswitch-default -Wunreachable-code -Wunused -Wvaria
dic-macros -Wwrite-strings -Wno-switch-default -Wconversion -Wno-psabi -Wno-unused-label -MMD -c dashsai.cpp -o dashsai.o
dashsai.cpp: In member function 'sai_status_t dash::DashSai::apiInitialize(uint64_t, const sai_service_method_table_t*)':
dashsai.cpp:172:31: error: ignoring return value of 'p4::config::v1::P4Info* p4::v1::ForwardingPipelineConfig::release_p4info()' declared with attribute 'warn_unused_result' [-Werror=unused-result]
  172 |         config->release_p4info();
      |         ~~~~~~~~~~~~~~~~~~~~~~^~
dashsai.cpp: In member function 'grpc::StatusCode dash::DashSai::mutateTableEntry(std::shared_ptr<p4::v1::TableEntry>, p4::v1::Update_Type)':
dashsai.cpp:605:32: error: ignoring return value of 'p4::v1::TableEntry* p4::v1::Entity::release_table_entry()' declared with attribute 'warn_unused_result' [-Werror=unused-result]
  605 |     entity->release_table_entry();
```

```
g++ -I../SAI/meta -I../SAI/inc -I../SAI/experimental -Wno-unused-result -ansi -fPIC -pipe -std=c++11 -Wall -Wcast-align -Wcast-qual -Wconversion -Wdisabled-optimization -Werror -Wextra -Wfloat-equal -Wfor
mat=2 -Wformat-nonliteral -Wformat-security -Wformat-y2k -Wimport -Winit-self -Wno-inline -Winvalid-pch -Wmissing-field-initializers -Wmissing-format-attribute -Wmissing-include-dirs -Wmissing-noreturn -W
no-aggregate-return -Wno-padded -Wno-switch-enum -Wno-unused-parameter -Wpacked -Wpointer-arith -Wredundant-decls -Wshadow -Wstack-protector -Wstrict-aliasing=3 -Wswitch -Wswitch-default -Wunreachable-cod
e -Wunused -Wvariadic-macros -Wwrite-strings -Wno-switch-default -Wconversion -Wno-psabi -Wno-unused-label -MMD -c objectidmanager.cpp -o objectidmanager.o
In file included from objectidmanager.cpp:1:
objectidmanager.h:69:37: error: 'string' in namespace 'std' does not name a type
   69 |                     _In_ const std::string& hardwareInfo);
      |                                     ^~~~~~
objectidmanager.h:10:1: note: 'std::string' is defined in header '<string>'; did you forget to '#include <string>'?
    9 | #include <map>
  +++ |+#include <string>
   10 |
objectidmanager.cpp:197:25: error: 'string' in namespace 'std' does not name a type
  197 |         _In_ const std::string& hardwareInfo)
      |                         ^~~~~~
objectidmanager.cpp:3:1: note: 'std::string' is defined in header '<string>'; did you forget to '#include <string>'?
    2 | #include "logger.h"
  +++ |+#include <string>
    3 |
objectidmanager.cpp: In member function 'sai_object_id_t dash::ObjectIdManager::allocateNewSwitchObjectId(const int&)':
objectidmanager.cpp:203:22: error: request for member 'size' in 'hardwareInfo', which is of non-class type 'const int'
  203 |     if (hardwareInfo.size())
      |                      ^~~~
In file included from objectidmanager.cpp:2:
objectidmanager.cpp:205:118: error: request for member 'c_str' in 'hardwareInfo', which is of non-class type 'const int'
  205 |         DASH_LOG_ERROR("hardware info is '%s', not supported yet, switch OID allocation failed, FIXME", hardwareInfo.c_str());
      |                                                                                                                      ^~~~~
logger.h:5:133: note: in definition of macro 'DASH_LOG_ERROR'
    5 | #define DASH_LOG_ERROR(MSG, ...)       dash::Logger::getInstance().write(dash::Logger::DASH_ERROR,  "e:- %s: " MSG, __FUNCTION__, ##__VA_ARGS__)
      |                                                                                                                                     ^~~~~~~~~~~
objectidmanager.cpp:230:91: error: request for member 'c_str' in 'hardwareInfo', which is of non-class type 'const int'
  230 |     DASH_LOG_NOTICE("allocated switch OID 0x%lx for hwinfo: '%s'", objectId, hardwareInfo.c_str());
      |                                                                                           ^~~~~
logger.h:7:133: note: in definition of macro 'DASH_LOG_NOTICE'
    7 | #define DASH_LOG_NOTICE(MSG, ...)      dash::Logger::getInstance().write(dash::Logger::DASH_NOTICE, "n:- %s: " MSG, __FUNCTION__, ##__VA_ARGS__)
      |                                                                                                                                     ^~~~~~~~~~~
make: *** [Makefile:67: objectidmanager.o] Error 1
```

Disable the unused-result warning and add the string header to the target file.