### PR TITLE
[dash-p4] Add pre-routing action apply stage.

### DIFF
--- a/dash-pipeline/bmv2/dash_metadata.p4
+++ b/dash-pipeline/bmv2/dash_metadata.p4
@@ -9,9 +9,11 @@
 enum bit<32> dash_routing_actions_t {
     NONE = 0,
     STATIC_ENCAP = (1 << 0),
-    NAT46 = (1 << 1),
-    NAT64 = (1 << 2)
-}
+    NAT = (1 << 1),
+    NAT46 = (1 << 2),
+    NAT64 = (1 << 3),
+    NAT_PORT = (1 << 4)
+};
 
 enum bit<16> dash_direction_t {
     INVALID = 0,
@@ -44,6 +46,7 @@ enum bit<16> dash_pipeline_stage_t {
     OUTBOUND_STAGE_START = 200,
     OUTBOUND_ROUTING = 200, // OUTBOUND_STAGE_START
     OUTBOUND_MAPPING = 201,
+    OUTBOUND_PRE_ROUTING_ACTION_APPLY = 280,
 
     // Common stages
     ROUTING_ACTION_APPLY = 300

--- a/dash-pipeline/bmv2/dash_outbound.p4
+++ b/dash-pipeline/bmv2/dash_outbound.p4
@@ -26,7 +26,7 @@ control outbound(inout headers_t hdr,
         }
 
 #ifdef STATEFUL_P4
-            ConntrackIn.apply(1);
+        ConntrackIn.apply(1);
 #endif /* STATEFUL_P4 */
 
 #ifdef PNA_CONNTRACK

--- a/dash-pipeline/bmv2/dash_outbound.p4
+++ b/dash-pipeline/bmv2/dash_outbound.p4
@@ -6,13 +6,14 @@
 #include "dash_conntrack.p4"
 #include "stages/outbound_routing.p4"
 #include "stages/outbound_mapping.p4"
+#include "stages/outbound_pre_routing_action_apply.p4"
 
 control outbound(inout headers_t hdr,
                  inout metadata_t meta)
 {
     apply {
 #ifdef STATEFUL_P4
-           ConntrackOut.apply(0);
+        ConntrackOut.apply(0);
 #endif /* STATEFUL_P4 */
 
 #ifdef PNA_CONNTRACK
@@ -37,6 +38,8 @@ control outbound(inout headers_t hdr,
 
         outbound_routing_stage.apply(hdr, meta);
         outbound_mapping_stage.apply(hdr, meta);
+
+        outbound_pre_routing_action_apply_stage.apply(hdr, meta);
     }
 }
 

--- a/dash-pipeline/bmv2/dash_routing_types.p4
+++ b/dash-pipeline/bmv2/dash_routing_types.p4
@@ -15,7 +15,7 @@ action set_meter_attrs(
 
 // Routing Type - drop:
 action drop(inout metadata_t meta) {
-    meta.target_stage = dash_pipeline_stage_t.ROUTING_ACTION_APPLY;
+    meta.target_stage = dash_pipeline_stage_t.OUTBOUND_PRE_ROUTING_ACTION_APPLY;
     meta.dropped = true;
 }
 
@@ -63,7 +63,7 @@ action route_direct(
     bit<32> meter_class_or,
     @SaiVal[default_value="4294967295"] bit<32> meter_class_and)
 {
-    meta.target_stage = dash_pipeline_stage_t.ROUTING_ACTION_APPLY;
+    meta.target_stage = dash_pipeline_stage_t.OUTBOUND_PRE_ROUTING_ACTION_APPLY;
     set_meter_attrs(meta, meter_class_or, meter_class_and);
 }
 
@@ -96,7 +96,7 @@ action route_service_tunnel(
     assert(overlay_dip_mask_is_v6 == 1 && overlay_sip_mask_is_v6 == 1);
     assert(underlay_dip_is_v6 != 1 && underlay_sip_is_v6 != 1); */
 
-    meta.target_stage = dash_pipeline_stage_t.ROUTING_ACTION_APPLY;
+    meta.target_stage = dash_pipeline_stage_t.OUTBOUND_PRE_ROUTING_ACTION_APPLY;
 
     push_action_nat46(hdr = hdr,
                     meta = meta,
@@ -130,7 +130,7 @@ action set_tunnel_mapping(
     bit<1> use_dst_vnet_vni,
     bit<32> meter_class_or)
 {
-    meta.target_stage = dash_pipeline_stage_t.ROUTING_ACTION_APPLY;
+    meta.target_stage = dash_pipeline_stage_t.OUTBOUND_PRE_ROUTING_ACTION_APPLY;
 
     if (use_dst_vnet_vni == 1)
         meta.vnet_id = meta.dst_vnet_id;
@@ -154,7 +154,7 @@ action set_private_link_mapping(
     bit<24> tunnel_key,
     bit<32> meter_class_or)
 {
-    meta.target_stage = dash_pipeline_stage_t.ROUTING_ACTION_APPLY;
+    meta.target_stage = dash_pipeline_stage_t.OUTBOUND_PRE_ROUTING_ACTION_APPLY;
     
     push_action_static_encap(hdr = hdr,
                             meta = meta,

--- a/dash-pipeline/bmv2/stages/outbound_pre_routing_action_apply.p4
+++ b/dash-pipeline/bmv2/stages/outbound_pre_routing_action_apply.p4
@@ -1,0 +1,19 @@
+#ifndef _DASH_STAGE_OUTBOUND_PRE_ROUTING_ACTION_APPLY_P4_
+#define _DASH_STAGE_OUTBOUND_PRE_ROUTING_ACTION_APPLY_P4_
+
+control outbound_pre_routing_action_apply_stage(
+    inout headers_t hdr,
+    inout metadata_t meta)
+{
+    apply {
+        // Outbound pre-routing action apply stage is added here for certain post processing before applying the final actions.
+        if (meta.target_stage != dash_pipeline_stage_t.OUTBOUND_PRE_ROUTING_ACTION_APPLY) {
+            return;
+        }
+
+        // Once it is done, move to routing action apply stage.
+        meta.target_stage = dash_pipeline_stage_t.ROUTING_ACTION_APPLY;
+    }
+}
+
+#endif /* _DASH_STAGE_OUTBOUND_PRE_ROUTING_ACTION_APPLY_P4_ */

--- a/dash-pipeline/bmv2/stages/outbound_pre_routing_action_apply.p4
+++ b/dash-pipeline/bmv2/stages/outbound_pre_routing_action_apply.p4
@@ -6,7 +6,7 @@ control outbound_pre_routing_action_apply_stage(
     inout metadata_t meta)
 {
     apply {
-        // Outbound pre-routing action apply stage is added here for certain post processing before applying the final actions.
+        // Outbound pre-routing action apply stage is added here for certain pre processing before applying the final actions.
         if (meta.target_stage != dash_pipeline_stage_t.OUTBOUND_PRE_ROUTING_ACTION_APPLY) {
             return;
         }


### PR DESCRIPTION
This change adds a pre routing action apply stage, which serves as a pivot for doing any post processing after routing and mapping stages before the final action being applied.