### PR TITLE
[sai] Update SAI to latest master

### DIFF
--- a/dash-pipeline/SAI/sai_api_gen.py
+++ b/dash-pipeline/SAI/sai_api_gen.py
@@ -204,7 +204,7 @@ class SAITypeSolver:
         "sai_ip_addr_family_t": SAITypeInfo("sai_ip_addr_family_t", "u32", default="SAI_IP_ADDR_FAMILY_IPV4"),
         "sai_uint32_t": SAITypeInfo("sai_uint32_t", "u32", default="0"),
         "sai_uint64_t": SAITypeInfo("sai_uint64_t", "u64", default="0"),
-        "sai_mac_t": SAITypeInfo("sai_mac_t", "mac", default="0:0:0:0:0:0"),
+        "sai_mac_t": SAITypeInfo("sai_mac_t", "mac", default="vendor"),
         "sai_ip_prefix_t": SAITypeInfo("sai_ip_prefix_t", "ipPrefix", default="0"),
         "sai_u8_list_t": SAITypeInfo("sai_u8_list_t", "u8list", default="empty"),
         "sai_u16_list_t": SAITypeInfo("sai_u16_list_t", "u16list", default="empty"),

--- a/dash-pipeline/SAI/templates/headers/sai_stats_api.j2
+++ b/dash-pipeline/SAI/templates/headers/sai_stats_api.j2
@@ -1,6 +1,6 @@
 {% if table.sai_stats | length > 0 %}
 /**
- * @brief Get {{ table.name }} statistics counters. Deprecated for backward compatibility.
+ * @brief Get {{ table.name | upper }} statistics counters. Deprecated for backward compatibility.
  *
 {% include 'templates/headers/sai_api_comment_object_id.j2' %}
  * @param[in] number_of_counters Number of counters in the array
@@ -16,7 +16,7 @@ typedef sai_status_t (*sai_get_{{ table.name }}_stats_fn)(
         _Out_ uint64_t *counters);
 
 /**
- * @brief Get {{ table.name }} statistics counters extended.
+ * @brief Get {{ table.name | upper }} statistics counters extended.
  *
 {% include 'templates/headers/sai_api_comment_object_id.j2' %}
  * @param[in] number_of_counters Number of counters in the array
@@ -34,7 +34,7 @@ typedef sai_status_t (*sai_get_{{ table.name }}_stats_ext_fn)(
         _Out_ uint64_t *counters);
 
 /**
- * @brief Clear {{ table.name }} statistics counters.
+ * @brief Clear {{ table.name | upper }} statistics counters.
  *
 {% include 'templates/headers/sai_api_comment_object_id.j2' %}
  * @param[in] number_of_counters Number of counters in the array

--- a/dash-pipeline/SAI/templates/headers/sai_stats_enum.j2
+++ b/dash-pipeline/SAI/templates/headers/sai_stats_enum.j2
@@ -1,6 +1,6 @@
 {% if table.sai_stats | length > 0 %}
 /**
- * @brief Counter IDs for {{ table.name }} in sai_get_{{ table.name }}_stats() call
+ * @brief Counter IDs for {{ table.name | upper }} in sai_get_{{ table.name }}_stats() call
  */
 typedef enum _sai_{{ table.name }}_stat_t
 {


### PR DESCRIPTION
We have the metering API, flow resimulation API, HA state management and inline sync APIs, and more updates all merged into OCP SAI. This change brings the updates back to DASH, so we can see the latest differences.