### PR TITLE
[sai-gen] Fix SAI generation if the coutners is the firs attribute.

### DIFF
--- a/dash-pipeline/SAI/templates/saiapi.h.j2
+++ b/dash-pipeline/SAI/templates/saiapi.h.j2
@@ -211,7 +211,12 @@ typedef enum _sai_{{ table.name }}_attr_t
      * @allownull true
      * @default SAI_NULL_OBJECT_ID
      */
+{% if not ns.firstattr %}
+    SAI_{{ table.name | upper }}_ATTR_COUNTER_ID = SAI_{{ table.name | upper }}_ATTR_START,
+{% set ns.firstattr = true %}
+{% else %}
     SAI_{{ table.name | upper }}_ATTR_COUNTER_ID,
+{% endif %}
 
 {% endif %}
 {% if table.is_object == 'true' %}


### PR DESCRIPTION
## Problem

When we create a new SAI object (table) without any attribute and with the counter attached, the counter id will be generated as the first attribute, however the format is not right, as it doesn't have the ` = SAI_TABLE_NAME_ATTR_START` part after it. This will cause SAI checkers to fail.

## What we are doing in this change

This change fixes the template, so we can have the counter attribute correctly generated as below in this case.

```c
typedef enum _sai_some_table_attr_t
{
    /**
     * @brief Start of attributes
     */
    SAI_SOME_TABLE_ATTR_START,
    /**
     * @brief Attach a counter
     *
     * When it is empty, then packet hits won't be counted
     *
     * @type sai_object_id_t
     * @flags CREATE_AND_SET
     * @objects SAI_OBJECT_TYPE_COUNTER
     * @allownull true
     * @default SAI_NULL_OBJECT_ID
     */
    SAI_SOME_TABLE_ATTR_COUNTER_ID = SAI_SOME_TABLE_ATTR_START,
    /**
     * @brief End of attributes
     */
    SAI_SOME_TABLE_ATTR_END,
    /** Custom range base value */
    SAI_SOME_TABLE_ATTR_CUSTOM_RANGE_START = 0x10000000,
    /** End of custom range base */
    SAI_SOME_TABLE_ATTR_CUSTOM_RANGE_END,
} sai_some_table_attr_t;
```