### PR TITLE
Add support for DPU scope DPU driven HA

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -377,6 +377,7 @@ Novus
 NPL
 NPU
 NPUS
+NPUs
 NSG
 NSGs
 num
@@ -736,3 +737,5 @@ validonly
 pb
 proto
 smac
+BFD
+hamgrd

--- a/dash-pipeline/SAI/specs/dash_eni.yaml
+++ b/dash-pipeline/SAI/specs/dash_eni.yaml
@@ -585,6 +585,19 @@ sai_apis:
     valid_only: null
     is_vlan: false
     deprecated: false
+  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
+    name: SAI_ENI_ATTR_IS_HA_FLOW_OWNER
+    description: Action parameter is HA flow owner
+    type: bool
+    attr_value_field: booldata
+    default: 'false'
+    isresourcetype: false
+    flags: CREATE_AND_SET
+    object_name: null
+    allow_null: false
+    valid_only: null
+    is_vlan: false
+    deprecated: false
   stats:
   - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
     name: SAI_ENI_STAT_RX_BYTES

--- a/dash-pipeline/SAI/specs/dash_ha.yaml
+++ b/dash-pipeline/SAI/specs/dash_ha.yaml
@@ -127,6 +127,19 @@ sai_apis:
     valid_only: null
     is_vlan: false
     deprecated: false
+  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
+    name: SAI_HA_SET_ATTR_SWITCHOVER_NETWORK_CONVERGENCE_TIME_MS
+    description: Action parameter switchover network convergence time ms
+    type: sai_uint32_t
+    attr_value_field: u32
+    default: '0'
+    isresourcetype: false
+    flags: CREATE_AND_SET
+    object_name: null
+    allow_null: false
+    valid_only: null
+    is_vlan: false
+    deprecated: false
   stats:
   - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
     name: SAI_HA_SET_STAT_DP_PROBE_REQ_RX_BYTES
@@ -461,6 +474,71 @@ sai_apis:
     description: Action parameter flow reconcile needed
     type: bool
     attr_value_field: booldata
+    default: null
+    isresourcetype: false
+    flags: READ_ONLY
+    object_name: null
+    allow_null: false
+    valid_only: null
+    is_vlan: false
+    deprecated: false
+  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
+    name: SAI_HA_SCOPE_ATTR_VIP_V4
+    description: Action parameter VIP v4
+    type: sai_ip_address_t
+    attr_value_field: ipaddr
+    default: 0.0.0.0
+    isresourcetype: false
+    flags: CREATE_AND_SET
+    object_name: null
+    allow_null: false
+    valid_only: null
+    is_vlan: false
+    deprecated: false
+  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
+    name: SAI_HA_SCOPE_ATTR_VIP_V6
+    description: Action parameter VIP v6
+    type: sai_ip_address_t
+    attr_value_field: ipaddr
+    default: 0.0.0.0
+    isresourcetype: false
+    flags: CREATE_AND_SET
+    object_name: null
+    allow_null: false
+    valid_only: null
+    is_vlan: false
+    deprecated: false
+  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
+    name: SAI_HA_SCOPE_ATTR_ADMIN_STATE
+    description: Action parameter admin state
+    type: bool
+    attr_value_field: booldata
+    default: 'false'
+    isresourcetype: false
+    flags: CREATE_AND_SET
+    object_name: null
+    allow_null: false
+    valid_only: null
+    is_vlan: false
+    deprecated: false
+  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
+    name: SAI_HA_SCOPE_ATTR_ACTIVATE_ROLE
+    description: Action parameter activate role
+    type: bool
+    attr_value_field: booldata
+    default: 'false'
+    isresourcetype: false
+    flags: CREATE_AND_SET
+    object_name: null
+    allow_null: false
+    valid_only: null
+    is_vlan: false
+    deprecated: false
+  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
+    name: SAI_HA_SCOPE_ATTR_DASH_HA_STATE
+    description: Action parameter DASH HA state
+    type: sai_dash_ha_state_t
+    attr_value_field: s32
     default: null
     isresourcetype: false
     flags: READ_ONLY

--- a/dash-pipeline/SAI/specs/sai_spec.yaml
+++ b/dash-pipeline/SAI/specs/sai_spec.yaml
@@ -314,6 +314,62 @@ enums:
     name: NONE
     description: ''
     value: '0'
