### PR TITLE
[sai-gen] Update the default action of inbound routing type to use the latest one instead of deprecated one.

### DIFF
--- a/dash-pipeline/bmv2/dash_pipeline.p4
+++ b/dash-pipeline/bmv2/dash_pipeline.p4
@@ -219,10 +219,10 @@ control dash_ingress(
             hdr.u0_ipv4.src_addr : ternary @SaiVal[name = "sip", type="sai_ip_address_t"];
         }
         actions = {
-            vxlan_decap;                // Deprecated, but cannot be removed until SWSS is updated.
-            vxlan_decap_pa_validate;    // Deprecated, but cannot be removed until SWSS is updated.
             tunnel_decap(hdr, meta);
             tunnel_decap_pa_validate(hdr, meta);
+            vxlan_decap;                // Deprecated, but cannot be removed until SWSS is updated.
+            vxlan_decap_pa_validate;    // Deprecated, but cannot be removed until SWSS is updated.
             @defaultonly deny;
         }
 


### PR DESCRIPTION
The SAI action type generation follows the order of the actions defined in P4 and the first one will be the default action. The newly added tunnel decap actions in inbound routing table are not used as default value, as they are put in the end of the action list.

This change fixes the action order, which produces the right default action in the SAI header:

![image](https://github.com/sonic-net/DASH/assets/1533278/291a474c-3f8c-4e84-95cb-79c6f74f16ac)
