### PR TITLE
Remove Outer SRC IP Prefix (not req's for Inbound routing lookup) in …

### DIFF
--- a/documentation/general/sdn-features-packet-transforms.md
+++ b/documentation/general/sdn-features-packet-transforms.md
@@ -185,9 +185,7 @@ must be applied depending on the rule.
 All inbound rules are matched based on the priority order (with lower priority
 value rule matched first). Matching is based on multiple fields (or must match
 if field is populated). The supported fields are: 
-
-- Most Outer Source IP Prefix 
-- Most Outer Destination IP Prefix 
+ 
 - VXLAN/GRE key 
 
 Once the rule is matched, the correct set of **decap, transposition** steps must


### PR DESCRIPTION
…sdn-features-packet-transforms.md

Per Issue 518, this is not required.  Attempting to update document.

[Issue 518 dash_pipeline.p4 Inbound Routing question](https://github.com/sonic-net/DASH/issues/518)