### PR TITLE
[dash-p4] Refactor incoming packet encap handling and inbound routing stage.

### DIFF
--- a/dash-pipeline/SAI/specs/dash_appliance.yaml
+++ b/dash-pipeline/SAI/specs/dash_appliance.yaml
@@ -27,9 +27,9 @@ sai_apis:
   p4_meta: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4Meta
     tables:
     - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
-      id: 42701762
+      id: 41082190
       actions:
         default: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaAction
           name: default
-          id: 21793905
+          id: 29775410
           attr_param_id: {}

--- a/dash-pipeline/SAI/specs/dash_inbound_routing.yaml
+++ b/dash-pipeline/SAI/specs/dash_inbound_routing.yaml
@@ -141,26 +141,26 @@ sai_apis:
   p4_meta: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4Meta
     tables:
     - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
-      id: 38920290
+      id: 48545572
       actions:
         SAI_INBOUND_ROUTING_ENTRY_ACTION_TUNNEL_DECAP: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaAction
           name: SAI_INBOUND_ROUTING_ENTRY_ACTION_TUNNEL_DECAP
-          id: 22253429
+          id: 20241846
           attr_param_id:
             SAI_INBOUND_ROUTING_ENTRY_ATTR_METER_CLASS_OR: 1
             SAI_INBOUND_ROUTING_ENTRY_ATTR_METER_CLASS_AND: 2
         SAI_INBOUND_ROUTING_ENTRY_ACTION_TUNNEL_DECAP_PA_VALIDATE: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaAction
           name: SAI_INBOUND_ROUTING_ENTRY_ACTION_TUNNEL_DECAP_PA_VALIDATE
-          id: 27987616
+          id: 32575252
           attr_param_id:
             SAI_INBOUND_ROUTING_ENTRY_ATTR_SRC_VNET_ID: 1
             SAI_INBOUND_ROUTING_ENTRY_ATTR_METER_CLASS_OR: 2
             SAI_INBOUND_ROUTING_ENTRY_ATTR_METER_CLASS_AND: 3
         SAI_INBOUND_ROUTING_ENTRY_ACTION_VXLAN_DECAP: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaAction
           name: SAI_INBOUND_ROUTING_ENTRY_ACTION_VXLAN_DECAP
-          id: 32581635
+          id: 30272260
           attr_param_id: {}
         SAI_INBOUND_ROUTING_ENTRY_ACTION_VXLAN_DECAP_PA_VALIDATE: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaAction
           name: SAI_INBOUND_ROUTING_ENTRY_ACTION_VXLAN_DECAP_PA_VALIDATE
-          id: 22711915
+          id: 24066060
           attr_param_id: {}

--- a/dash-pipeline/SAI/specs/dash_pa_validation.yaml
+++ b/dash-pipeline/SAI/specs/dash_pa_validation.yaml
@@ -70,9 +70,9 @@ sai_apis:
   p4_meta: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4Meta
     tables:
     - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
-      id: 35526612
+      id: 41827129
       actions:
         SAI_PA_VALIDATION_ENTRY_ACTION_PERMIT: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaAction
           name: SAI_PA_VALIDATION_ENTRY_ACTION_PERMIT
-          id: 32591400
+          id: 31497578
           attr_param_id: {}

--- a/dash-pipeline/SAI/specs/dash_vip.yaml
+++ b/dash-pipeline/SAI/specs/dash_vip.yaml
@@ -64,9 +64,9 @@ sai_apis:
   p4_meta: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4Meta
     tables:
     - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
-      id: 45245089
+      id: 43450617
       actions:
         SAI_VIP_ENTRY_ACTION_ACCEPT: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaAction
           name: SAI_VIP_ENTRY_ACTION_ACCEPT
-          id: 26041632
+          id: 22888270
           attr_param_id: {}

--- a/dash-pipeline/bmv2/dash_inbound.p4
+++ b/dash-pipeline/bmv2/dash_inbound.p4
@@ -6,6 +6,7 @@
 #include "dash_acl.p4"
 #include "routing_actions/routing_actions.p4"
 #include "dash_conntrack.p4"
