### PR TITLE
[sai-gen] Maintaining the order of SAI enum types.

### DIFF
--- a/dash-pipeline/SAI/utils/sai_spec/sai_spec.py
+++ b/dash-pipeline/SAI/utils/sai_spec/sai_spec.py
@@ -64,11 +64,14 @@ class SaiSpec:
         )
         sai_spec_utils.merge_sai_common_lists(self.object_entries, other.object_entries)
 
-        # The global enums are generated from the P4 enum types, so we can respect whatever in the
-        # new spec and simply replace them, because:
-        # - It doesn't matter if the order of enum itself changes.
-        # - We cannot move the enum members as we want, as their order changes their values.
-        self.enums = other.enums
+        # Althoug the order of enum value doesn't matter, but we still merge it in the same way
+        # other SAI values, because:
+        # - P4 compiler is not maintaining the order of enum values, so the definitions in SAI
+        #   spec can move around and make code review harder.
+        # - Removing enum can break existing code.
+        sai_spec_utils.merge_sai_value_lists(
+            self.enums, other.enums, lambda x: x.name
+        )
 
         self.port_extenstion.merge(other.port_extenstion)
         sai_spec_utils.merge_sai_common_lists(self.api_groups, other.api_groups)


### PR DESCRIPTION
Since P4 compiler won't maintain the order of the generated enums in p4runtime, it causes all enum values moves around in the code review. Since the enum types from P4 doesn't have any dependencies to each other, we can merge the new enum values into the current SAI spec by appending to the end of the list, just like other SAI attributes.

Additionally, to maintain the SAI ABI, we will not remove any existing enum values too.