### PR TITLE
Check for valid overlay_dmac value before overwriting the field in the header

### DIFF
--- a/dash-pipeline/bmv2/dash_tunnel.p4
+++ b/dash-pipeline/bmv2/dash_tunnel.p4
@@ -12,7 +12,7 @@ action push_vxlan_tunnel_ ## underlay_id ## (inout headers_t hdr, \
                                        in IPv4Address underlay_dip, \
                                        in IPv4Address underlay_sip, \
                                        in bit<24> tunnel_key) { \
-    hdr. ## overlay_id ## _ethernet.dst_addr = overlay_dmac; \
+    hdr. ## overlay_id ## _ethernet.dst_addr = (overlay_dmac == 0) ? hdr. ## overlay_id ## _ethernet.dst_addr : overlay_dmac; \
     hdr. ## underlay_id ## _ethernet.setValid(); \
     hdr. ## underlay_id ## _ethernet.dst_addr = underlay_dmac; \
     hdr. ## underlay_id ## _ethernet.src_addr = underlay_smac; \


### PR DESCRIPTION
We found this issue while running one of the inbound routing PTF tests in saidashvnet.py. Most likely the bug was introduced during refactoring of tunnel encapsulation code.

In case of inbound routing, overlay_dmac is not supposed to be modified. But, in inbound_routing.p4, when tunnel_encap action is called, the value of meta.overlay_data.dmac is zero and tunnel_encap action ends up incorrectly setting the overlay_dmac to zero.

`        
tunnel_encap(hdr,
                     meta,
                     meta.overlay_data.dmac,
                     meta.encap_data.underlay_dmac,
                     meta.encap_data.underlay_smac,
                     meta.encap_data.underlay_dip,
                     meta.encap_data.underlay_sip,
                     dash_encapsulation_t.VXLAN,
                     meta.encap_data.vni);
`

This fix will check for a non-zero overlay_dmac value before overwriting the customer dmac field in the packet header.