### PR TITLE
[dash-sai] Update SAI API template to make SAI explorer working better.

### DIFF
--- a/dash-pipeline/SAI/templates/saiapi.h.j2
+++ b/dash-pipeline/SAI/templates/saiapi.h.j2
@@ -19,7 +19,9 @@
  *
  * @file    saiexperimental{{ sai_api.app_name | replace('_', '') }}.h
  *
- * @brief   This module defines SAI P4 extension  interface
+ * @brief   This module defines SAI extensions for {{ sai_api.app_name | replace('_', ' ') | upper }}
+ *
+ * @warning This module is a SAI experimental module
  */
 
 #if !defined (__SAIEXPERIMENTAL{{ sai_api.app_name | replace('_', '') | upper }}_H_)
@@ -28,7 +30,7 @@
 #include <saitypesextensions.h>
 
 /**
- * @defgroup SAIEXPERIMENTAL{{ sai_api.app_name | upper}} SAI - Extension specific API definitions
+ * @defgroup SAIEXPERIMENTAL{{ sai_api.app_name | upper}} SAI - Experimental: {{ sai_api.app_name | replace('_', ' ') | upper }} specific API definitions
  *
  * @{
  */


### PR DESCRIPTION
There is a change directly committed to OCP SAI to make the DASH SAI APIs working better for SAI explorer. However, this change is not updated into DASH repo, which means all future SAI API updates from DASH could override it and any new APIs will not be covered.

To help with this, this change updates the SAI API template to have a better naming.

For references, the original OCP PR is here: https://github.com/opencomputeproject/SAI/pull/1971.