### PR TITLE
Skip default IPv6 route with prefix zero and fix IPv6 prefix bug

### DIFF
--- a/dash-pipeline/SAI/src/utils.cpp
+++ b/dash-pipeline/SAI/src/utils.cpp
@@ -67,3 +67,25 @@ int dash::utils::leadingNonZeroBits(const sai_ip6_t& ipv6)
 
     return 0;
 }
+
+
+int dash::utils::getPrefixLength(const sai_ip_prefix_t &value)
+{
+    switch(value.addr_family)
+    {
+        case SAI_IP_ADDR_FAMILY_IPV4:
+            // LPM entry match field prefix length calculation needs to be fixed to accomodate 128 bit size.
+            // So the 96 is added to the prefix length.
+            return leadingNonZeroBits(htonl(value.mask.ip4)) + 96;
+        case SAI_IP_ADDR_FAMILY_IPV6:
+            return leadingNonZeroBits(value.mask.ip6);
+        default:
+            assert(0 && "unrecognzed value.ipaddr.addr_family");
+    }
+    return 0;
+}
+
+int dash::utils::getPrefixLength(const sai_attribute_value_t &value)
+{
+    return getPrefixLength(value.ipprefix);
+}

--- a/dash-pipeline/SAI/src/utils.cpp
+++ b/dash-pipeline/SAI/src/utils.cpp
@@ -1,5 +1,7 @@
 #include "utils.h"
 
+#include <algorithm>
+
 const sai_attribute_t* dash::utils::getMaskAttr(sai_attr_id_t id, uint32_t attr_count, const sai_attribute_t *attr_list)
 {
     DASH_LOG_ENTER();
@@ -78,7 +80,10 @@ int dash::utils::getPrefixLength(const sai_ip_prefix_t &value)
             // So the 96 is added to the prefix length.
             return leadingNonZeroBits(htonl(value.mask.ip4)) + 96;
         case SAI_IP_ADDR_FAMILY_IPV6:
-            return leadingNonZeroBits(value.mask.ip6);
+            sai_ip6_t mask;
+            memcpy(mask, value.mask.ip6, sizeof(mask));
+            std::reverse(std::begin(mask), std::end(mask));
+            return leadingNonZeroBits(mask);
         default:
             assert(0 && "unrecognzed value.ipaddr.addr_family");
     }

--- a/dash-pipeline/SAI/src/utils.cpp
+++ b/dash-pipeline/SAI/src/utils.cpp
@@ -59,7 +59,7 @@ int dash::utils::leadingNonZeroBits(const sai_ip6_t& ipv6)
 
         if (firstSetBit > 0)
         {
-            return 129-trailingZeros-firstSetBit;
+            return 129-trailingZeros-(33-firstSetBit);
         }
 
         trailingZeros += 32;

--- a/dash-pipeline/SAI/src/utils.h
+++ b/dash-pipeline/SAI/src/utils.h
@@ -27,7 +27,6 @@ extern "C"
 #include <limits>
 #include <fstream>
 #include <memory>
