### PR TITLE
[dash-p4] Deprecate order attribute on SaiVal and SaiCounter annotations.

### DIFF
--- a/dash-pipeline/bmv2/README.md
+++ b/dash-pipeline/bmv2/README.md
@@ -30,7 +30,6 @@ Available tags are:
 - `default_value`: Override the default value for this key or action parameter.
 - `isresourcetype`: When set to "true", we generate a corresponding SAI tag in SAI APIs: `@isresourcetype true`.
 - `objects`: Space separated list of SAI object type this value accepts. When set, we force this value to be a SAI object id, and generate a corresponding SAI tag in SAI APIs: `@objects <list>`.
-- `order`: Specify the order of the generated attributes in the SAI API header file. This will be particularly useful, when a table has multiple actions, and we add parameters to one of them. The new attributes might be generated in the middle of existing attributes, which breaks ABI compatibility with older version of SAI APIs.
 - `isreadonly`: When set to "true", we generate force this value to be read-only in SAI API using: `@flags READ_ONLY`, otherwise, we generate `@flags CREATE_AND_SET`.
 - `skipattr`: When set to "true", we skip this attribute in SAI API generation.
 
@@ -46,7 +45,6 @@ Available tags are:
   - `counter_attr`: The counters will be generated as attributes for directly fetching the counter value on the target SAI object.
   - `counter_id`: The counters will be generated as counter ids on the target SAI objects.
   - `stats`: The counters will be generated as SAI stats attributes. If any SAI objects has any stats attributes, SAI get stats API will be generated.
-- `order`: Specify the order of the generated attributes in the SAI API header file. This will be particularly useful, when a table has multiple actions, and we add parameters to one of them. The new attributes might be generated in the middle of existing attributes, which breaks ABI compatibility with older version of SAI APIs. When `attr_type` is set, it will be compared with the order of other attributes from match keys and action parameters in the same object too.
 
 #### `@SaiTable`: Tables
 

--- a/dash-pipeline/bmv2/dash_arch_specific.p4
+++ b/dash-pipeline/bmv2/dash_arch_specific.p4
@@ -29,7 +29,7 @@
         counter(count, CounterType.bytes) name;
 
     #define DEFINE_HIT_COUNTER(name, count, ...) \
-        @SaiCounter[__VA_ARGS__, no_suffix="true"] \
+        @SaiCounter[no_suffix="true", __VA_ARGS__] \
         counter(count, CounterType.packets) name;
 
     #define UPDATE_COUNTER(name, index) \

--- a/dash-pipeline/bmv2/dash_counters.p4
+++ b/dash-pipeline/bmv2/dash_counters.p4
@@ -22,48 +22,48 @@ DEFINE_COUNTER(port_lb_fast_path_eni_miss_drop, 1, attr_type="stats")
 // ENI level counters:
 //
 #define DEFINE_ENI_COUNTER(name, ...) \
