### PR TITLE
[doc] Add bulk sync support in HA session API.

### DIFF
--- a/documentation/high-avail/ha-api-hld.md
+++ b/documentation/high-avail/ha-api-hld.md
@@ -6,7 +6,7 @@
 | 0.2 | 03/15/2024 | Riff Jiang | Added HA set notification. |
 | 0.3 | 03/21/2024 | Riff Jiang | Added capabilities for HA topology and stats. |
 | 0.4 | 04/01/2024 | Riff Jiang | Added capabilities for HA owner, simplified capabilities for HA topology. |
-| 0.5 | 04/08/2024 | Riff Jiang | Added support for bulk sync and flow reconcile for planned and unplanned switchover. |
+| 0.5 | 04/08/2024 | Riff Jiang | Added support for bulk sync. |
 
 1. [1. Terminology](#1-terminology)
 2. [2. Background](#2-background)
@@ -102,8 +102,6 @@ HA set is defined as a SAI object and contains the following SAI attributes:
 | SAI_HA_SET_ATTR_DP_CHANNEL_PROBE_INTERVAL_MS | `sai_uint32_t` | The interval of the data plane channel probe. |
 | SAI_HA_SET_ATTR_DP_CHANNEL_PROBE_FAIL_THRESHOLD | `sai_uint32_t` | The threshold of the data plane channel probe fail. |
 | SAI_HA_SET_ATTR_DP_CHANNEL_IS_ALIVE | `bool` | (Read-only) Is data plane channel alive. |
-| SAI_HA_SET_ATTR_FLOW_RECONCILE_REQUESTED | `bool` | When set to true, flow reconcile will be initiated. |
-| SAI_HA_SET_ATTR_FLOW_RECONCILE_NEEDED | `bool` | (Read-only) If true, flow reconcile is needed. |
 
 ### 4.2. HA Scope
 
@@ -214,9 +212,6 @@ typedef enum _sai_ha_set_event_t
 
     /** Data plane channel goes down. */
     SAI_HA_SET_DP_CHANNEL_DOWN,
-
-    /** Flow reconcile is needed */
-    SAI_HA_SCOPE_FLOW_RECONCILE_NEEDED,
 
 } sai_ha_set_event_t;
 

--- a/documentation/high-avail/ha-api-hld.md
+++ b/documentation/high-avail/ha-api-hld.md
@@ -306,8 +306,8 @@ Here are the new stats we added for monitoring HA on HA set (DPU pair).
 
 | Name | Description |
 | --- | --- |
-| SAI_HA_SET_STAT_CP_DATA_CHANNEL_CONNECT_ATTEMPTED | Number of connect calls for establishing the data channel. |
-| SAI_HA_SET_STAT_CP_DATA_CHANNEL_CONNECT_RECEIVED | Number of connect calls received to estabilish the data channel. |
+| SAI_HA_SET_STAT_CP_DATA_CHANNEL_CONNECT_ATTEMPTED | Number of connect called to establish the data channel. |
+| SAI_HA_SET_STAT_CP_DATA_CHANNEL_CONNECT_RECEIVED | Number of connect calls received to establish the data channel. |
 | SAI_HA_SET_STAT_CP_DATA_CHANNEL_CONNECT_SUCCEEDED | Number of connect calls that succeeded. |
 | SAI_HA_SET_STAT_CP_DATA_CHANNEL_CONNECT_FAILED | Number of connect calls that failed because of any reason other than timeout / unreachable. |
 | SAI_HA_SET_STAT_CP_DATA_CHANNEL_CONNECT_REJECTED | Number of connect calls that rejected due to certs and etc. |

--- a/documentation/high-avail/ha-api-hld.md
+++ b/documentation/high-avail/ha-api-hld.md
@@ -95,7 +95,7 @@ HA set is defined as a SAI object and contains the following SAI attributes:
 | -------------- | ---- | ----------- |
 | SAI_HA_SET_ATTR_LOCAL_IP | `sai_ip_address_t` | The IP address of the local DPU. |
 | SAI_HA_SET_ATTR_PEER_IP | `sai_ip_address_t` | The IP address of the peer DPU. |
-| SAI_HA_SET_ATTR_CP_DATA_CHANNEL_PORT | `sai_uint16_t` | The port of the control plane data channel. |
+| SAI_HA_SET_ATTR_CP_DATA_CHANNEL_PORT | `sai_uint16_t` | The port used for control plane data channel. |
 | SAI_HA_SET_ATTR_DP_CHANNEL_DST_PORT | `sai_uint16_t` | The destination port of the data plane channel. |
 | SAI_HA_SET_ATTR_DP_CHANNEL_SRC_PORT_MIN | `sai_uint16_t` | The minimum source port of the data plane channel. |
 | SAI_HA_SET_ATTR_DP_CHANNEL_SRC_PORT_MAX | `sai_uint16_t` | The maximum source port of the data plane channel. |
@@ -317,9 +317,10 @@ Besides the channel status, we should also have the following counters for the b
 
 | Name | Description |
 | --- | --- |
-| SAI_HA_SET_STAT_BULK_SYNC_MESSAGE_RECV | Number of messages we received for bulk sync via data channel. |
+| SAI_HA_SET_STAT_BULK_SYNC_MESSAGE_RECEIVED | Number of messages we received for bulk sync via data channel. |
 | SAI_HA_SET_STAT_BULK_SYNC_MESSAGE_SENT | Number of messages we sent for bulk sync via data channel. |
-| SAI_HA_SET_STAT_BULK_SYNC_FLOW_RECV | Number of flows received from bulk sync message. A single bulk sync message can contain many flow records. |
+| SAI_HA_SET_STAT_BULK_SYNC_MESSAGE_SEND_FAILED | Number of messages we failed to sent for bulk sync via data channel. |
+| SAI_HA_SET_STAT_BULK_SYNC_FLOW_RECEIVED | Number of flows received from bulk sync message. A single bulk sync message can contain many flow records. |
 | SAI_HA_SET_STAT_BULK_SYNC_FLOW_SENT | Number of flows sent via bulk sync message. A single bulk sync message can contain many flow records. |
 
 #### 4.7.2. ENI stats


### PR DESCRIPTION
The initial HA session API added the support of HA state machine management and support of configurating data plane channel for inline sync. And this change added the API to support bulk sync.

From SAI point of view, the bulk sync works as below:

1. On the source side, a flow API will be called to create the bulk sync session with specified conditions, which points to a certain destination, which can either be the swbusd in the control plane for flow relay or the paired DPU directly.
2. Once session is created, the source DPU will start to connect to the destination w/ a gRPC server and send the flow record across.
3. Once session is done, optionally the connection can be closed.

Hence, in the API, we will see 2 major things being added:

- On HA set attributes, the control plane channel port will be added.
- More stats will be added on the HA set to show how the flow sync works.
