### PR TITLE
[dash-p4] Add VXLAN tunnel to avoid build break in swss.

### DIFF
--- a/dash-pipeline/bmv2/dash_inbound.p4
+++ b/dash-pipeline/bmv2/dash_inbound.p4
@@ -34,7 +34,7 @@ control inbound(inout headers_t hdr,
         ConntrackOut.apply(hdr, meta);
 #endif //PNA_CONNTRACK
 
-        tunnel_encap(hdr,
+        do_tunnel_encap(hdr,
                      meta,
                      meta.overlay_data.dmac,
                      meta.encap_data.underlay_dmac,

--- a/dash-pipeline/bmv2/dash_tunnel.p4
+++ b/dash-pipeline/bmv2/dash_tunnel.p4
@@ -211,7 +211,7 @@ PUSH_VXLAN_TUNNEL_DEF(u1, u0)
 PUSH_NVGRE_TUNNEL_DEF(u0, customer)
 PUSH_NVGRE_TUNNEL_DEF(u1, u0)
 
-#define tunnel_encap(hdr, \
+#define do_tunnel_encap(hdr, \
                     meta, \
                     overlay_dmac, \
                     underlay_dmac, \
@@ -266,7 +266,7 @@ PUSH_NVGRE_TUNNEL_DEF(u1, u0)
    reparse it.
    It is also assumed, that if DASH pushes more than one tunnel,
    they won't need to pop them */
-action tunnel_decap(inout headers_t hdr, inout metadata_t meta) {
+action do_tunnel_decap(inout headers_t hdr, inout metadata_t meta) {
     hdr.u0_ethernet.setInvalid();
     hdr.u0_ipv4.setInvalid();
     hdr.u0_ipv6.setInvalid();


### PR DESCRIPTION
## Problems

With recent tunnel update, the SAI API generated by current P4 code will have the VXLAN_DECAP_* attributes on inbound routing table renamed to TUNNEL_DECAP_*. However, these 2 attributes are already used by SWSS, hence renaming then will cause build break in SWSS.

## What we are doing in this change

This change adds the vxlan decap actions back as dummy actions, so the old attributes will be generated as before and buy us time for swss to update the code.

![image](https://github.com/sonic-net/DASH/assets/1533278/09f65623-0d28-422d-91a8-dcf901d5e927)