+- !!python/object:utils.sai_spec.sai_enum.SaiEnum
+  name: sai_dash_ha_state_t
+  description: ''
+  members:
+  - !!python/object:utils.sai_spec.sai_enum_member.SaiEnumMember
+    name: DEAD
+    description: ''
+    value: '0'
+  - !!python/object:utils.sai_spec.sai_enum_member.SaiEnumMember
+    name: CONNECTING
+    description: ''
+    value: '1'
+  - !!python/object:utils.sai_spec.sai_enum_member.SaiEnumMember
+    name: CONNECTED
+    description: ''
+    value: '2'
+  - !!python/object:utils.sai_spec.sai_enum_member.SaiEnumMember
+    name: INITIALIZING_TO_ACTIVE
+    description: ''
+    value: '3'
+  - !!python/object:utils.sai_spec.sai_enum_member.SaiEnumMember
+    name: INITIALIZING_TO_STANDBY
+    description: ''
+    value: '4'
+  - !!python/object:utils.sai_spec.sai_enum_member.SaiEnumMember
+    name: PENDING_STANDALONE_ACTIVATION
+    description: ''
+    value: '5'
+  - !!python/object:utils.sai_spec.sai_enum_member.SaiEnumMember
+    name: PENDING_ACTIVE_ACTIVATION
+    description: ''
+    value: '6'
+  - !!python/object:utils.sai_spec.sai_enum_member.SaiEnumMember
+    name: PENDING_STANDBY_ACTIVATION
+    description: ''
+    value: '7'
+  - !!python/object:utils.sai_spec.sai_enum_member.SaiEnumMember
+    name: STANDALONE
+    description: ''
+    value: '8'
+  - !!python/object:utils.sai_spec.sai_enum_member.SaiEnumMember
+    name: ACTIVE
+    description: ''
+    value: '9'
+  - !!python/object:utils.sai_spec.sai_enum_member.SaiEnumMember
+    name: STANDBY
+    description: ''
+    value: '10'
+  - !!python/object:utils.sai_spec.sai_enum_member.SaiEnumMember
+    name: DESTROYING
+    description: ''
+    value: '11'
+  - !!python/object:utils.sai_spec.sai_enum_member.SaiEnumMember
+    name: SWITCHING_TO_STANDALONE
+    description: ''
+    value: '12'
 port_extenstion: !!python/object:utils.sai_spec.sai_api_extension.SaiApiExtension
   attributes: []
   stats:

--- a/dash-pipeline/bmv2/dash_metadata.p4
+++ b/dash-pipeline/bmv2/dash_metadata.p4
@@ -106,7 +106,7 @@ enum bit<16> dash_flow_entry_bulk_get_session_filter_key_t
     DST_IP_ADDR = 5,
     SRC_L4_PORT = 6,
     DST_L4_PORT = 7,
-    KEY_VERSION = 8 
+    KEY_VERSION = 8
 }
 
 enum bit<8> dash_flow_entry_bulk_get_session_op_key_t
