### PR TITLE
[dash-p4] Refactor global and ENI counter definitions.

### DIFF
--- a/dash-pipeline/bmv2/dash_counters.p4
+++ b/dash-pipeline/bmv2/dash_counters.p4
@@ -1,8 +1,8 @@
 //
 // This file is used for defining the global and ENI counters inside DASH.
 //
-// These counters are added here, because they are special and working more like "global" counters, and spreaded across the pipoeline.
-// This helps us to have a better view and helps us maintaining the ABI compatibiity of these counters.
+// These counters are added here, because they are special and working more like "global" counters, and spread across the pipeline.
+// This helps us to have a better view and helps us maintaining the ABI compatibility of these counters.
 //
 // The other counters will go with its table, such as HA set, because they are only used in logic that is related to that single table.
 // 
@@ -93,7 +93,7 @@ DEFINE_ENI_FLOW_SYNC_COUNTERS(flow_update)
 DEFINE_ENI_FLOW_SYNC_COUNTERS(flow_delete)
 
 //
-// ENI-level drop counters
+// ENI-level drop counters:
 //
 DEFINE_ENI_PACKET_COUNTER(outbound_routing_entry_miss_drop, order=3)
 DEFINE_ENI_PACKET_COUNTER(outbound_ca_pa_entry_miss_drop, order=3)

