### PR TITLE
[sai-gen] Fix template for generating the SAI stats.

### DIFF
--- a/dash-pipeline/SAI/templates/headers/sai_stats_enum.j2
+++ b/dash-pipeline/SAI/templates/headers/sai_stats_enum.j2
@@ -5,7 +5,7 @@
 typedef enum _sai_{{ table.name }}_stat_t
 {
     {% for stat in table.sai_stats %}
-    /** DASH {{ table.name | lower }} {{ stat.name | upper }} stat count */
+    /** DASH {{ table.name | upper }} {{ stat.name | upper }} stat count */
     SAI_{{ table.name | upper }}_STAT_{{ stat.name | upper }},
 
     {% endfor %}


### PR DESCRIPTION
SAI has a style checker that forces the certain words to be upper cases in the comment, such as acronyms like ENI. However, currently we are generating the comments using lower cases, which breaks this checker.

![image](https://github.com/sonic-net/DASH/assets/1533278/8bbc6995-a8e4-435e-b546-ddbd869ff533)

This issue will be gone after moving everything to upper case, hence making this change to fix this issue.