### PR TITLE
[ci] Update CI to ensure SAI spec are generated and updated.

### DIFF
--- a/.github/workflows/dash-bmv2-ci.yml
+++ b/.github/workflows/dash-bmv2-ci.yml
@@ -62,6 +62,8 @@ jobs:
       run:  make docker-bmv2-bldr
     - name: Generate SAI API
       run:  DOCKER_FLAGS=$docker_fg_flags make sai
+    - name: Check if SAI spec is updated
+      run:  DOCKER_FLAGS=$docker_fg_flags make check-sai-spec
     - name: Build libsai c++ tests
       run:  DOCKER_FLAGS=$docker_fg_flags make test
     - name: Prepare network

--- a/dash-pipeline/Makefile
+++ b/dash-pipeline/Makefile
@@ -237,6 +237,14 @@ sai-clean: SAI/SAI libsai-clean saithrift-server-clean
 	rm -rf SAI/SAI/inc SAI/SAI/experimental SAI/SAI/meta
 	cd SAI/SAI && git checkout -- inc experimental meta
 
+.PHONY:check-sai-spec
+check-sai-spec:
+	if git status | grep -q "SAI/specs"; then \
+		echo 'SAI specs have changed, please run "make sai-headers" locally and commit the changes for review.'; \
+		echo ""; echo "SAI spec diff found as below:"; \
+		git diff SAI/specs; \
+		exit 1; \
+	fi
 
 # Run to recreate same environment as building saithrift client & server
 run-saithrift-bldr-bash:


### PR DESCRIPTION
To help the code review of SAI header updates, update the CI workflow to ensure we have up-to-date SAI spec included in the PR.

This is achieved by checking git status and see if any changes in the SAI/specs folder, after running `make sai` in the CI pipeline.