+#include "stages/inbound_routing.p4"
 
 control inbound(inout headers_t hdr,
                 inout metadata_t meta)
@@ -28,11 +29,13 @@ control inbound(inout headers_t hdr,
         }
 
 #ifdef STATEFUL_P4
-            ConntrackOut.apply(1);
+        ConntrackOut.apply(1);
 #endif /* STATEFUL_P4 */
 #ifdef PNA_CONNTRACK
         ConntrackOut.apply(hdr, meta);
 #endif //PNA_CONNTRACK
+
+        inbound_routing_stage.apply(hdr, meta);
 
         do_tunnel_encap(hdr,
                      meta,

--- a/dash-pipeline/bmv2/dash_metadata.p4
+++ b/dash-pipeline/bmv2/dash_metadata.p4
@@ -40,6 +40,7 @@ enum bit<16> dash_pipeline_stage_t {
 
     // Inbound stages
     INBOUND_STAGE_START = 100,
+    INBOUND_ROUTING = 100, // OUTBOUND_STAGE_START
 
     // Outbound stages
     OUTBOUND_STAGE_START = 200,
@@ -164,6 +165,7 @@ struct eni_data_t {
     bit<6> dscp;
     dash_tunnel_dscp_mode_t dscp_mode;
     outbound_routing_group_data_t outbound_routing_group_data;
+    IPv4Address vip;
 }
 
 struct meter_context_t {
@@ -273,6 +275,7 @@ struct metadata_t {
     dash_direction_t direction;
     dash_eni_mac_type_t eni_mac_type;
     dash_eni_mac_override_type_t eni_mac_override_type;
+    encap_data_t rx_encap;
     EthernetAddress eni_addr;
     bit<16> vnet_id;
     bit<16> dst_vnet_id;

--- a/dash-pipeline/bmv2/dash_pipeline.p4
+++ b/dash-pipeline/bmv2/dash_pipeline.p4
@@ -10,6 +10,7 @@
 #include "dash_inbound.p4"
 #include "dash_conntrack.p4"
 #include "stages/conntrack_lookup.p4"
+#include "stages/pre_pipeline.p4"
 #include "stages/direction_lookup.p4"
 #include "stages/eni_lookup.p4"
 #include "stages/ha.p4"
@@ -40,58 +41,6 @@ control dash_ingress(
 
     action deny() {
         meta.dropped = true;
-    }
-
-    action accept() {
-    }
-
-    @SaiTable[name = "vip", api = "dash_vip"]
-    table vip {
-        key = {
-            hdr.u0_ipv4.dst_addr : exact @SaiVal[name = "VIP", type="sai_ip_address_t"];
-        }
-
-        actions = {
-            accept;
-            @defaultonly deny;
-        }
-
-        const default_action = deny;
-    }
-
-    action set_appliance(bit<8> local_region_id) {
-        meta.local_region_id = local_region_id;
-    }
-
-    @SaiTable[name = "dash_appliance", api = "dash_appliance", order = 0, isobject="true"]
-    table appliance {
-        key = {
-            meta.appliance_id : exact @SaiVal[type="sai_object_id_t"];
-        }
-
-        actions = {
-            set_appliance;
-            @defaultonly accept;
-        }
-        const default_action = accept;
-    }
-
-    action set_underlay_mac(EthernetAddress neighbor_mac,
-                            EthernetAddress mac) {
-        meta.encap_data.underlay_dmac = neighbor_mac;
-        meta.encap_data.underlay_smac = mac;
-    }
-
-    /* This table API should be implemented manually using underlay SAI */
-    @SaiTable[ignored = "true"]
-    table underlay_mac {
-        key = {
-            meta.appliance_id : ternary;
-        }
-
-        actions = {
-            set_underlay_mac;
-        }
     }
 
 #define ACL_GROUPS_PARAM(prefix) \
@@ -189,61 +138,6 @@ control dash_ingress(
         const default_action = deny;
     }
 
-    action permit() {
-    }
-
-    action vxlan_decap() {}
-    action vxlan_decap_pa_validate() {}
-
-    action tunnel_decap(inout headers_t hdr,
-                        inout metadata_t meta,
-                        bit<32> meter_class_or,
-                        @SaiVal[default_value="4294967295"] bit<32> meter_class_and) {
-        set_meter_attrs(meta, meter_class_or, meter_class_and);
-    }
-
-    action tunnel_decap_pa_validate(inout headers_t hdr,
-                                    inout metadata_t meta,
-                                    @SaiVal[type="sai_object_id_t"] bit<16> src_vnet_id,
-                                    bit<32> meter_class_or,
-                                    @SaiVal[default_value="4294967295"] bit<32> meter_class_and) {
-        meta.vnet_id = src_vnet_id;
-        set_meter_attrs(meta, meter_class_or, meter_class_and);
-    }
-
-    @SaiTable[name = "pa_validation", api = "dash_pa_validation"]
-    table pa_validation {
-        key = {
-            meta.vnet_id: exact @SaiVal[type="sai_object_id_t"];
-            hdr.u0_ipv4.src_addr : exact @SaiVal[name = "sip", type="sai_ip_address_t"];
-        }
-
-        actions = {
-            permit;
-            @defaultonly deny;
-        }
-
-        const default_action = deny;
-    }
-
-    @SaiTable[name = "inbound_routing", api = "dash_inbound_routing"]
-    table inbound_routing {
-        key = {
-            meta.eni_id: exact @SaiVal[type="sai_object_id_t"];
-            hdr.u0_vxlan.vni : exact @SaiVal[name = "VNI"];
-            hdr.u0_ipv4.src_addr : ternary @SaiVal[name = "sip", type="sai_ip_address_t"];
-        }
-        actions = {
-            tunnel_decap(hdr, meta);
-            tunnel_decap_pa_validate(hdr, meta);
-            vxlan_decap;                // Deprecated, but cannot be removed until SWSS is updated.
-            vxlan_decap_pa_validate;    // Deprecated, but cannot be removed until SWSS is updated.
-            @defaultonly deny;
-        }
-
-        const default_action = deny;
-    }
-
     action set_acl_group_attrs(@SaiVal[type="sai_ip_addr_family_t", isresourcetype="true"] bit<32> ip_addr_family) {
         if (ip_addr_family == 0) /* SAI_IP_ADDR_FAMILY_IPV4 */ {
             if (meta.is_overlay_ip_v6 == 1) {
@@ -282,70 +176,9 @@ control dash_ingress(
 #endif  // DPDK_PNA_SEND_TO_PORT_FIX_MERGED
 #endif // TARGET_DPDK_PNA
 
-        if (meta.is_fast_path_icmp_flow_redirection_packet) {
-            UPDATE_COUNTER(port_lb_fast_path_icmp_in, 0);
-        }
-
-        if (vip.apply().hit) {
-            /* Use the same VIP that was in packet's destination if it's
-               present in the VIP table */
-            meta.encap_data.underlay_sip = hdr.u0_ipv4.dst_addr;
-        } else {
-            UPDATE_COUNTER(vip_miss_drop, 0);
-
-            if (meta.is_fast_path_icmp_flow_redirection_packet) {
-            }
-        }
-
+        pre_pipeline_stage.apply(hdr, meta);
         direction_lookup_stage.apply(hdr, meta);
-
-        appliance.apply();
-        underlay_mac.apply();
-
-        /* Outer header processing */
         eni_lookup_stage.apply(hdr, meta);
-
-        // Save the original DSCP value
-        meta.eni_data.dscp_mode = dash_tunnel_dscp_mode_t.PRESERVE_MODEL;
-        meta.eni_data.dscp = (bit<6>)hdr.u0_ipv4.diffserv;
-
-        if (meta.direction == dash_direction_t.INBOUND) {
-            switch (inbound_routing.apply().action_run) {
-                tunnel_decap_pa_validate: {
-                    pa_validation.apply();
-                }
-                deny: {
-                    UPDATE_ENI_COUNTER(inbound_routing_entry_miss_drop);
-                }
-            }
-        }
-
-        do_tunnel_decap(hdr, meta);
-
-        /* At this point the processing is done on customer headers */
-
-        meta.is_overlay_ip_v6 = 0;
-        meta.ip_protocol = 0;
-        meta.dst_ip_addr = 0;
-        meta.src_ip_addr = 0;
-        if (hdr.customer_ipv6.isValid()) {
-            meta.ip_protocol = hdr.customer_ipv6.next_header;
-            meta.src_ip_addr = hdr.customer_ipv6.src_addr;
-            meta.dst_ip_addr = hdr.customer_ipv6.dst_addr;
-            meta.is_overlay_ip_v6 = 1;
-        } else if (hdr.customer_ipv4.isValid()) {
-            meta.ip_protocol = hdr.customer_ipv4.protocol;
-            meta.src_ip_addr = (bit<128>)hdr.customer_ipv4.src_addr;
-            meta.dst_ip_addr = (bit<128>)hdr.customer_ipv4.dst_addr;
-        }
-
-        if (hdr.customer_tcp.isValid()) {
-            meta.src_l4_port = hdr.customer_tcp.src_port;
-            meta.dst_l4_port = hdr.customer_tcp.dst_port;
-        } else if (hdr.customer_udp.isValid()) {
-            meta.src_l4_port = hdr.customer_udp.src_port;
-            meta.dst_l4_port = hdr.customer_udp.dst_port;
-        }
 
         if (!eni.apply().hit) {
             UPDATE_COUNTER(eni_miss_drop, 0);
@@ -359,21 +192,28 @@ control dash_ingress(
         conntrack_lookup_stage.apply(hdr, meta);
 
         UPDATE_ENI_COUNTER(eni_rx);
+
+        if (meta.direction == dash_direction_t.OUTBOUND) {
+            UPDATE_ENI_COUNTER(eni_outbound_rx);
+        } else if (meta.direction == dash_direction_t.INBOUND) {
+            UPDATE_ENI_COUNTER(eni_inbound_rx);
+        }
+
         if (meta.is_fast_path_icmp_flow_redirection_packet) {
             UPDATE_ENI_COUNTER(eni_lb_fast_path_icmp_in);
         }
 
+        do_tunnel_decap(hdr, meta);
+        
         ha_stage.apply(hdr, meta);
 
         acl_group.apply();
 
         if (meta.direction == dash_direction_t.OUTBOUND) {
-            UPDATE_ENI_COUNTER(eni_outbound_rx);
-
             meta.target_stage = dash_pipeline_stage_t.OUTBOUND_ROUTING;
             outbound.apply(hdr, meta);
         } else if (meta.direction == dash_direction_t.INBOUND) {
-            UPDATE_ENI_COUNTER(eni_inbound_rx);
+            meta.target_stage = dash_pipeline_stage_t.INBOUND_ROUTING;
             inbound.apply(hdr, meta);
         }
 

--- a/dash-pipeline/bmv2/stages/direction_lookup.p4
+++ b/dash-pipeline/bmv2/stages/direction_lookup.p4
@@ -33,7 +33,7 @@ control direction_lookup_stage(
     @SaiTable[name = "direction_lookup", api = "dash_direction_lookup"]
     table direction_lookup {
         key = {
-            hdr.u0_vxlan.vni : exact @SaiVal[name = "VNI"];
+            meta.rx_encap.vni : exact @SaiVal[name = "VNI"];
         }
 
         actions = {

--- a/dash-pipeline/bmv2/stages/inbound_routing.p4
+++ b/dash-pipeline/bmv2/stages/inbound_routing.p4
@@ -1,0 +1,79 @@
+#ifndef _DASH_STAGE_INBOUND_ROUTING_P4_
+#define _DASH_STAGE_INBOUND_ROUTING_P4_
+
+#include "../dash_routing_types.p4"
+
+control inbound_routing_stage(inout headers_t hdr,
+                              inout metadata_t meta)
+{
+    action permit() {}
+
+    @SaiTable[name = "pa_validation", api = "dash_pa_validation"]
+    table pa_validation {
+        key = {
+            meta.vnet_id: exact @SaiVal[type="sai_object_id_t"];
+            meta.rx_encap.underlay_sip : exact @SaiVal[name = "sip", type="sai_ip_address_t"];
+        }
+
+        actions = {
+            permit;
+            @defaultonly drop(meta);
+        }
+
+        const default_action = drop(meta);
+    }
+
+    action vxlan_decap() {}
+    action vxlan_decap_pa_validate() {}
+
+    action tunnel_decap(inout headers_t hdr,
+                        inout metadata_t meta,
+                        bit<32> meter_class_or,
+                        @SaiVal[default_value="4294967295"] bit<32> meter_class_and) {
+        set_meter_attrs(meta, meter_class_or, meter_class_and);
+    }
+
+    action tunnel_decap_pa_validate(inout headers_t hdr,
+                                    inout metadata_t meta,
+                                    @SaiVal[type="sai_object_id_t"] bit<16> src_vnet_id,
+                                    bit<32> meter_class_or,
+                                    @SaiVal[default_value="4294967295"] bit<32> meter_class_and) {
+        meta.vnet_id = src_vnet_id;
+        set_meter_attrs(meta, meter_class_or, meter_class_and);
+    }
+
+    @SaiTable[name = "inbound_routing", api = "dash_inbound_routing"]
+    table inbound_routing {
+        key = {
+            meta.eni_id: exact @SaiVal[type="sai_object_id_t"];
+            meta.rx_encap.vni : exact @SaiVal[name = "VNI"];
+            meta.rx_encap.underlay_sip : ternary @SaiVal[name = "sip", type="sai_ip_address_t"];
+        }
+        actions = {
+            tunnel_decap(hdr, meta);
+            tunnel_decap_pa_validate(hdr, meta);
+            vxlan_decap;                // Deprecated, but cannot be removed until SWSS is updated.
+            vxlan_decap_pa_validate;    // Deprecated, but cannot be removed until SWSS is updated.
+            @defaultonly drop(meta);
+        }
+
+        const default_action = drop(meta);
+    }
+
+    apply {
+        if (meta.target_stage != dash_pipeline_stage_t.INBOUND_ROUTING) {
+            return;
+        }
+
+        switch (inbound_routing.apply().action_run) {
+            tunnel_decap_pa_validate: {
+                pa_validation.apply();
+            }
+            drop: {
+                UPDATE_ENI_COUNTER(inbound_routing_entry_miss_drop);
+            }
+        }
+    }
+}
+
+#endif /* _DASH_STAGE_INBOUND_ROUTING_P4_ */

--- a/dash-pipeline/bmv2/stages/pre_pipeline.p4
+++ b/dash-pipeline/bmv2/stages/pre_pipeline.p4
@@ -1,0 +1,125 @@
+#ifndef _DASH_STAGE_PRE_PIPELINE_P4_
+#define _DASH_STAGE_PRE_PIPELINE_P4_
+
+control pre_pipeline_stage(inout headers_t hdr,
+                           inout metadata_t meta)
+{
+    action accept() {}
+
+    action set_appliance(bit<8> local_region_id) {
+        meta.local_region_id = local_region_id;
+    }
+
+    @SaiTable[name = "dash_appliance", api = "dash_appliance", order = 0, isobject="true"]
+    table appliance {
+        key = {
+            meta.appliance_id : exact @SaiVal[type="sai_object_id_t"];
+        }
+
+        actions = {
+            set_appliance;
+            @defaultonly accept;
+        }
+        const default_action = accept;
+    }
+
+    action set_underlay_mac(EthernetAddress neighbor_mac,
+                            EthernetAddress mac) {
+        meta.encap_data.underlay_dmac = neighbor_mac;
+        meta.encap_data.underlay_smac = mac;
+    }
+
+    /* This table API should be implemented manually using underlay SAI */
+    @SaiTable[ignored = "true"]
+    table underlay_mac {
+        key = {
+            meta.appliance_id : ternary;
+        }
+
+        actions = {
+            set_underlay_mac;
+        }
+    }
+
+    @SaiTable[name = "vip", api = "dash_vip"]
+    table vip {
+        key = {
+            meta.rx_encap.underlay_dip : exact @SaiVal[name = "VIP", type="sai_ip_address_t"];
+        }
+
+        actions = {
+            accept;
+            @defaultonly drop(meta);
+        }
+
+        const default_action = drop(meta);
+    }
+
+    apply {
+        // Normalize the outer headers.
+        // This helps us handling multiple encaps and different type of encaps in the future and simplify the later packet processing.
+        meta.rx_encap.underlay_smac = hdr.u0_ethernet.src_addr;
+        meta.rx_encap.underlay_dmac = hdr.u0_ethernet.dst_addr;
+
+        if (hdr.u0_ipv4.isValid()) {
+            meta.rx_encap.underlay_sip = hdr.u0_ipv4.src_addr;
+            meta.rx_encap.underlay_dip = hdr.u0_ipv4.dst_addr;
+        }
+        // IPv6 encap on received packet is not supported yet.
+        // else if ((hdr.u0_ipv6.isValid()) {
+        //     meta.rx_encap.underlay_sip = hdr.u0_ipv6.src_addr;
+        //     meta.rx_encap.underlay_dip = hdr.u0_ipv6.dst_addr;
+        // }
+
+        meta.rx_encap.dash_encapsulation = dash_encapsulation_t.VXLAN;
+        meta.rx_encap.vni = hdr.u0_vxlan.vni;
+
+        // Save the original DSCP value
+        meta.eni_data.dscp_mode = dash_tunnel_dscp_mode_t.PRESERVE_MODEL;
+        meta.eni_data.dscp = (bit<6>)hdr.u0_ipv4.diffserv;
+
+        // Normalize the customer headers for later lookups.
+        meta.is_overlay_ip_v6 = 0;
+        meta.ip_protocol = 0;
+        meta.dst_ip_addr = 0;
+        meta.src_ip_addr = 0;
+        if (hdr.customer_ipv6.isValid()) {
+            meta.ip_protocol = hdr.customer_ipv6.next_header;
+            meta.src_ip_addr = hdr.customer_ipv6.src_addr;
+            meta.dst_ip_addr = hdr.customer_ipv6.dst_addr;
+            meta.is_overlay_ip_v6 = 1;
+        } else if (hdr.customer_ipv4.isValid()) {
+            meta.ip_protocol = hdr.customer_ipv4.protocol;
+            meta.src_ip_addr = (bit<128>)hdr.customer_ipv4.src_addr;
+            meta.dst_ip_addr = (bit<128>)hdr.customer_ipv4.dst_addr;
+        }
+
+        if (hdr.customer_tcp.isValid()) {
+            meta.src_l4_port = hdr.customer_tcp.src_port;
+            meta.dst_l4_port = hdr.customer_tcp.dst_port;
+        } else if (hdr.customer_udp.isValid()) {
+            meta.src_l4_port = hdr.customer_udp.src_port;
+            meta.dst_l4_port = hdr.customer_udp.dst_port;
+        }
+
+        // The pipeline starts from here and we can use the normalized headers for processing.
+        if (meta.is_fast_path_icmp_flow_redirection_packet) {
+            UPDATE_COUNTER(port_lb_fast_path_icmp_in, 0);
+        }
+
+        if (vip.apply().hit) {
+            /* Use the same VIP that was in packet's destination if it's present in the VIP table */
+            meta.encap_data.underlay_sip = meta.rx_encap.underlay_dip;
+        } else {
+            UPDATE_COUNTER(vip_miss_drop, 0);
+
+            if (meta.is_fast_path_icmp_flow_redirection_packet) {
+            }
+        }
+
+        appliance.apply();
+        underlay_mac.apply();
+    }
+}
+
+#endif // _DASH_STAGE_PRE_PIPELINE_P4_


### PR DESCRIPTION
Currently, several stages / tables in DASH directly uses the headers to lookup entries, such as direction. inbound routing, and etc. It it ok currently, because DASH only accepts traffic with a single layer and a single type of encap. However, once we start to handle multiple layers and types of encaps, it will make the pipeline very complicated.

This change refactors the pipeline to add a pre-pipeline stage to preprocess the underlay and overlay data for pipeline lookup and actions, so we can keep the rest of the pipeline more future-proof.