@@ -123,7 +123,7 @@ struct conntrack_data_t {
     bool allow_in;
     bool allow_out;
     flow_table_data_t flow_table;
-    EthernetAddress eni_mac; 
+    EthernetAddress eni_mac;
     flow_data_t flow_data;
     flow_key_t flow_key;
     flow_key_t reverse_flow_key;
@@ -169,7 +169,7 @@ struct encap_data_t {
     dash_encapsulation_t dash_encapsulation;
     EthernetAddress underlay_smac;
     EthernetAddress underlay_dmac;
-}    
+}
 
 struct overlay_rewrite_data_t {
     bool is_ipv6;
@@ -187,6 +187,35 @@ enum bit<8> dash_ha_role_t {
     STANDBY = 2,
     STANDALONE = 3,
     SWITCHING_TO_ACTIVE = 4
+};
+
+// HA states
+enum bit<8> dash_ha_state_t {
+    DEAD = 0,
+    // trying to connect to HA pair
+    CONNECTING = 1,
+    // bulk sync in progress
+    CONNECTED = 2,
+    // connection successful, bulk sync in progress
+    INITIALIZING_TO_ACTIVE      = 3,
+    // connection successful, bulk sync in progress
+    INITIALIZING_TO_STANDBY     = 4,
+    // ready to be in STANDALONE state, waiting for activation of admin role
+    PENDING_STANDALONE_ACTIVATION  = 5,
+    // ready to be in ACTIVE state, waiting for activation of admin role
+    PENDING_ACTIVE_ACTIVATION      = 6,
+    // ready to be in STANDBY state, waiting for activation of admin role
+    PENDING_STANDBY_ACTIVATION     = 7,
+    // activation done, fowarding traffic
+    STANDALONE = 8,
+    // activation done, fowarding traffic and syncing flows with HA pair
+    ACTIVE = 9,
+    // activation done, ready to fowarding traffic if pair fails
+    STANDBY = 10,
+    // going down for planned shutdown
+    DESTROYING = 11,
+    // gracefully transitioning from paired state to stand-alone
+    SWITCHING_TO_STANDALONE = 12
 };
 
 // Flow sync state

--- a/dash-pipeline/bmv2/dash_pipeline.p4
+++ b/dash-pipeline/bmv2/dash_pipeline.p4
@@ -113,7 +113,8 @@ control dash_ingress(
                          bit<1> disable_fast_path_icmp_flow_redirection,
                          bit<1> full_flow_resimulation_requested,
                          bit<64> max_resimulated_flow_per_second,
-                         @SaiVal[type="sai_object_id_t"] bit<16> outbound_routing_group_id)
+                         @SaiVal[type="sai_object_id_t"] bit<16> outbound_routing_group_id,
+                         bit<1> is_ha_flow_owner)
     {
         meta.eni_data.cps                                                   = cps;
         meta.eni_data.pps                                                   = pps;
@@ -338,7 +339,7 @@ control dash_ingress(
         }
 
         conntrack_lookup_stage.apply(hdr, meta);
-        
+
         UPDATE_ENI_COUNTER(eni_rx);
         if (meta.is_fast_path_icmp_flow_redirection_packet) {
             UPDATE_ENI_COUNTER(eni_lb_fast_path_icmp_in);
@@ -375,7 +376,7 @@ control dash_ingress(
     #endif // TARGET_BMV2_V1MODEL
     #ifdef TARGET_DPDK_PNA
             , istd
-    #endif // TARGET_DPDK_PNA        
+    #endif // TARGET_DPDK_PNA
         );
 
         if (meta.eni_data.dscp_mode == dash_tunnel_dscp_mode_t.PIPE_MODEL) {

--- a/dash-pipeline/bmv2/stages/ha.p4
+++ b/dash-pipeline/bmv2/stages/ha.p4
@@ -12,7 +12,12 @@ control ha_stage(inout headers_t hdr,
         @SaiVal[type="sai_dash_ha_role_t"] dash_ha_role_t dash_ha_role,
         @SaiVal[isreadonly="true"] bit<32> flow_version,
         bit<1> flow_reconcile_requested,
-        @SaiVal[isreadonly="true"] bit<1> flow_reconcile_needed
+        @SaiVal[isreadonly="true"] bit<1> flow_reconcile_needed,
+        @SaiVal[type="sai_ip_address_t"] IPv4Address vip_v4,
+        IPv6Address vip_v6,
+        bit<1> admin_state,
+        bit<1> activate_role,
+        @SaiVal[isreadonly="true", type="sai_dash_ha_state_t"] dash_ha_state_t dash_ha_state
     ) {
         meta.ha.ha_set_id = ha_set_id;
         meta.ha.ha_role = dash_ha_role;
@@ -65,11 +70,12 @@ control ha_stage(inout headers_t hdr,
         bit<16> dp_channel_max_src_port,
         bit<32> dp_channel_probe_interval_ms,
         bit<32> dp_channel_probe_fail_threshold,
-        @SaiVal[isreadonly="true"] bit<1> dp_channel_is_alive
+        @SaiVal[isreadonly="true"] bit<1> dp_channel_is_alive,
+        bit<32> switchover_network_convergence_time_ms
     ) {
         meta.ha.peer_ip_is_v6 = peer_ip_is_v6;
         meta.ha.peer_ip = peer_ip;
-        
+
         meta.ha.dp_channel_dst_port = dp_channel_dst_port;
         meta.ha.dp_channel_src_port_min = dp_channel_min_src_port;
         meta.ha.dp_channel_src_port_max = dp_channel_max_src_port;
@@ -97,7 +103,7 @@ control ha_stage(inout headers_t hdr,
             return;
         }
         ha_set.apply();
-    
+
         // TODO: HA state machine handling.
     }
 }

--- a/documentation/high-avail/ha-api-hld.md
+++ b/documentation/high-avail/ha-api-hld.md
@@ -108,7 +108,7 @@ HA set is defined as a SAI object and contains the following SAI attributes:
 | SAI_HA_SET_ATTR_DP_CHANNEL_PROBE_INTERVAL_MS | `sai_uint32_t` | The interval of the data plane channel probe. |
 | SAI_HA_SET_ATTR_DP_CHANNEL_PROBE_FAIL_THRESHOLD | `sai_uint32_t` | The threshold of the data plane channel probe fail. |
 | SAI_HA_SET_ATTR_DP_CHANNEL_IS_ALIVE | `bool` | (Read-only) Is data plane channel alive. |
-| SAI_HA_SET_ATTR_SWITCHOVER_NETWORK_CONVERGENCE_TIME_MS | sai_uint32_t | Time for which DPU driven HA state machine needs to wait for the network to switchover traffic during planned shutdown of the other DPU in the HA pair. |
+| SAI_HA_SET_ATTR_DPU_DRIVEN_HA_SWITCHOVER_WAIT_TIME_MS | sai_uint32_t | Time to wait for the network to switchover traffic in DPU driven HA mode. |
 
 ### 4.2. HA Scope
 
@@ -121,10 +121,10 @@ HA scope is also defined as a SAI object and contains the following SAI attribut
 | SAI_HA_SCOPE_ATTR_FLOW_VERSION | `sai_uint32_t` | The flow version for new flows. |
 | SAI_HA_SCOPE_ATTR_FLOW_RECONCILE_REQUESTED | `bool` | When set to true, flow reconcile will be initiated. |
 | SAI_HA_SCOPE_ATTR_FLOW_RECONCILE_NEEDED | `bool` | (Read-only) If true, flow reconcile is needed. |
-| SAI_HA_SCOPE_ATTR_VIP_V4 | `sai_ip_address_t` | Dedicated IPv4 VIP for DPU HA scope. |
-| SAI_HA_SCOPE_ATTR_VIP_V6 | `sai_ip_address_t` | Dedicated IPv6 VIP for DPU HA scope. |
-| SAI_HA_SCOPE_ATTR_ADMIN_STATE | `bool` | Start or stop the DPU driven HA state machine. |
-| SAI_HA_SCOPE_ATTR_HA_STATE | `sai_dash_ha_state_t` | Read-only state in case of DPU driven state machine. |
+| SAI_HA_SCOPE_ATTR_VIP_V4 | `sai_ip_address_t` | IPv4 VIP of the HA scope (Used in DPU driven HA mode only). |
+| SAI_HA_SCOPE_ATTR_VIP_V6 | `sai_ip_address_t` | IPv6 VIP of the HA scope (Used in DPU driven HA mode only). |
+| SAI_HA_SCOPE_ATTR_ADMIN_STATE | `bool` | Administrative control of HA scope (In case of DPU driven HA mode, this is used to start or stop HA state machine). |
+| SAI_HA_SCOPE_ATTR_HA_STATE | `sai_dash_ha_state_t` | (Read-only) Operational HA state. |
 | SAI_HA_SCOPE_ATTR_ACTIVATE_ROLE | `bool` | Trigger DPU driven HA state machine to transition to steady state and prepare to start receiving traffic destined to VIP. |
 
 The HA role is defined as below:
@@ -292,10 +292,13 @@ Similar to HA set, whenever any HA scope state is changed, it will be reported b
 typedef enum _sai_ha_scope_event_t
 {
     /** HA scope state changed */
-    SAI_HA_SCOPE_STATE_CHANGED,
+    SAI_HA_SCOPE_EVENT_STATE_CHANGED,
 
     /** Flow reconcile is needed */
-    SAI_HA_SCOPE_FLOW_RECONCILE_NEEDED,
+    SAI_HA_SCOPE_EVENT_FLOW_RECONCILE_NEEDED,
+
+    /** DPU driven HA split brain detected */
+    SAI_HA_SCOPE_EVENT_SPLIT_BRAIN_DETECTED,
 
 } sai_ha_scope_event_t;
 
@@ -316,7 +319,7 @@ typedef struct _sai_ha_scope_event_data_t
     /** Flow version */
     sai_uint32_t flow_version;
 
-    /** HA role */
+    /** HA state */
     sai_dash_ha_state_t ha_state;
 
 } sai_ha_scope_event_data_t;


### PR DESCRIPTION
This PR adds SAI API support for the DPU scope DPU driven Dash HA mode described in this PR. 
https://github.com/sonic-net/SONiC/pull/1710

In this mode, the HA scope / HA state is at the DPU level. Also the DPU vendor SDK owns the HA state machine and drives state transitions on its own by directly communicating with its HA pair underneath the SAI layer. The DPU SDK advertises HA state changes as SAI event notifications.