-#include <type_traits>
 
 namespace dash
 {
@@ -240,13 +239,13 @@ namespace dash
         int leadingNonZeroBits(const sai_ip6_t& ipv6);
 
         template<typename T>
-            sai_status_t ipPrefixSetVal(const sai_attribute_value_t &value, T &t, int bits = -1)
+            void ipPrefixSetVal(const sai_attribute_value_t &value, T &t, int bits = -1)
             {
-                return ipPrefixSetVal(value.ipprefix, t);
+                ipPrefixSetVal(value.ipprefix, t);
             }
 
         template<typename T>
-            sai_status_t ipPrefixSetVal(const sai_ip_prefix_t &value, T &t, int bits = -1)
+            void ipPrefixSetVal(const sai_ip_prefix_t &value, T &t, int bits = -1)
             {
                 switch(value.addr_family)
                 {
@@ -269,10 +268,6 @@ namespace dash
                     case SAI_IP_ADDR_FAMILY_IPV6:
                         {
                             uint8_t ip[16];
-                            if (std::is_same<T, p4::v1::FieldMatch_LPM>::value) {
-                                // BMv2 cannot support IPv6 LPM with prefix
-                                return SAI_STATUS_NOT_SUPPORTED;
-                            }
 
                             std::copy(const_cast<uint8_t*>(&value.addr.ip6[0]), const_cast<uint8_t*>(&value.addr.ip6[0]) + 16, ip);
 
@@ -286,8 +281,6 @@ namespace dash
                     default:
                         assert(0 && "unrecognzed value.ipaddr.addr_family");
                 }
-
-                return SAI_STATUS_SUCCESS;
             }
 
         template<typename T>

--- a/dash-pipeline/SAI/src/utils.h
+++ b/dash-pipeline/SAI/src/utils.h
@@ -238,26 +238,9 @@ namespace dash
 
         int leadingNonZeroBits(const sai_ip6_t& ipv6);
 
-        inline int getPrefixLength(const sai_ip_prefix_t &value)
-        {
-            switch(value.addr_family)
-            {
-                case SAI_IP_ADDR_FAMILY_IPV4:
-                    // LPM entry match field prefix length calculation needs to be fixed to accomodate 128 bit size.
-                    // So the 96 is added to the prefix length.
-                    return leadingNonZeroBits(htonl(value.mask.ip4)) + 96;
-                case SAI_IP_ADDR_FAMILY_IPV6:
-                    return leadingNonZeroBits(value.mask.ip6);
-                default:
-                    assert(0 && "unrecognzed value.ipaddr.addr_family");
-            }
-            return 0;
-        }
+        int getPrefixLength(const sai_ip_prefix_t &value);
 
-        inline int getPrefixLength(const sai_attribute_value_t &value)
-        {
-            return getPrefixLength(value.ipprefix);
-        }
+        int getPrefixLength(const sai_attribute_value_t &value);
 
         template<typename T>
             void ipPrefixSetVal(const sai_attribute_value_t &value, T &t, int bits = -1)

--- a/dash-pipeline/SAI/templates/saiapi.cpp.j2
+++ b/dash-pipeline/SAI/templates/saiapi.cpp.j2
@@ -87,6 +87,14 @@ static sai_status_t dash_sai_create_{{ table.name }}(
                 auto mf_exact = mf->mutable_exact();
                 {{key.field}}SetVal(attr_list[i].value, mf_exact, {{key.bitwidth}});
                 {% elif key.match_type == 'lpm' %}
+                {% if key.field == 'ipPrefix' %}
+                if (getPrefixLength(attr_list[i].value) == 0)
+                {
+                    // https://github.com/p4lang/PI/blob/24e0a3c08c964e36d235973556b90e0ae922b894/proto/frontend/src/device_mgr.cpp#L2242-L2246
+                    DASH_LOG_WARN("Invalid reprsentation of 'don't care' LPM match, omit match field instead of using a prefix length of 0");
+                    return SAI_STATUS_SUCCESS;
+                }
+                {% endif %}
                 auto mf_lpm = mf->mutable_lpm();
                 {{key.field}}SetVal(attr_list[i].value, mf_lpm, {{key.bitwidth}});
                 {% elif key.match_type == 'list' %}
@@ -401,6 +409,14 @@ static sai_status_t dash_sai_create_{{ table.name }}(
           {{key.field}}SetVal(static_cast<uint{{key.bitwidth}}_t>(tableEntry->{{ key.name | lower }}), mf_exact, {{key.bitwidth}});
         {% endif %}
         {% elif key.match_type == 'lpm' %}
+        {% if key.field == 'ipPrefix' %}
+        if (getPrefixLength(tableEntry->{{ key.name | lower }}) == 0)
+        {
+            // https://github.com/p4lang/PI/blob/24e0a3c08c964e36d235973556b90e0ae922b894/proto/frontend/src/device_mgr.cpp#L2242-L2246
+            DASH_LOG_WARN("Invalid reprsentation of 'don't care' LPM match, omit match field instead of using a prefix length of 0");
+            return SAI_STATUS_SUCCESS;
+        }
+        {% endif %}
         auto mf_lpm = mf->mutable_lpm();
         {{key.field}}SetVal(tableEntry->{{ key.name | lower }}, mf_lpm, {{key.bitwidth}});
         {% elif key.match_type == 'ternary' %}
@@ -582,6 +598,14 @@ static sai_status_t dash_sai_remove_{{ table.name }}(
         {% endif %}  
         //{{key.field}}SetVal(tableEntry->{{ key.name | lower }}, mf_exact, {{key.bitwidth}});
         {% elif key.match_type == 'lpm' %}
+        {% if key.field == 'ipPrefix' %}
+        if (getPrefixLength(tableEntry->{{ key.name | lower }}) == 0)
+        {
+            // https://github.com/p4lang/PI/blob/24e0a3c08c964e36d235973556b90e0ae922b894/proto/frontend/src/device_mgr.cpp#L2242-L2246
+            DASH_LOG_WARN("Invalid reprsentation of 'don't care' LPM match, omit match field instead of using a prefix length of 0");
+            return SAI_STATUS_SUCCESS;
+        }
+        {% endif %}
         auto mf_lpm = mf->mutable_lpm();
         {{key.field}}SetVal(tableEntry->{{ key.name | lower }}, mf_lpm, {{key.bitwidth}});
         {% elif key.match_type == 'ternary' %}

--- a/dash-pipeline/SAI/templates/saiapi.cpp.j2
+++ b/dash-pipeline/SAI/templates/saiapi.cpp.j2
@@ -88,7 +88,10 @@ static sai_status_t dash_sai_create_{{ table.name }}(
                 {{key.field}}SetVal(attr_list[i].value, mf_exact, {{key.bitwidth}});
                 {% elif key.match_type == 'lpm' %}
                 auto mf_lpm = mf->mutable_lpm();
-                {{key.field}}SetVal(attr_list[i].value, mf_lpm, {{key.bitwidth}});
+                if ({{key.field}}SetVal(tableEntry->{{ key.name | lower }}, mf_lpm, {{key.bitwidth}}) != SAI_STATUS_SUCCESS) {
+                    DASH_LOG_WARN("Failed to set lpm value for {{key.field}}");
+                    return SAI_STATUS_SUCCESS;
+                }
                 {% elif key.match_type == 'list' %}
                 // BMv2 doesn't support "list" match type, and we are using "optional" match in v1model as our implementation.
                 // Hence, here we only take the first item from the list and program it as optional match.
@@ -402,7 +405,10 @@ static sai_status_t dash_sai_create_{{ table.name }}(
         {% endif %}
         {% elif key.match_type == 'lpm' %}
         auto mf_lpm = mf->mutable_lpm();
-        {{key.field}}SetVal(tableEntry->{{ key.name | lower }}, mf_lpm, {{key.bitwidth}});
+        if ({{key.field}}SetVal(tableEntry->{{ key.name | lower }}, mf_lpm, {{key.bitwidth}}) != SAI_STATUS_SUCCESS) {
+            DASH_LOG_WARN("Failed to set lpm value for {{key.field}}");
+            return SAI_STATUS_SUCCESS;
+        }
         {% elif key.match_type == 'ternary' %}
         auto mf_ternary = mf->mutable_ternary();
         {{key.field}}SetVal(tableEntry->{{ key.name | lower }}, mf_ternary, {{key.bitwidth}});
@@ -583,7 +589,10 @@ static sai_status_t dash_sai_remove_{{ table.name }}(
         //{{key.field}}SetVal(tableEntry->{{ key.name | lower }}, mf_exact, {{key.bitwidth}});
         {% elif key.match_type == 'lpm' %}
         auto mf_lpm = mf->mutable_lpm();
-        {{key.field}}SetVal(tableEntry->{{ key.name | lower }}, mf_lpm, {{key.bitwidth}});
+        if ({{key.field}}SetVal(tableEntry->{{ key.name | lower }}, mf_lpm, {{key.bitwidth}}) != SAI_STATUS_SUCCESS) {
+            DASH_LOG_WARN("Failed to set lpm value for {{key.field}}");
+            return SAI_STATUS_SUCCESS;
+        }
         {% elif key.match_type == 'ternary' %}
         auto mf_ternary = mf->mutable_ternary();
         {{key.field}}SetVal(tableEntry->{{ key.name | lower }}, mf_ternary, {{key.bitwidth}});

--- a/dash-pipeline/SAI/templates/saiapi.cpp.j2
+++ b/dash-pipeline/SAI/templates/saiapi.cpp.j2
@@ -88,10 +88,7 @@ static sai_status_t dash_sai_create_{{ table.name }}(
                 {{key.field}}SetVal(attr_list[i].value, mf_exact, {{key.bitwidth}});
                 {% elif key.match_type == 'lpm' %}
                 auto mf_lpm = mf->mutable_lpm();
-                if ({{key.field}}SetVal(tableEntry->{{ key.name | lower }}, mf_lpm, {{key.bitwidth}}) != SAI_STATUS_SUCCESS) {
-                    DASH_LOG_WARN("Failed to set lpm value for {{key.field}}");
-                    return SAI_STATUS_SUCCESS;
-                }
+                {{key.field}}SetVal(attr_list[i].value, mf_lpm, {{key.bitwidth}});
                 {% elif key.match_type == 'list' %}
                 // BMv2 doesn't support "list" match type, and we are using "optional" match in v1model as our implementation.
                 // Hence, here we only take the first item from the list and program it as optional match.
@@ -405,10 +402,7 @@ static sai_status_t dash_sai_create_{{ table.name }}(
         {% endif %}
         {% elif key.match_type == 'lpm' %}
         auto mf_lpm = mf->mutable_lpm();
-        if ({{key.field}}SetVal(tableEntry->{{ key.name | lower }}, mf_lpm, {{key.bitwidth}}) != SAI_STATUS_SUCCESS) {
-            DASH_LOG_WARN("Failed to set lpm value for {{key.field}}");
-            return SAI_STATUS_SUCCESS;
-        }
+        {{key.field}}SetVal(tableEntry->{{ key.name | lower }}, mf_lpm, {{key.bitwidth}});
         {% elif key.match_type == 'ternary' %}
         auto mf_ternary = mf->mutable_ternary();
         {{key.field}}SetVal(tableEntry->{{ key.name | lower }}, mf_ternary, {{key.bitwidth}});
@@ -589,10 +583,7 @@ static sai_status_t dash_sai_remove_{{ table.name }}(
         //{{key.field}}SetVal(tableEntry->{{ key.name | lower }}, mf_exact, {{key.bitwidth}});
         {% elif key.match_type == 'lpm' %}
         auto mf_lpm = mf->mutable_lpm();
-        if ({{key.field}}SetVal(tableEntry->{{ key.name | lower }}, mf_lpm, {{key.bitwidth}}) != SAI_STATUS_SUCCESS) {
-            DASH_LOG_WARN("Failed to set lpm value for {{key.field}}");
-            return SAI_STATUS_SUCCESS;
-        }
+        {{key.field}}SetVal(tableEntry->{{ key.name | lower }}, mf_lpm, {{key.bitwidth}});
         {% elif key.match_type == 'ternary' %}
         auto mf_ternary = mf->mutable_ternary();
         {{key.field}}SetVal(tableEntry->{{ key.name | lower }}, mf_ternary, {{key.bitwidth}});


### PR DESCRIPTION
1.To set a default IPv6 route with the prefix 0, we will get following error logs. It's caused by the limitation of p4lang: https://github.com/p4lang/PI/blob/24e0a3c08c964e36d235973556b90e0ae922b894/proto/frontend/src/device_mgr.cpp#L2242-L2246 .

```
2024 Jun  3 15:26:21.033130 vlab-01 ERR syncd#syncd_dash: e:- mutateTableEntry: GRPC ERROR[2]: , #010#002#032¡#001#012#037type.googleapis.com/p4.v1.Error#022~#010#003#022gInvalid reprsentation of 'don't care' LPM match, omit match field instead of using a prefix length of 0#032#021ALL-sswitch-p4org
2024 Jun  3 15:26:21.033130 vlab-01 ERR syncd#syncd_dash: e:- mutateTableEntry: GRPC call Write::INSERT ERROR: table_id: 49279256 match { field_id: 1 lpm { value: "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000" } } action { action { action_id: 32404057 params { param_id: 1 value: "\000\000" } params { param_id: 2 value: "\000\000" } } }
```
In this case, I just ignore the default IPv6 route to skip this limitation.


2. Fix IPv6 prefix length function bug.
There are two issues on the IPv6 prefix:
- when we calculate the prefix length from the mask, we should consider the trailing zeros from high address space, aka, the end of mask array, of SAI IPv6 attribution. So, I revised this issue by reversing the IPv6 mask array.
- Because the function `leadingNonZeroBits` returns the exact length of prefix, we shouldn't directly subtract it from 129. For example, if the mask is 0xffffffffffffffffffffffff, the original implementation will get 129-0-32=97, it is obviously wrong. The correct answer is 128. So, I fix this bug.