-    DEFINE_COUNTER(name, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", __VA_ARGS__)
+    DEFINE_COUNTER(name, MAX_ENI, __VA_ARGS__ attr_type="stats", action_names="set_eni_attrs")
 
 #define DEFINE_ENI_PACKET_COUNTER(name, ...) \
-    DEFINE_PACKET_COUNTER(name, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", __VA_ARGS__)
+    DEFINE_PACKET_COUNTER(name, MAX_ENI, __VA_ARGS__ attr_type="stats", action_names="set_eni_attrs")
 
 #define DEFINE_ENI_BYTE_COUNTER(name, count, ...) \
-    DEFINE_BYTE_COUNTER(name, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", __VA_ARGS__)
+    DEFINE_BYTE_COUNTER(name, MAX_ENI, __VA_ARGS__ attr_type="stats", action_names="set_eni_attrs")
 
 #define DEFINE_ENI_HIT_COUNTER(name, ...) \
-    DEFINE_HIT_COUNTER(name, MAX_ENI, attr_type="stats", action_names="set_eni_attrs", __VA_ARGS__)
+    DEFINE_HIT_COUNTER(name, MAX_ENI, __VA_ARGS__ attr_type="stats", action_names="set_eni_attrs")
 
 #define UPDATE_ENI_COUNTER(name) \
     UPDATE_COUNTER(name, meta.eni_id)
 
-DEFINE_ENI_COUNTER(eni_rx, order=0, name="rx")
-DEFINE_ENI_COUNTER(eni_tx, order=0, name="tx")
-DEFINE_ENI_COUNTER(eni_outbound_rx, order=0, name="outbound_rx")
-DEFINE_ENI_COUNTER(eni_outbound_tx, order=0, name="outbound_tx")
-DEFINE_ENI_COUNTER(eni_inbound_rx, order=0, name="inbound_rx")
-DEFINE_ENI_COUNTER(eni_inbound_tx, order=0, name="inbound_tx")
-DEFINE_ENI_COUNTER(eni_lb_fast_path_icmp_in, order=0, name="lb_fast_path_icmp_in")
+DEFINE_ENI_COUNTER(eni_rx, name="rx",)
+DEFINE_ENI_COUNTER(eni_tx, name="tx",)
+DEFINE_ENI_COUNTER(eni_outbound_rx, name="outbound_rx",)
+DEFINE_ENI_COUNTER(eni_outbound_tx, name="outbound_tx",)
+DEFINE_ENI_COUNTER(eni_inbound_rx, name="inbound_rx",)
+DEFINE_ENI_COUNTER(eni_inbound_tx, name="inbound_tx",)
+DEFINE_ENI_COUNTER(eni_lb_fast_path_icmp_in, name="lb_fast_path_icmp_in",)
 
 //
 // ENI-level flow operation counters:
 //
-DEFINE_ENI_HIT_COUNTER(flow_created, order=1)
-DEFINE_ENI_HIT_COUNTER(flow_create_failed, order=1)
-DEFINE_ENI_HIT_COUNTER(flow_updated, order=1)
-DEFINE_ENI_HIT_COUNTER(flow_update_failed, order=1)
-DEFINE_ENI_HIT_COUNTER(flow_updated_by_resimulation, order=1)
-DEFINE_ENI_HIT_COUNTER(flow_update_by_resimulation_failed, order=1)
-DEFINE_ENI_HIT_COUNTER(flow_deleted, order=1)
-DEFINE_ENI_HIT_COUNTER(flow_delete_failed, order=1)
-DEFINE_ENI_HIT_COUNTER(flow_aged, order=1)
+DEFINE_ENI_HIT_COUNTER(flow_created)
+DEFINE_ENI_HIT_COUNTER(flow_create_failed)
+DEFINE_ENI_HIT_COUNTER(flow_updated)
+DEFINE_ENI_HIT_COUNTER(flow_update_failed)
+DEFINE_ENI_HIT_COUNTER(flow_updated_by_resimulation)
+DEFINE_ENI_HIT_COUNTER(flow_update_by_resimulation_failed)
+DEFINE_ENI_HIT_COUNTER(flow_deleted)
+DEFINE_ENI_HIT_COUNTER(flow_delete_failed)
+DEFINE_ENI_HIT_COUNTER(flow_aged)
 
 //
 // ENI-level data plane flow sync packet counters:
 //
-DEFINE_ENI_COUNTER(inline_sync_packet_rx, order=2)
-DEFINE_ENI_COUNTER(inline_sync_packet_tx, order=2)
-DEFINE_ENI_COUNTER(timed_sync_packet_rx, order=2)
-DEFINE_ENI_COUNTER(timed_sync_packet_tx, order=2)
+DEFINE_ENI_COUNTER(inline_sync_packet_rx)
+DEFINE_ENI_COUNTER(inline_sync_packet_tx)
+DEFINE_ENI_COUNTER(timed_sync_packet_rx)
+DEFINE_ENI_COUNTER(timed_sync_packet_tx)
 
 //
 // ENI-level data plane flow sync request counters:
@@ -74,21 +74,21 @@ DEFINE_ENI_COUNTER(timed_sync_packet_tx, order=2)
 //   - Request result: succeeded, failed (unexpected) and ignored (expected and ok to ignore, e.g., more packets arrives before flow sync is acked).
 //
 #define DEFINE_ENI_FLOW_SYNC_COUNTERS(counter_name) \
-    DEFINE_ENI_HIT_COUNTER(inline_ ## counter_name ## _req_sent, order=2) \
-    DEFINE_ENI_HIT_COUNTER(inline_ ## counter_name ## _req_recv, order=2) \
-    DEFINE_ENI_HIT_COUNTER(inline_ ## counter_name ## _req_failed, order=2) \
-    DEFINE_ENI_HIT_COUNTER(inline_ ## counter_name ## _req_ignored, order=2) \
-    DEFINE_ENI_HIT_COUNTER(inline_ ## counter_name ## _ack_recv, order=2) \
-    DEFINE_ENI_HIT_COUNTER(inline_ ## counter_name ## _ack_failed, order=2) \
-    DEFINE_ENI_HIT_COUNTER(inline_ ## counter_name ## _ack_ignored, order=2) \
+    DEFINE_ENI_HIT_COUNTER(inline_ ## counter_name ## _req_sent) \
+    DEFINE_ENI_HIT_COUNTER(inline_ ## counter_name ## _req_recv) \
+    DEFINE_ENI_HIT_COUNTER(inline_ ## counter_name ## _req_failed) \
+    DEFINE_ENI_HIT_COUNTER(inline_ ## counter_name ## _req_ignored) \
+    DEFINE_ENI_HIT_COUNTER(inline_ ## counter_name ## _ack_recv) \
+    DEFINE_ENI_HIT_COUNTER(inline_ ## counter_name ## _ack_failed) \
+    DEFINE_ENI_HIT_COUNTER(inline_ ## counter_name ## _ack_ignored) \
     \
-    DEFINE_ENI_HIT_COUNTER(timed_ ## counter_name ## _req_sent, order=2) \
-    DEFINE_ENI_HIT_COUNTER(timed_ ## counter_name ## _req_recv, order=2) \
-    DEFINE_ENI_HIT_COUNTER(timed_ ## counter_name ## _req_failed, order=2) \
-    DEFINE_ENI_HIT_COUNTER(timed_ ## counter_name ## _req_ignored, order=2) \
-    DEFINE_ENI_HIT_COUNTER(timed_ ## counter_name ## _ack_recv, order=2) \
-    DEFINE_ENI_HIT_COUNTER(timed_ ## counter_name ## _ack_failed, order=2) \
-    DEFINE_ENI_HIT_COUNTER(timed_ ## counter_name ## _ack_ignored, order=2)
+    DEFINE_ENI_HIT_COUNTER(timed_ ## counter_name ## _req_sent) \
+    DEFINE_ENI_HIT_COUNTER(timed_ ## counter_name ## _req_recv) \
+    DEFINE_ENI_HIT_COUNTER(timed_ ## counter_name ## _req_failed) \
+    DEFINE_ENI_HIT_COUNTER(timed_ ## counter_name ## _req_ignored) \
+    DEFINE_ENI_HIT_COUNTER(timed_ ## counter_name ## _ack_recv) \
+    DEFINE_ENI_HIT_COUNTER(timed_ ## counter_name ## _ack_failed) \
+    DEFINE_ENI_HIT_COUNTER(timed_ ## counter_name ## _ack_ignored)
 
 DEFINE_ENI_FLOW_SYNC_COUNTERS(flow_create)
 DEFINE_ENI_FLOW_SYNC_COUNTERS(flow_update)
@@ -97,10 +97,10 @@ DEFINE_ENI_FLOW_SYNC_COUNTERS(flow_delete)
 //
 // ENI-level drop counters:
 //
-DEFINE_ENI_PACKET_COUNTER(outbound_routing_entry_miss_drop, order=3)
-DEFINE_ENI_PACKET_COUNTER(outbound_ca_pa_entry_miss_drop, order=3)
-DEFINE_ENI_PACKET_COUNTER(inbound_routing_entry_miss_drop, order=3)
-DEFINE_ENI_PACKET_COUNTER(outbound_routing_group_miss_drop, order=3)
-DEFINE_ENI_PACKET_COUNTER(outbound_routing_group_admin_down_drop, order=3)
+DEFINE_ENI_PACKET_COUNTER(outbound_routing_entry_miss_drop)
+DEFINE_ENI_PACKET_COUNTER(outbound_ca_pa_entry_miss_drop)
+DEFINE_ENI_PACKET_COUNTER(inbound_routing_entry_miss_drop)
+DEFINE_ENI_PACKET_COUNTER(outbound_routing_group_miss_drop)
+DEFINE_ENI_PACKET_COUNTER(outbound_routing_group_admin_down_drop)
 
 #endif // __DASH_COUNTERS__

--- a/dash-pipeline/bmv2/dash_pipeline.p4
+++ b/dash-pipeline/bmv2/dash_pipeline.p4
@@ -237,7 +237,7 @@ control dash_ingress(
         }
     }
 
-    @SaiTable[name = "dash_acl_group", api = "dash_acl", order = 0, isobject="true"]
+    @SaiTable[name = "dash_acl_group", api = "dash_acl", isobject="true"]
     table acl_group {
         key = {
             meta.stage1_dash_acl_group_id : exact @SaiVal[name = "dash_acl_group_id"];

--- a/dash-pipeline/bmv2/stages/ha.p4
+++ b/dash-pipeline/bmv2/stages/ha.p4
@@ -40,19 +40,19 @@ control ha_stage(inout headers_t hdr,
     DEFINE_HIT_COUNTER(dp_probe_failed, MAX_HA_SET, name="dp_probe_failed", attr_type="stats", action_names="set_ha_set_attr")
 
     // Control plane data channel related counters
-    DEFINE_HIT_COUNTER(cp_data_channel_connect_attempted, MAX_HA_SET, name="cp_data_channel_connect_attempted", attr_type="stats", action_names="set_ha_set_attr", order=1)
-    DEFINE_HIT_COUNTER(cp_data_channel_connect_received, MAX_HA_SET, name="cp_data_channel_connect_received", attr_type="stats", action_names="set_ha_set_attr", order=1)
-    DEFINE_HIT_COUNTER(cp_data_channel_connect_succeeded, MAX_HA_SET, name="cp_data_channel_connect_succeeded", attr_type="stats", action_names="set_ha_set_attr", order=1)
-    DEFINE_HIT_COUNTER(cp_data_channel_connect_failed, MAX_HA_SET, name="cp_data_channel_connect_failed", attr_type="stats", action_names="set_ha_set_attr", order=1)
-    DEFINE_HIT_COUNTER(cp_data_channel_connect_rejected, MAX_HA_SET, name="cp_data_channel_connect_rejected", attr_type="stats", action_names="set_ha_set_attr", order=1)
-    DEFINE_HIT_COUNTER(cp_data_channel_timeout_count, MAX_HA_SET, name="cp_data_channel_timeout_count", attr_type="stats", action_names="set_ha_set_attr", order=1)
+    DEFINE_HIT_COUNTER(cp_data_channel_connect_attempted, MAX_HA_SET, name="cp_data_channel_connect_attempted", attr_type="stats", action_names="set_ha_set_attr")
+    DEFINE_HIT_COUNTER(cp_data_channel_connect_received, MAX_HA_SET, name="cp_data_channel_connect_received", attr_type="stats", action_names="set_ha_set_attr")
+    DEFINE_HIT_COUNTER(cp_data_channel_connect_succeeded, MAX_HA_SET, name="cp_data_channel_connect_succeeded", attr_type="stats", action_names="set_ha_set_attr")
+    DEFINE_HIT_COUNTER(cp_data_channel_connect_failed, MAX_HA_SET, name="cp_data_channel_connect_failed", attr_type="stats", action_names="set_ha_set_attr")
+    DEFINE_HIT_COUNTER(cp_data_channel_connect_rejected, MAX_HA_SET, name="cp_data_channel_connect_rejected", attr_type="stats", action_names="set_ha_set_attr")
+    DEFINE_HIT_COUNTER(cp_data_channel_timeout_count, MAX_HA_SET, name="cp_data_channel_timeout_count", attr_type="stats", action_names="set_ha_set_attr")
 
     // Bulk sync related counters
-    DEFINE_HIT_COUNTER(bulk_sync_message_received, MAX_HA_SET, name="bulk_sync_message_received", attr_type="stats", action_names="set_ha_set_attr", order=1)
-    DEFINE_HIT_COUNTER(bulk_sync_message_sent, MAX_HA_SET, name="bulk_sync_message_sent", attr_type="stats", action_names="set_ha_set_attr", order=1)
-    DEFINE_HIT_COUNTER(bulk_sync_message_send_failed, MAX_HA_SET, name="bulk_sync_message_send_failed", attr_type="stats", action_names="set_ha_set_attr", order=1)
-    DEFINE_HIT_COUNTER(bulk_sync_flow_received, MAX_HA_SET, name="bulk_sync_flow_received", attr_type="stats", action_names="set_ha_set_attr", order=1)
-    DEFINE_HIT_COUNTER(bulk_sync_flow_sent, MAX_HA_SET, name="bulk_sync_flow_sent", attr_type="stats", action_names="set_ha_set_attr", order=1)
+    DEFINE_HIT_COUNTER(bulk_sync_message_received, MAX_HA_SET, name="bulk_sync_message_received", attr_type="stats", action_names="set_ha_set_attr")
+    DEFINE_HIT_COUNTER(bulk_sync_message_sent, MAX_HA_SET, name="bulk_sync_message_sent", attr_type="stats", action_names="set_ha_set_attr")
+    DEFINE_HIT_COUNTER(bulk_sync_message_send_failed, MAX_HA_SET, name="bulk_sync_message_send_failed", attr_type="stats", action_names="set_ha_set_attr")
+    DEFINE_HIT_COUNTER(bulk_sync_flow_received, MAX_HA_SET, name="bulk_sync_flow_received", attr_type="stats", action_names="set_ha_set_attr")
+    DEFINE_HIT_COUNTER(bulk_sync_flow_sent, MAX_HA_SET, name="bulk_sync_flow_sent", attr_type="stats", action_names="set_ha_set_attr")
 
     action set_ha_set_attr(
         bit<1> local_ip_is_v6,


### PR DESCRIPTION
Since we can now use SAI spec to handle the order of all attributes and APIs, we don't need to explicit specify the order anymore. Hence, removing it from the P4 code.

After all orders are removed, `make sai-header` locally will not cause any SAI API change as below:

```
r12f@r12f-dl380:~/code/sonic/DASH/dash-pipeline/SAI/SAI
$ gst
On branch temp
Your branch is up to date with 'origin/temp'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        bm/

nothing added to commit but untracked files present (use "git add" to track)
```

The order attribute in the SaiTable annotation still needs to be kept, because the lib generation will require it to be present to generate the API initialization code correctly.