### PR TITLE
[sai-gen] Simplify condition for table action generation.

### DIFF
--- a/dash-pipeline/SAI/templates/saiapi.h.j2
+++ b/dash-pipeline/SAI/templates/saiapi.h.j2
@@ -34,7 +34,7 @@
  */
 
 {% for table in sai_api.tables %}
-{% if table.actions | length > 1 or ((table.actions | length == 1) and (((table.is_object == 'false') or (table['keys'] | length <= 1)) and ((table['action_params'] | length == 0))))  %}
+{% if table.actions | length > 1 or table.is_object == 'false' %}
 /**
  * @brief Attribute data for #SAI_{{ table.name | upper }}_ATTR_ACTION
  */
@@ -103,7 +103,7 @@ typedef enum _sai_{{ table.name }}_attr_t
     SAI_{{ table.name | upper }}_ATTR_START,
 
 {% set ns = namespace(firstattr=false) %}
-{% if table.actions | length > 1 or ((table.actions | length == 1) and (((table.is_object == 'false') or (table['keys'] | length <= 1)) and ((table['action_params'] | length == 0))))  %}
+{% if table.actions | length > 1 or table.is_object == 'false'  %}
     /**
      * @brief Action
      *

--- a/dash-pipeline/SAI/templates/saiapi.h.j2
+++ b/dash-pipeline/SAI/templates/saiapi.h.j2
@@ -103,7 +103,7 @@ typedef enum _sai_{{ table.name }}_attr_t
     SAI_{{ table.name | upper }}_ATTR_START,
 
 {% set ns = namespace(firstattr=false) %}
-{% if table.actions | length > 1 or table.is_object == 'false'  %}
+{% if table.actions | length > 1 or table.is_object == 'false' %}
     /**
      * @brief Action
      *

--- a/dash-pipeline/tests/libsai/vnet_out/vnet_out.cpp
+++ b/dash-pipeline/tests/libsai/vnet_out/vnet_out.cpp
@@ -224,6 +224,10 @@ int main(int argc, char **argv)
     eam.address[4] = 0xcc;
     eam.address[5] = 0xcc;
 
+    attr.id = SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ACTION;
+    attr.value.u32 = SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ACTION_SET_ENI;
+    attrs.push_back(attr);
+
     attr.id = SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ENI_ID;
     attr.value.u16 = eni_id;
     attrs.push_back(attr);

--- a/test/test-cases/functional/saic/config_bidir_setup_commands.py
+++ b/test/test-cases/functional/saic/config_bidir_setup_commands.py
@@ -225,6 +225,7 @@ dpu_config = [
       "address": INNER_SRC_MAC
     },
     "attributes": [
+      "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ACTION","SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ACTION_SET_ENI",
       "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ENI_ID", "$eni_#1"
     ]
   },
@@ -237,6 +238,7 @@ dpu_config = [
       "address": INNER_DST_MAC
     },
     "attributes": [
+      "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ACTION","SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ACTION_SET_ENI",
       "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ENI_ID", "$eni_#2"
     ]
   },
@@ -249,6 +251,7 @@ dpu_config = [
       "address": INNER_DST_MAC2
     },
     "attributes": [
+      "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ACTION","SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ACTION_SET_ENI",
       "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ENI_ID", "$eni_#3"
     ]
   },

--- a/test/test-cases/functional/saic/config_inbound_setup_commands.py
+++ b/test/test-cases/functional/saic/config_inbound_setup_commands.py
@@ -258,6 +258,8 @@ dpu_config = [
       "address": INNER_SRC_MAC
     },
     "attributes": [
+      "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ACTION",
+      "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ACTION_SET_ENI",
       "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ENI_ID",
       "$eni_#1"
     ]
@@ -271,6 +273,8 @@ dpu_config = [
       "address": INNER_DST_MAC
     },
     "attributes": [
+      "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ACTION",
+      "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ACTION_SET_ENI",
       "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ENI_ID",
       "$eni_#2"
     ]

--- a/test/test-cases/functional/saic/config_outbound_setup_commands.json
+++ b/test/test-cases/functional/saic/config_outbound_setup_commands.json
@@ -156,6 +156,7 @@
       "address": "00:1A:C5:00:00:01"
     },
     "attributes": [
+      "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ACTION", "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ACTION_SET_ENI",
       "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ENI_ID", "$eni_#1"
     ]
   },
@@ -168,6 +169,7 @@
       "address": "00:1b:6e:00:00:01"
     },
     "attributes": [
+      "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ACTION", "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ACTION_SET_ENI",
       "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ENI_ID", "$eni_#2"
     ]
   },

--- a/test/test-cases/functional/saic/sai-api/test_sai_api_vnet_eni_addr.py
+++ b/test/test-cases/functional/saic/sai-api/test_sai_api_vnet_eni_addr.py
@@ -23,6 +23,8 @@ class TestSaiVnetEniAddr:
                     "address": "00:AA:AA:AA:AB:00"
                 },
                 "attributes": [
+                    "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ACTION",
+                    "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ACTION_SET_ENI",
                     "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ENI_ID",
                     "1"
                 ]
@@ -59,6 +61,8 @@ class TestSaiVnetEniAddr:
                     "address": "00:AA:AA:AA:BB:00"
                 },
                 "attributes": [
+                    "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ACTION",
+                    "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ACTION_SET_ENI",
                     "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ENI_ID",
                     "$eni_id"
                 ]

--- a/test/test-cases/functional/saic/tutorial/test_sai_vnet_outbound_small_scale_config_via_dpugen_create.json
+++ b/test/test-cases/functional/saic/tutorial/test_sai_vnet_outbound_small_scale_config_via_dpugen_create.json
@@ -241,6 +241,8 @@
       "address": "00:1A:C5:00:00:01"
     },
     "attributes": [
+      "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ACTION",
+      "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ACTION_SET_ENI",
       "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ENI_ID",
       "$eni_#5000"
     ]
@@ -254,6 +256,8 @@
       "address": "00:1A:C5:18:00:01"
     },
     "attributes": [
+      "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ACTION",
+      "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ACTION_SET_ENI",
       "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ENI_ID",
       "$eni_#6000"
     ]

--- a/test/test-cases/scale/saic/vnet_inbound_setup_commands.json
+++ b/test/test-cases/scale/saic/vnet_inbound_setup_commands.json
@@ -140,6 +140,8 @@
       "address": "00:AA:AA:AA:AA:00"
     },
     "attributes": [
+      "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ACTION",
+      "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ACTION_SET_ENI",
       "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ENI_ID",
       "$eni_id"
     ]

--- a/test/test-cases/scale/saic/vnet_outbound_setup_commands_scale.json
+++ b/test/test-cases/scale/saic/vnet_outbound_setup_commands_scale.json
@@ -194,6 +194,7 @@
       "address": "00:CC:CC:CC:00:00"
     },
     "attributes": [
+      "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ACTION", "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ACTION_SET_ENI",
       "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ENI_ID", "$eni_#0"
     ]
   },
@@ -206,6 +207,7 @@
       "address": "00:CC:CC:CC:00:01"
     },
     "attributes": [
+      "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ACTION", "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ACTION_SET_ENI",
       "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ENI_ID", "$eni_#1"
     ]
   },

--- a/test/test-cases/scale/saic/vnet_outbound_setup_commands_simple.json
+++ b/test/test-cases/scale/saic/vnet_outbound_setup_commands_simple.json
@@ -99,6 +99,7 @@
       "address": "00:CC:CC:CC:00:00"
     },
     "attributes": [
+      "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ACTION", "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ACTION_SET_ENI",
       "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ENI_ID", "$eni"
     ]
   },

--- a/test/test-cases/scale/saic/vnet_route_setup_commands_bidirectional.json
+++ b/test/test-cases/scale/saic/vnet_route_setup_commands_bidirectional.json
@@ -438,6 +438,8 @@
             "address": "00:CC:CC:CC:00:00"
         },
         "attributes": [
+            "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ACTION",
+            "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ACTION_SET_ENI",
             "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ENI_ID",
             "$eni"
         ]
@@ -451,6 +453,8 @@
             "address": "00:0a:04:06:06:06"
         },
         "attributes": [
+            "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ACTION",
+            "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ACTION_SET_ENI",
             "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ENI_ID",
             "$eni"
         ]

--- a/test/test-cases/scale/saic/vnet_route_setup_commands_unidirectional.json
+++ b/test/test-cases/scale/saic/vnet_route_setup_commands_unidirectional.json
@@ -140,6 +140,8 @@
             "address": "00:CC:CC:CC:00:00"
         },
         "attributes": [
+            "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ACTION",
+            "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ACTION_SET_ENI",
             "SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ENI_ID",
             "$eni"
         ]


### PR DESCRIPTION
## Problem

Currently, we have a very complicated check for when a table action should be generated, for example:

![image](https://github.com/sonic-net/DASH/assets/1533278/9fbd5ee4-a3fb-4680-833d-c12bc3104518)

The reason of this check being introduced is to enable us ignore the `SAI_VIP_ENTRY_ACTION_DENY` and `SAI_PA_VALIDATION_ENTRY_ACTION_DENY` action while still keep the action generated for them, as these entries only has 1 action which will be ignored.

However, this check is too narrowed, and also create some issues, for example - an object (not entry) with 1 action will also have the action type generated, which is not ideal.

## What are we doing in this change

Ideally, the condition to generate the action type should be really straightforward:
1. If the table entry has more than 2 valid actions (not deny), the action type should be generated.
2. If the table entry is an entry, not object, the action type should be generated.
3. Otherwise, the action type should not be generated.

This simple logic simplify the mind model a lot, and the only case it didn't cover is the eni_eth_address_map_entry, which IMO, should follow the same pattern as many other similar tables (direction lookup, VIP, PA validation) and have the action type created too.

![image](https://github.com/sonic-net/DASH/assets/1533278/22292468-11d0-4b54-8fc7-7478ebd4a356)

Hence, proposing the change to make our life easier.