### PR TITLE
[dash-p4] Update DASH p4 code for generating the drop counters.

### DIFF
--- a/dash-pipeline/bmv2/dash_pipeline.p4
+++ b/dash-pipeline/bmv2/dash_pipeline.p4
@@ -43,6 +43,7 @@ control dash_ingress(
     action accept() {
     }
 
+    DEFINE_PACKET_COUNTER(vip_miss_drop_counter, 1, name="vip_miss_drop", attr_type="stats")
     DEFINE_COUNTER(port_lb_fast_path_icmp_in_counter, 1, name="lb_fast_path_icmp_in", attr_type="stats")
     
     @SaiTable[name = "vip", api = "dash_vip"]
@@ -211,6 +212,8 @@ control dash_ingress(
         const default_action = deny;
     }
 
+    DEFINE_PACKET_COUNTER(inbound_routing_entry_miss_drop, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=3)
+
     @SaiTable[name = "inbound_routing", api = "dash_inbound_routing"]
     table inbound_routing {
         key = {
@@ -276,7 +279,8 @@ control dash_ingress(
                present in the VIP table */
             meta.encap_data.underlay_sip = hdr.u0_ipv4.dst_addr;
         } else {
-            // TODO: Count the packet drops due to VIP miss
+            UPDATE_COUNTER(vip_miss_drop_counter, 0);
+
             if (meta.is_fast_path_icmp_flow_redirection_packet) {
             }
         }
@@ -296,6 +300,9 @@ control dash_ingress(
             switch (inbound_routing.apply().action_run) {
                 tunnel_decap_pa_validate: {
                     pa_validation.apply();
+                }
+                deny: {
+                    UPDATE_COUNTER(inbound_routing_entry_miss_drop, meta.eni_id);
                 }
             }
         }
@@ -327,7 +334,11 @@ control dash_ingress(
             meta.dst_l4_port = hdr.customer_udp.dst_port;
         }
 
-        eni.apply();
+        if (!eni.apply().hit) {
+            UPDATE_COUNTER(eni_miss_drop_counter, 0);
+            deny();
+        }
+
         if (meta.eni_data.admin_state == 0) {
             deny();
         }

--- a/dash-pipeline/bmv2/stages/eni_lookup.p4
+++ b/dash-pipeline/bmv2/stages/eni_lookup.p4
@@ -1,11 +1,13 @@
 #ifndef _DASH_STAGE_ENI_LOOKUP_P4_
 #define _DASH_STAGE_ENI_LOOKUP_P4_
 
+DEFINE_PACKET_COUNTER(eni_miss_drop_counter, 1, name="eni_miss_drop", attr_type="stats")
+
 control eni_lookup_stage(
     inout headers_t hdr,
     inout metadata_t meta)
 {
-    DEFINE_COUNTER(port_lb_fast_path_eni_miss_counter, 1, name="lb_fast_path_eni_miss", attr_type="stats")
+    DEFINE_COUNTER(port_lb_fast_path_eni_miss_drop_counter, 1, name="lb_fast_path_eni_miss_drop", attr_type="stats")
 
     action set_eni(@SaiVal[type="sai_object_id_t"] bit<16> eni_id) {
         meta.eni_id = eni_id;
@@ -35,8 +37,10 @@ control eni_lookup_stage(
                                           hdr.customer_ethernet.dst_addr;
                                           
         if (!eni_ether_address_map.apply().hit) {
+            UPDATE_COUNTER(eni_miss_drop_counter, 0);
+
             if (meta.is_fast_path_icmp_flow_redirection_packet) {
-                UPDATE_COUNTER(port_lb_fast_path_eni_miss_counter, 0);
+                UPDATE_COUNTER(port_lb_fast_path_eni_miss_drop_counter, 0);
             }
         }
     }

--- a/dash-pipeline/bmv2/stages/outbound_mapping.p4
+++ b/dash-pipeline/bmv2/stages/outbound_mapping.p4
@@ -3,6 +3,8 @@
 
 #include "../dash_routing_types.p4"
 
+DEFINE_PACKET_COUNTER(outbound_ca_pa_entry_miss_drop, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=3)
+
 control outbound_mapping_stage(inout headers_t hdr,
                       inout metadata_t meta)
 {
@@ -50,6 +52,9 @@ control outbound_mapping_stage(inout headers_t hdr,
         switch (ca_to_pa.apply().action_run) {
             set_tunnel_mapping: {
                 vnet.apply();
+            }
+            drop: {
+                UPDATE_COUNTER(outbound_ca_pa_entry_miss_drop, meta.eni_id);
             }
         }
     }

--- a/dash-pipeline/bmv2/stages/outbound_routing.p4
+++ b/dash-pipeline/bmv2/stages/outbound_routing.p4
@@ -3,6 +3,8 @@
 
 #include "../dash_routing_types.p4"
 
+DEFINE_PACKET_COUNTER(outbound_routing_entry_miss_drop, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=3)
+
 control outbound_routing_stage(inout headers_t hdr,
                                inout metadata_t meta)
 {
@@ -33,7 +35,9 @@ control outbound_routing_stage(inout headers_t hdr,
             return;
         }
 
-        routing.apply();
+        if (!routing.apply().hit) {
+            UPDATE_COUNTER(outbound_routing_entry_miss_drop, meta.eni_id);
+        }
     }
 }
 

--- a/documentation/high-avail/ha-api-hld.md
+++ b/documentation/high-avail/ha-api-hld.md
@@ -310,8 +310,8 @@ Since the packet could be dropped before it hits any ENI, e.g. ENI is not found,
 
 | SAI stats name | Description |
 | -------------- | ----------- |
-| SAI_PORT_STAT_ENI_MISS_DROP_PKTS | Number of packets that are dropped due to ENI not found. |
-| SAI_PORT_STAT_VIP_MISS_DROP_PKTS | Number of packets that are dropped due to VIP not found. |
+| SAI_PORT_STAT_ENI_MISS_DROP_PACKETS | Number of packets that are dropped due to ENI not found. |
+| SAI_PORT_STAT_VIP_MISS_DROP_PACKETS | Number of packets that are dropped due to VIP not found. |
 
 #### 4.7.2. HA set stats
 
@@ -415,10 +415,10 @@ When the packet is landed on the ENI going through each match stages, it might b
 
 | SAI stats name | Description |
 | -------------- | ----------- |
-| SAI_ENI_STAT_OUTBOUND_ROUTING_ENTRY_MISS_DROP_PKTS | Number of packets that are dropped due to outbound routing entry not found. |
-| SAI_ENI_STAT_OUTBOUND_CA_PA_ENTRY_MISS_DROP_PKTS | Number of packets that are dropped due to outbound routing entry not found. |
-| SAI_ENI_STAT_TUNNEL_MISS_DROP_PKTS | Number of packets that are dropped due to outbound routing entry not found. |
-| SAI_ENI_STAT_INBOUND_ROUTING_MISS_DROP_PKTS | Number of packets that are dropped due to outbound routing entry not found. |
+| SAI_ENI_STAT_OUTBOUND_ROUTING_ENTRY_MISS_DROP_PACKETS | Number of packets that are dropped due to outbound routing entry not found. |
+| SAI_ENI_STAT_OUTBOUND_CA_PA_ENTRY_MISS_DROP_PACKETS | Number of packets that are dropped due to outbound routing entry not found. |
+| SAI_ENI_STAT_TUNNEL_MISS_DROP_PACKETS | Number of packets that are dropped due to outbound routing entry not found. |
+| SAI_ENI_STAT_INBOUND_ROUTING_MISS_DROP_PACKETS| Number of packets that are dropped due to outbound routing entry not found. |
 
 ### 4.8. Capability
 


### PR DESCRIPTION
This change follows the drop counter HLD to add the drop counters into DASH p4 code for generating the drop counters on port stats and ENI stats.

The detailed HLD is here: https://github.com/sonic-net/DASH/pull/563.