--- a/dash-pipeline/bmv2/dash_counters.p4
+++ b/dash-pipeline/bmv2/dash_counters.p4
@@ -1,0 +1,87 @@
+//
+// This file is used for defining the global and ENI counters inside DASH.
+//
+// These counters are added here, because they are special and working more like "global" counters, and spreaded across the pipoeline.
+// This helps us to have a better view and helps us maintaining the ABI compatibiity of these counters.
+//
+// The other counters will go with its table, such as HA set, because they are only used in logic that is related to that single table.
+// 
+
+#ifndef __DASH_COUNTERS__
+#define __DASH_COUNTERS__
+
+//
+// Port level counters
+//
+DEFINE_PACKET_COUNTER(vip_miss_drop, 1, attr_type="stats")
+DEFINE_PACKET_COUNTER(eni_miss_drop, 1, attr_type="stats")
+DEFINE_COUNTER(port_lb_fast_path_icmp_in, 1, attr_type="stats")
+DEFINE_COUNTER(port_lb_fast_path_eni_miss_drop, 1, attr_type="stats")
+
+//
+// ENI level counters:
+//
+DEFINE_COUNTER(eni_rx, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=0)
+DEFINE_COUNTER(eni_tx, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=0)
+DEFINE_COUNTER(eni_outbound_rx, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=0)
+DEFINE_COUNTER(eni_outbound_tx, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=0)
+DEFINE_COUNTER(eni_inbound_rx, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=0)
+DEFINE_COUNTER(eni_inbound_tx, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=0)
+DEFINE_COUNTER(eni_lb_fast_path_icmp_in, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=0)
+
+//
+// ENI-level flow operation counters:
+//
+DEFINE_HIT_COUNTER(flow_created, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=1)
+DEFINE_HIT_COUNTER(flow_create_failed, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=1)
+DEFINE_HIT_COUNTER(flow_updated, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=1)
+DEFINE_HIT_COUNTER(flow_update_failed, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=1)
+DEFINE_HIT_COUNTER(flow_deleted, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=1)
+DEFINE_HIT_COUNTER(flow_delete_failed, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=1)
+DEFINE_HIT_COUNTER(flow_aged, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=1)
+
+//
+// ENI-level data plane flow sync packet counters:
+//
+DEFINE_COUNTER(inline_sync_packet_rx, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=2)
+DEFINE_COUNTER(inline_sync_packet_tx, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=2)
+DEFINE_COUNTER(timed_sync_packet_rx, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=2)
+DEFINE_COUNTER(timed_sync_packet_tx, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=2)
+
+//
+// ENI-level data plane flow sync request counters:
+// - Depends on implementations, the flow sync request could be batched, hence they need to tracked separately.
+// - The counters are defined as combination of following things:
+//   - 3 flow sync operations: create, update, delete.
+//   - 2 ways of sync: Inline sync and timed sync.
+//   - Request result: succeeded, failed (unexpected) and ignored (expected and ok to ignore, e.g., more packets arrives before flow sync is acked).
+//
+#define DEFINE_ENI_FLOW_SYNC_COUNTERS(counter_name) \
+    DEFINE_HIT_COUNTER(inline_ ## counter_name ## _req_sent, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=2) \
+    DEFINE_HIT_COUNTER(inline_ ## counter_name ## _req_recv, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=2) \
+    DEFINE_HIT_COUNTER(inline_ ## counter_name ## _req_failed, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=2) \
+    DEFINE_HIT_COUNTER(inline_ ## counter_name ## _req_ignored, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=2) \
+    DEFINE_HIT_COUNTER(inline_ ## counter_name ## _ack_recv, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=2) \
+    DEFINE_HIT_COUNTER(inline_ ## counter_name ## _ack_failed, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=2) \
+    DEFINE_HIT_COUNTER(inline_ ## counter_name ## _ack_ignored, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=2) \
+    \
+    DEFINE_HIT_COUNTER(timed_ ## counter_name ## _req_sent, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=2) \
+    DEFINE_HIT_COUNTER(timed_ ## counter_name ## _req_recv, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=2) \
+    DEFINE_HIT_COUNTER(timed_ ## counter_name ## _req_failed, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=2) \
+    DEFINE_HIT_COUNTER(timed_ ## counter_name ## _req_ignored, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=2) \
+    DEFINE_HIT_COUNTER(timed_ ## counter_name ## _ack_recv, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=2) \
+    DEFINE_HIT_COUNTER(timed_ ## counter_name ## _ack_failed, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=2) \
+    DEFINE_HIT_COUNTER(timed_ ## counter_name ## _ack_ignored, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=2)
+
+DEFINE_ENI_FLOW_SYNC_COUNTERS(flow_create)
+DEFINE_ENI_FLOW_SYNC_COUNTERS(flow_update)
+DEFINE_ENI_FLOW_SYNC_COUNTERS(flow_delete)
+
+//
+// ENI-level drop counters
+//
+DEFINE_PACKET_COUNTER(outbound_routing_entry_miss_drop, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=3)
+DEFINE_PACKET_COUNTER(outbound_ca_pa_entry_miss_drop, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=3)
+DEFINE_PACKET_COUNTER(inbound_routing_entry_miss_drop, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=3)
+
+#endif // __DASH_COUNTERS__

--- a/dash-pipeline/bmv2/dash_counters.p4
+++ b/dash-pipeline/bmv2/dash_counters.p4
@@ -36,13 +36,13 @@ DEFINE_COUNTER(port_lb_fast_path_eni_miss_drop, 1, attr_type="stats")
 #define UPDATE_ENI_COUNTER(name) \
     UPDATE_COUNTER(name, meta.eni_id)
 
-DEFINE_ENI_COUNTER(eni_rx, name="rx", order=0)
-DEFINE_ENI_COUNTER(eni_tx, name="tx", order=0)
-DEFINE_ENI_COUNTER(eni_outbound_rx, name="outbound_rx", order=0)
-DEFINE_ENI_COUNTER(eni_outbound_tx, name="outbound_tx", order=0)
-DEFINE_ENI_COUNTER(eni_inbound_rx, name="inbound_rx", order=0)
-DEFINE_ENI_COUNTER(eni_inbound_tx, name="inbound_tx", order=0)
-DEFINE_ENI_COUNTER(eni_lb_fast_path_icmp_in, name="lb_fast_path_icmp_in", order=0)
+DEFINE_ENI_COUNTER(eni_rx, order=0, name="rx")
+DEFINE_ENI_COUNTER(eni_tx, order=0, name="tx")
+DEFINE_ENI_COUNTER(eni_outbound_rx, order=0, name="outbound_rx")
+DEFINE_ENI_COUNTER(eni_outbound_tx, order=0, name="outbound_tx")
+DEFINE_ENI_COUNTER(eni_inbound_rx, order=0, name="inbound_rx")
+DEFINE_ENI_COUNTER(eni_inbound_tx, order=0, name="inbound_tx")
+DEFINE_ENI_COUNTER(eni_lb_fast_path_icmp_in, order=0, name="lb_fast_path_icmp_in")
 
 //
 // ENI-level flow operation counters:

--- a/dash-pipeline/bmv2/dash_counters.p4
+++ b/dash-pipeline/bmv2/dash_counters.p4
@@ -36,13 +36,13 @@ DEFINE_COUNTER(port_lb_fast_path_eni_miss_drop, 1, attr_type="stats")
 #define UPDATE_ENI_COUNTER(name) \
     UPDATE_COUNTER(name, meta.eni_id)
 
-DEFINE_ENI_COUNTER(eni_rx, order=0)
-DEFINE_ENI_COUNTER(eni_tx, order=0)
-DEFINE_ENI_COUNTER(eni_outbound_rx, order=0)
-DEFINE_ENI_COUNTER(eni_outbound_tx, order=0)
-DEFINE_ENI_COUNTER(eni_inbound_rx, order=0)
-DEFINE_ENI_COUNTER(eni_inbound_tx, order=0)
-DEFINE_ENI_COUNTER(eni_lb_fast_path_icmp_in, order=0)
+DEFINE_ENI_COUNTER(eni_rx, name="rx", order=0)
+DEFINE_ENI_COUNTER(eni_tx, name="tx", order=0)
+DEFINE_ENI_COUNTER(eni_outbound_rx, name="outbound_rx", order=0)
+DEFINE_ENI_COUNTER(eni_outbound_tx, name="outbound_tx", order=0)
+DEFINE_ENI_COUNTER(eni_inbound_rx, name="inbound_rx", order=0)
+DEFINE_ENI_COUNTER(eni_inbound_tx, name="inbound_tx", order=0)
+DEFINE_ENI_COUNTER(eni_lb_fast_path_icmp_in, name="lb_fast_path_icmp_in", order=0)
 
 //
 // ENI-level flow operation counters:

--- a/dash-pipeline/bmv2/dash_counters.p4
+++ b/dash-pipeline/bmv2/dash_counters.p4
@@ -21,32 +21,47 @@ DEFINE_COUNTER(port_lb_fast_path_eni_miss_drop, 1, attr_type="stats")
 //
 // ENI level counters:
 //
-DEFINE_COUNTER(eni_rx, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=0)
-DEFINE_COUNTER(eni_tx, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=0)
-DEFINE_COUNTER(eni_outbound_rx, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=0)
-DEFINE_COUNTER(eni_outbound_tx, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=0)
-DEFINE_COUNTER(eni_inbound_rx, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=0)
-DEFINE_COUNTER(eni_inbound_tx, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=0)
-DEFINE_COUNTER(eni_lb_fast_path_icmp_in, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=0)
+#define DEFINE_ENI_COUNTER(name, ...) \
+    DEFINE_COUNTER(name, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", __VA_ARGS__)
+
+#define DEFINE_ENI_PACKET_COUNTER(name, ...) \
+    DEFINE_PACKET_COUNTER(name, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", __VA_ARGS__)
+
+#define DEFINE_ENI_BYTE_COUNTER(name, count, ...) \
+    DEFINE_BYTE_COUNTER(name, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", __VA_ARGS__)
+
+#define DEFINE_ENI_HIT_COUNTER(name, ...) \
+    DEFINE_HIT_COUNTER(name, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", __VA_ARGS__)
+
+#define UPDATE_ENI_COUNTER(name) \
+    UPDATE_COUNTER(name, meta.eni_id)
+
+DEFINE_ENI_COUNTER(eni_rx, order=0)
+DEFINE_ENI_COUNTER(eni_tx, order=0)
+DEFINE_ENI_COUNTER(eni_outbound_rx, order=0)
+DEFINE_ENI_COUNTER(eni_outbound_tx, order=0)
+DEFINE_ENI_COUNTER(eni_inbound_rx, order=0)
+DEFINE_ENI_COUNTER(eni_inbound_tx, order=0)
+DEFINE_ENI_COUNTER(eni_lb_fast_path_icmp_in, order=0)
 
 //
 // ENI-level flow operation counters:
 //
-DEFINE_HIT_COUNTER(flow_created, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=1)
-DEFINE_HIT_COUNTER(flow_create_failed, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=1)
-DEFINE_HIT_COUNTER(flow_updated, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=1)
-DEFINE_HIT_COUNTER(flow_update_failed, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=1)
-DEFINE_HIT_COUNTER(flow_deleted, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=1)
-DEFINE_HIT_COUNTER(flow_delete_failed, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=1)
-DEFINE_HIT_COUNTER(flow_aged, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=1)
+DEFINE_ENI_HIT_COUNTER(flow_created, order=1)
+DEFINE_ENI_HIT_COUNTER(flow_create_failed, order=1)
+DEFINE_ENI_HIT_COUNTER(flow_updated, order=1)
+DEFINE_ENI_HIT_COUNTER(flow_update_failed, order=1)
+DEFINE_ENI_HIT_COUNTER(flow_deleted, order=1)
+DEFINE_ENI_HIT_COUNTER(flow_delete_failed, order=1)
+DEFINE_ENI_HIT_COUNTER(flow_aged, order=1)
 
 //
 // ENI-level data plane flow sync packet counters:
 //
-DEFINE_COUNTER(inline_sync_packet_rx, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=2)
-DEFINE_COUNTER(inline_sync_packet_tx, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=2)
-DEFINE_COUNTER(timed_sync_packet_rx, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=2)
-DEFINE_COUNTER(timed_sync_packet_tx, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=2)
+DEFINE_ENI_COUNTER(inline_sync_packet_rx, order=2)
+DEFINE_ENI_COUNTER(inline_sync_packet_tx, order=2)
+DEFINE_ENI_COUNTER(timed_sync_packet_rx, order=2)
+DEFINE_ENI_COUNTER(timed_sync_packet_tx, order=2)
 
 //
 // ENI-level data plane flow sync request counters:
@@ -57,21 +72,21 @@ DEFINE_COUNTER(timed_sync_packet_tx, MAX_ENI, attr_type="stats", action_names="s
 //   - Request result: succeeded, failed (unexpected) and ignored (expected and ok to ignore, e.g., more packets arrives before flow sync is acked).
 //
 #define DEFINE_ENI_FLOW_SYNC_COUNTERS(counter_name) \
-    DEFINE_HIT_COUNTER(inline_ ## counter_name ## _req_sent, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=2) \
-    DEFINE_HIT_COUNTER(inline_ ## counter_name ## _req_recv, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=2) \
-    DEFINE_HIT_COUNTER(inline_ ## counter_name ## _req_failed, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=2) \
-    DEFINE_HIT_COUNTER(inline_ ## counter_name ## _req_ignored, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=2) \
-    DEFINE_HIT_COUNTER(inline_ ## counter_name ## _ack_recv, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=2) \
-    DEFINE_HIT_COUNTER(inline_ ## counter_name ## _ack_failed, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=2) \
-    DEFINE_HIT_COUNTER(inline_ ## counter_name ## _ack_ignored, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=2) \
+    DEFINE_ENI_HIT_COUNTER(inline_ ## counter_name ## _req_sent, order=2) \
+    DEFINE_ENI_HIT_COUNTER(inline_ ## counter_name ## _req_recv, order=2) \
+    DEFINE_ENI_HIT_COUNTER(inline_ ## counter_name ## _req_failed, order=2) \
+    DEFINE_ENI_HIT_COUNTER(inline_ ## counter_name ## _req_ignored, order=2) \
+    DEFINE_ENI_HIT_COUNTER(inline_ ## counter_name ## _ack_recv, order=2) \
+    DEFINE_ENI_HIT_COUNTER(inline_ ## counter_name ## _ack_failed, order=2) \
+    DEFINE_ENI_HIT_COUNTER(inline_ ## counter_name ## _ack_ignored, order=2) \
     \
-    DEFINE_HIT_COUNTER(timed_ ## counter_name ## _req_sent, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=2) \
-    DEFINE_HIT_COUNTER(timed_ ## counter_name ## _req_recv, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=2) \
-    DEFINE_HIT_COUNTER(timed_ ## counter_name ## _req_failed, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=2) \
-    DEFINE_HIT_COUNTER(timed_ ## counter_name ## _req_ignored, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=2) \
-    DEFINE_HIT_COUNTER(timed_ ## counter_name ## _ack_recv, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=2) \
-    DEFINE_HIT_COUNTER(timed_ ## counter_name ## _ack_failed, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=2) \
-    DEFINE_HIT_COUNTER(timed_ ## counter_name ## _ack_ignored, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=2)
+    DEFINE_ENI_HIT_COUNTER(timed_ ## counter_name ## _req_sent, order=2) \
+    DEFINE_ENI_HIT_COUNTER(timed_ ## counter_name ## _req_recv, order=2) \
+    DEFINE_ENI_HIT_COUNTER(timed_ ## counter_name ## _req_failed, order=2) \
+    DEFINE_ENI_HIT_COUNTER(timed_ ## counter_name ## _req_ignored, order=2) \
+    DEFINE_ENI_HIT_COUNTER(timed_ ## counter_name ## _ack_recv, order=2) \
+    DEFINE_ENI_HIT_COUNTER(timed_ ## counter_name ## _ack_failed, order=2) \
+    DEFINE_ENI_HIT_COUNTER(timed_ ## counter_name ## _ack_ignored, order=2)
 
 DEFINE_ENI_FLOW_SYNC_COUNTERS(flow_create)
 DEFINE_ENI_FLOW_SYNC_COUNTERS(flow_update)
@@ -80,8 +95,8 @@ DEFINE_ENI_FLOW_SYNC_COUNTERS(flow_delete)
 //
 // ENI-level drop counters
 //
-DEFINE_PACKET_COUNTER(outbound_routing_entry_miss_drop, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=3)
-DEFINE_PACKET_COUNTER(outbound_ca_pa_entry_miss_drop, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=3)
-DEFINE_PACKET_COUNTER(inbound_routing_entry_miss_drop, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=3)
+DEFINE_ENI_PACKET_COUNTER(outbound_routing_entry_miss_drop, order=3)
+DEFINE_ENI_PACKET_COUNTER(outbound_ca_pa_entry_miss_drop, order=3)
+DEFINE_ENI_PACKET_COUNTER(inbound_routing_entry_miss_drop, order=3)
 
 #endif // __DASH_COUNTERS__

--- a/dash-pipeline/bmv2/dash_pipeline.p4
+++ b/dash-pipeline/bmv2/dash_pipeline.p4
@@ -290,7 +290,7 @@ control dash_ingress(
                     pa_validation.apply();
                 }
                 deny: {
-                    UPDATE_COUNTER(inbound_routing_entry_miss_drop, meta.eni_id);
+                    UPDATE_ENI_COUNTER(inbound_routing_entry_miss_drop);
                 }
             }
         }
@@ -331,9 +331,9 @@ control dash_ingress(
             deny();
         }
         
-        UPDATE_COUNTER(eni_rx, meta.eni_id);
+        UPDATE_ENI_COUNTER(eni_rx);
         if (meta.is_fast_path_icmp_flow_redirection_packet) {
-            UPDATE_COUNTER(eni_lb_fast_path_icmp_in, meta.eni_id);
+            UPDATE_ENI_COUNTER(eni_lb_fast_path_icmp_in);
         }
 
         ha_stage.apply(hdr, meta);
@@ -341,12 +341,12 @@ control dash_ingress(
         acl_group.apply();
 
         if (meta.direction == dash_direction_t.OUTBOUND) {
-            UPDATE_COUNTER(eni_outbound_rx, meta.eni_id);
+            UPDATE_ENI_COUNTER(eni_outbound_rx);
 
             meta.target_stage = dash_pipeline_stage_t.OUTBOUND_ROUTING;
             outbound.apply(hdr, meta);
         } else if (meta.direction == dash_direction_t.INBOUND) {
-            UPDATE_COUNTER(eni_inbound_rx, meta.eni_id);
+            UPDATE_ENI_COUNTER(eni_inbound_rx);
             inbound.apply(hdr, meta);
         }
 
@@ -375,12 +375,12 @@ control dash_ingress(
         if (meta.dropped) {
             drop_action();
         } else {
-            UPDATE_COUNTER(eni_tx, meta.eni_id);
+            UPDATE_ENI_COUNTER(eni_tx);
 
             if (meta.direction == dash_direction_t.OUTBOUND) {
-                UPDATE_COUNTER(eni_outbound_tx, meta.eni_id);
+                UPDATE_ENI_COUNTER(eni_outbound_tx);
             } else if (meta.direction == dash_direction_t.INBOUND) {
-                UPDATE_COUNTER(eni_inbound_tx, meta.eni_id);
+                UPDATE_ENI_COUNTER(eni_inbound_tx);
             }
         }
     }

--- a/dash-pipeline/bmv2/stages/eni_lookup.p4
+++ b/dash-pipeline/bmv2/stages/eni_lookup.p4
@@ -1,14 +1,10 @@
 #ifndef _DASH_STAGE_ENI_LOOKUP_P4_
 #define _DASH_STAGE_ENI_LOOKUP_P4_
 
-DEFINE_PACKET_COUNTER(eni_miss_drop_counter, 1, name="eni_miss_drop", attr_type="stats")
-
 control eni_lookup_stage(
     inout headers_t hdr,
     inout metadata_t meta)
 {
-    DEFINE_COUNTER(port_lb_fast_path_eni_miss_drop_counter, 1, name="lb_fast_path_eni_miss_drop", attr_type="stats")
-
     action set_eni(@SaiVal[type="sai_object_id_t"] bit<16> eni_id) {
         meta.eni_id = eni_id;
     }
@@ -37,10 +33,10 @@ control eni_lookup_stage(
                                           hdr.customer_ethernet.dst_addr;
                                           
         if (!eni_ether_address_map.apply().hit) {
-            UPDATE_COUNTER(eni_miss_drop_counter, 0);
+            UPDATE_COUNTER(eni_miss_drop, 0);
 
             if (meta.is_fast_path_icmp_flow_redirection_packet) {
-                UPDATE_COUNTER(port_lb_fast_path_eni_miss_drop_counter, 0);
+                UPDATE_COUNTER(port_lb_fast_path_eni_miss_drop, 0);
             }
         }
     }

--- a/dash-pipeline/bmv2/stages/ha.p4
+++ b/dash-pipeline/bmv2/stages/ha.p4
@@ -5,54 +5,6 @@ control ha_stage(inout headers_t hdr,
                  inout metadata_t meta)
 {
     //
-    // ENI-level flow operation counters:
-    //
-    DEFINE_HIT_COUNTER(flow_created_counter, MAX_ENI, name="flow_created", attr_type="stats", action_names="set_eni_attrs", order=1)
-    DEFINE_HIT_COUNTER(flow_create_failed_counter, MAX_ENI, name="flow_create_failed", attr_type="stats", action_names="set_eni_attrs", order=1)
-    DEFINE_HIT_COUNTER(flow_updated_counter, MAX_ENI, name="flow_updated", attr_type="stats", action_names="set_eni_attrs", order=1)
-    DEFINE_HIT_COUNTER(flow_update_failed_counter, MAX_ENI, name="flow_update_failed", attr_type="stats", action_names="set_eni_attrs", order=1)
-    DEFINE_HIT_COUNTER(flow_deleted_counter, MAX_ENI, name="flow_deleted", attr_type="stats", action_names="set_eni_attrs", order=1)
-    DEFINE_HIT_COUNTER(flow_delete_failed_counter, MAX_ENI, name="flow_delete_failed", attr_type="stats", action_names="set_eni_attrs", order=1)
-    DEFINE_HIT_COUNTER(flow_aged_counter, MAX_ENI, name="flow_aged", attr_type="stats", action_names="set_eni_attrs", order=1)
-
-    //
-    // ENI-level data plane flow sync packet counters:
-    //
-    DEFINE_COUNTER(inline_sync_packet_rx_counter, MAX_ENI, name="inline_sync_packet_rx", attr_type="stats", action_names="set_eni_attrs", order=2)
-    DEFINE_COUNTER(inline_sync_packet_tx_counter, MAX_ENI, name="inline_sync_packet_tx", attr_type="stats", action_names="set_eni_attrs", order=2)
-    DEFINE_COUNTER(timed_sync_packet_rx_counter, MAX_ENI, name="timed_sync_packet_rx", attr_type="stats", action_names="set_eni_attrs", order=2)
-    DEFINE_COUNTER(timed_sync_packet_tx_counter, MAX_ENI, name="timed_sync_packet_tx", attr_type="stats", action_names="set_eni_attrs", order=2)
-
-    //
-    // ENI-level data plane flow sync request counters:
-    // - Depends on implementations, the flow sync request could be batched, hence they need to tracked separately.
-    // - The counters are defined as combination of following things:
-    //   - 3 flow sync operations: create, update, delete.
-    //   - 2 ways of sync: Inline sync and timed sync.
-    //   - Request result: succeeded, failed (unexpected) and ignored (expected and ok to ignore, e.g., more packets arrives before flow sync is acked).
-    //
-    #define DEFINE_ENI_FLOW_SYNC_COUNTERS(counter_name) \
-        DEFINE_HIT_COUNTER(inline_ ## counter_name ## _req_sent_counter, MAX_ENI, name=PP_STR(inline_ ## counter_name ## _req_sent), attr_type="stats", action_names="set_eni_attrs", order=2) \
-        DEFINE_HIT_COUNTER(inline_ ## counter_name ## _req_recv_counter, MAX_ENI, name=PP_STR(inline_ ## counter_name ## _req_recv), attr_type="stats", action_names="set_eni_attrs", order=2) \
-        DEFINE_HIT_COUNTER(inline_ ## counter_name ## _req_failed_counter, MAX_ENI, name=PP_STR(inline_ ## counter_name ## _req_failed), attr_type="stats", action_names="set_eni_attrs", order=2) \
-        DEFINE_HIT_COUNTER(inline_ ## counter_name ## _req_ignored_counter, MAX_ENI, name=PP_STR(inline_ ## counter_name ## _req_failed), attr_type="stats", action_names="set_eni_attrs", order=2) \
-        DEFINE_HIT_COUNTER(inline_ ## counter_name ## _ack_recv_counter, MAX_ENI, name=PP_STR(inline_ ## counter_name ## _ack_recv), attr_type="stats", action_names="set_eni_attrs", order=2) \
-        DEFINE_HIT_COUNTER(inline_ ## counter_name ## _ack_failed_counter, MAX_ENI, name=PP_STR(inline_ ## counter_name ## _ack_failed_recv), attr_type="stats", action_names="set_eni_attrs", order=2) \
-        DEFINE_HIT_COUNTER(inline_ ## counter_name ## _ack_ignored_counter, MAX_ENI, name=PP_STR(inline_ ## counter_name ## _ack_ignored_recv), attr_type="stats", action_names="set_eni_attrs", order=2) \
-        \
-        DEFINE_HIT_COUNTER(timed_ ## counter_name ## _req_sent_counter, MAX_ENI, name=PP_STR(timed_ ## counter_name ## _req_sent), attr_type="stats", action_names="set_eni_attrs", order=2) \
-        DEFINE_HIT_COUNTER(timed_ ## counter_name ## _req_recv_counter, MAX_ENI, name=PP_STR(timed_ ## counter_name ## _req_recv), attr_type="stats", action_names="set_eni_attrs", order=2) \
-        DEFINE_HIT_COUNTER(timed_ ## counter_name ## _req_failed_counter, MAX_ENI, name=PP_STR(timed_ ## counter_name ## _req_failed), attr_type="stats", action_names="set_eni_attrs", order=2) \
-        DEFINE_HIT_COUNTER(timed_ ## counter_name ## _req_ignored_counter, MAX_ENI, name=PP_STR(timed_ ## counter_name ## _req_failed), attr_type="stats", action_names="set_eni_attrs", order=2) \
-        DEFINE_HIT_COUNTER(timed_ ## counter_name ## _ack_recv_counter, MAX_ENI, name=PP_STR(timed_ ## counter_name ## _ack_recv), attr_type="stats", action_names="set_eni_attrs", order=2) \
-        DEFINE_HIT_COUNTER(timed_ ## counter_name ## _ack_failed_counter, MAX_ENI, name=PP_STR(timed_ ## counter_name ## _ack_failed_recv), attr_type="stats", action_names="set_eni_attrs", order=2) \
-        DEFINE_HIT_COUNTER(timed_ ## counter_name ## _ack_ignored_counter, MAX_ENI, name=PP_STR(timed_ ## counter_name ## _ack_ignored_recv), attr_type="stats", action_names="set_eni_attrs", order=2)
-
-    DEFINE_ENI_FLOW_SYNC_COUNTERS(flow_create)
-    DEFINE_ENI_FLOW_SYNC_COUNTERS(flow_update)
-    DEFINE_ENI_FLOW_SYNC_COUNTERS(flow_delete)
-
-    //
     // HA scope:
     //
     action set_ha_scope_attr(

--- a/dash-pipeline/bmv2/stages/outbound_mapping.p4
+++ b/dash-pipeline/bmv2/stages/outbound_mapping.p4
@@ -52,7 +52,7 @@ control outbound_mapping_stage(inout headers_t hdr,
                 vnet.apply();
             }
             drop: {
-                UPDATE_COUNTER(outbound_ca_pa_entry_miss_drop, meta.eni_id);
+                UPDATE_ENI_COUNTER(outbound_ca_pa_entry_miss_drop);
             }
         }
     }

--- a/dash-pipeline/bmv2/stages/outbound_mapping.p4
+++ b/dash-pipeline/bmv2/stages/outbound_mapping.p4
@@ -3,8 +3,6 @@
 
 #include "../dash_routing_types.p4"
 
-DEFINE_PACKET_COUNTER(outbound_ca_pa_entry_miss_drop, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=3)
-
 control outbound_mapping_stage(inout headers_t hdr,
                       inout metadata_t meta)
 {

--- a/dash-pipeline/bmv2/stages/outbound_routing.p4
+++ b/dash-pipeline/bmv2/stages/outbound_routing.p4
@@ -34,7 +34,7 @@ control outbound_routing_stage(inout headers_t hdr,
         }
 
         if (!routing.apply().hit) {
-            UPDATE_COUNTER(outbound_routing_entry_miss_drop, meta.eni_id);
+            UPDATE_ENI_COUNTER(outbound_routing_entry_miss_drop);
         }
     }
 }

--- a/dash-pipeline/bmv2/stages/outbound_routing.p4
+++ b/dash-pipeline/bmv2/stages/outbound_routing.p4
@@ -3,8 +3,6 @@
 
 #include "../dash_routing_types.p4"
 
-DEFINE_PACKET_COUNTER(outbound_routing_entry_miss_drop, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", order=3)
-
 control outbound_routing_stage(inout headers_t hdr,
                                inout metadata_t meta)
 {


### PR DESCRIPTION
Moving the global and ENI counters from all over the places to a dedicated file, because they are special and working more like "global" counters, and spread across the pipeline.

This helps us to have a better view and helps us maintaining the ABI compatibility of these counters.

The other counters will go with its table, such as HA set, because they are only used in logic that is related to that single table.