### PR TITLE
[dash-p4] Support SAI API generation for bulk sync API, flow reconcile API and related counter.

### DIFF
--- a/dash-pipeline/SAI/sai_api_gen.py
+++ b/dash-pipeline/SAI/sai_api_gen.py
@@ -368,7 +368,7 @@ class SAIObject:
             self.name = str(p4rt_anno['value']['stringValue'])
             return True
         elif p4rt_anno['key'] == 'order':
-            self.order = str(p4rt_anno['value']['int64Value'])
+            self.order = int(p4rt_anno['value']['int64Value'])
             return True
 
         return False

--- a/dash-pipeline/SAI/templates/saiapi.h.j2
+++ b/dash-pipeline/SAI/templates/saiapi.h.j2
@@ -25,7 +25,7 @@
 #if !defined (__SAIEXPERIMENTAL{{ sai_api.app_name | replace('_', '') | upper }}_H_)
 #define __SAIEXPERIMENTAL{{ sai_api.app_name | replace('_', '') | upper}}_H_
 
-#include <saitypes.h>
+#include <saitypesextensions.h>
 
 /**
  * @defgroup SAIEXPERIMENTAL{{ sai_api.app_name | upper}} SAI - Extension specific API definitions

--- a/dash-pipeline/bmv2/stages/ha.p4
+++ b/dash-pipeline/bmv2/stages/ha.p4
@@ -58,7 +58,9 @@ control ha_stage(inout headers_t hdr,
     action set_ha_scope_attr(
         @SalVal[type="sai_object_id_t"] bit<16> ha_set_id,
         @SaiVal[type="sai_dash_ha_role_t"] dash_ha_role_t dash_ha_role,
-        @SaiVal[isreadonly="true"] bit<32> flow_version
+        @SaiVal[isreadonly="true"] bit<32> flow_version,
+        bit<1> flow_reconcile_requested,
+        @SaiVal[isreadonly="true"] bit<1> flow_reconcile_needed,
     ) {
         meta.ha.ha_set_id = ha_set_id;
         meta.ha.ha_role = dash_ha_role;

--- a/dash-pipeline/bmv2/stages/ha.p4
+++ b/dash-pipeline/bmv2/stages/ha.p4
@@ -16,7 +16,7 @@ control ha_stage(inout headers_t hdr,
     DEFINE_HIT_COUNTER(flow_aged_counter, MAX_ENI, name="flow_aged", attr_type="stats", action_names="set_eni_attrs", order=1)
 
     //
-    // ENI-level flow sync packet counters:
+    // ENI-level data plane flow sync packet counters:
     //
     DEFINE_COUNTER(inline_sync_packet_rx_counter, MAX_ENI, name="inline_sync_packet_rx", attr_type="stats", action_names="set_eni_attrs", order=2)
     DEFINE_COUNTER(inline_sync_packet_tx_counter, MAX_ENI, name="inline_sync_packet_tx", attr_type="stats", action_names="set_eni_attrs", order=2)
@@ -24,7 +24,7 @@ control ha_stage(inout headers_t hdr,
     DEFINE_COUNTER(timed_sync_packet_tx_counter, MAX_ENI, name="timed_sync_packet_tx", attr_type="stats", action_names="set_eni_attrs", order=2)
 
     //
-    // ENI-level flow sync request counters:
+    // ENI-level data plane flow sync request counters:
     // - Depends on implementations, the flow sync request could be batched, hence they need to tracked separately.
     // - The counters are defined as combination of following things:
     //   - 3 flow sync operations: create, update, delete.
@@ -77,17 +77,35 @@ control ha_stage(inout headers_t hdr,
     //
     // HA set:
     //
+
+    // Data plane probe related counters
     DEFINE_COUNTER(dp_probe_req_rx, MAX_HA_SET, name="dp_probe_req_rx", attr_type="stats", action_names="set_ha_set_attr")
     DEFINE_COUNTER(dp_probe_req_tx, MAX_HA_SET, name="dp_probe_req_tx", attr_type="stats", action_names="set_ha_set_attr")
     DEFINE_COUNTER(dp_probe_ack_rx, MAX_HA_SET, name="dp_probe_ack_rx", attr_type="stats", action_names="set_ha_set_attr")
     DEFINE_COUNTER(dp_probe_ack_tx, MAX_HA_SET, name="dp_probe_ack_tx", attr_type="stats", action_names="set_ha_set_attr")
     DEFINE_HIT_COUNTER(dp_probe_failed, MAX_HA_SET, name="dp_probe_failed", attr_type="stats", action_names="set_ha_set_attr")
 
+    // Control plane data channel related counters
+    DEFINE_HIT_COUNTER(cp_data_channel_connect_attempted, MAX_HA_SET, name="cp_data_channel_connect_attempted", attr_type="stats", action_names="set_ha_set_attr", order=1)
+    DEFINE_HIT_COUNTER(cp_data_channel_connect_received, MAX_HA_SET, name="cp_data_channel_connect_received", attr_type="stats", action_names="set_ha_set_attr", order=1)
+    DEFINE_HIT_COUNTER(cp_data_channel_connect_succeeded, MAX_HA_SET, name="cp_data_channel_connect_succeeded", attr_type="stats", action_names="set_ha_set_attr", order=1)
+    DEFINE_HIT_COUNTER(cp_data_channel_connect_failed, MAX_HA_SET, name="cp_data_channel_connect_failed", attr_type="stats", action_names="set_ha_set_attr", order=1)
+    DEFINE_HIT_COUNTER(cp_data_channel_connect_rejected, MAX_HA_SET, name="cp_data_channel_connect_rejected", attr_type="stats", action_names="set_ha_set_attr", order=1)
+    DEFINE_HIT_COUNTER(cp_data_channel_timeout_count, MAX_HA_SET, name="cp_data_channel_timeout_count", attr_type="stats", action_names="set_ha_set_attr", order=1)
+
+    // Bulk sync related counters
+    DEFINE_HIT_COUNTER(bulk_sync_message_received, MAX_HA_SET, name="bulk_sync_message_received", attr_type="stats", action_names="set_ha_set_attr", order=1)
+    DEFINE_HIT_COUNTER(bulk_sync_message_sent, MAX_HA_SET, name="bulk_sync_message_sent", attr_type="stats", action_names="set_ha_set_attr", order=1)
+    DEFINE_HIT_COUNTER(bulk_sync_message_send_failed, MAX_HA_SET, name="bulk_sync_message_send_failed", attr_type="stats", action_names="set_ha_set_attr", order=1)
+    DEFINE_HIT_COUNTER(bulk_sync_flow_received, MAX_HA_SET, name="bulk_sync_flow_received", attr_type="stats", action_names="set_ha_set_attr", order=1)
+    DEFINE_HIT_COUNTER(bulk_sync_flow_sent, MAX_HA_SET, name="bulk_sync_flow_sent", attr_type="stats", action_names="set_ha_set_attr", order=1)
+
     action set_ha_set_attr(
         bit<1> local_ip_is_v6,
         @SaiVal[type="sai_ip_address_t"] IPv4ORv6Address local_ip,
         bit<1> peer_ip_is_v6,
         @SaiVal[type="sai_ip_address_t"] IPv4ORv6Address peer_ip,
+        bit<16> cp_data_channel_port,
         bit<16> dp_channel_dst_port,
         bit<16> dp_channel_min_src_port,
         bit<16> dp_channel_max_src_port,

--- a/dash-pipeline/bmv2/stages/ha.p4
+++ b/dash-pipeline/bmv2/stages/ha.p4
@@ -60,7 +60,7 @@ control ha_stage(inout headers_t hdr,
         @SaiVal[type="sai_dash_ha_role_t"] dash_ha_role_t dash_ha_role,
         @SaiVal[isreadonly="true"] bit<32> flow_version,
         bit<1> flow_reconcile_requested,
-        @SaiVal[isreadonly="true"] bit<1> flow_reconcile_needed,
+        @SaiVal[isreadonly="true"] bit<1> flow_reconcile_needed
     ) {
         meta.ha.ha_set_id = ha_set_id;
         meta.ha.ha_role = dash_ha_role;


### PR DESCRIPTION
This change updates the P4 code to generate the SAI APIs for bulk sync API, flow reconcile API and related counters.

The API change can be found via the PR in OCP SAI repo here: https://github.com/opencomputeproject/SAI/pull/2014.