### PR TITLE
Update the SAI specs to make it match with the latest merged SAI APIs

### DIFF
--- a/dash-pipeline/SAI/specs/dash_outbound_ca_to_pa.yaml
+++ b/dash-pipeline/SAI/specs/dash_outbound_ca_to_pa.yaml
@@ -112,6 +112,20 @@ sai_apis:
     is_vlan: false
     deprecated: false
   - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
+    name: SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_DASH_TUNNEL_ID
+    description: Action parameter DASH tunnel id
+    type: sai_object_id_t
+    attr_value_field: u16
+    default: SAI_NULL_OBJECT_ID
+    isresourcetype: false
+    flags: CREATE_AND_SET
+    object_name: SAI_OBJECT_TYPE_DASH_TUNNEL
+    allow_null: true
+    valid_only: SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_ACTION == SAI_OUTBOUND_CA_TO_PA_ENTRY_ACTION_SET_TUNNEL_MAPPING
+      or SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_ACTION == SAI_OUTBOUND_CA_TO_PA_ENTRY_ACTION_SET_PRIVATE_LINK_MAPPING
+    is_vlan: false
+    deprecated: false
+  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
     name: SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_FLOW_RESIMULATION_REQUESTED
     description: Action parameter flow re-simulation requested
     type: bool
@@ -153,8 +167,34 @@ sai_apis:
     is_vlan: false
     deprecated: false
   - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
+    name: SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_OVERLAY_SIP_MASK
+    description: Action parameter overlay sip mask
+    type: sai_ip_address_t
+    attr_value_field: ipaddr
+    default: 0.0.0.0
+    isresourcetype: false
+    flags: CREATE_AND_SET
+    object_name: null
+    allow_null: false
+    valid_only: SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_ACTION == SAI_OUTBOUND_CA_TO_PA_ENTRY_ACTION_SET_PRIVATE_LINK_MAPPING
+    is_vlan: false
+    deprecated: false
+  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
     name: SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_OVERLAY_DIP
     description: Action parameter overlay dip
+    type: sai_ip_address_t
+    attr_value_field: ipaddr
+    default: 0.0.0.0
+    isresourcetype: false
+    flags: CREATE_AND_SET
+    object_name: null
+    allow_null: false
+    valid_only: SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_ACTION == SAI_OUTBOUND_CA_TO_PA_ENTRY_ACTION_SET_PRIVATE_LINK_MAPPING
+    is_vlan: false
+    deprecated: false
+  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
+    name: SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_OVERLAY_DIP_MASK
+    description: Action parameter overlay dip mask
     type: sai_ip_address_t
     attr_value_field: ipaddr
     default: 0.0.0.0
@@ -215,46 +255,6 @@ sai_apis:
     object_name: null
     allow_null: false
     valid_only: null
-    is_vlan: false
-    deprecated: false
-  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
-    name: SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_DASH_TUNNEL_ID
-    description: Action parameter DASH tunnel id
-    type: sai_object_id_t
-    attr_value_field: u16
-    default: SAI_NULL_OBJECT_ID
-    isresourcetype: false
-    flags: CREATE_AND_SET
-    object_name: SAI_OBJECT_TYPE_DASH_TUNNEL
-    allow_null: true
-    valid_only: SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_ACTION == SAI_OUTBOUND_CA_TO_PA_ENTRY_ACTION_SET_TUNNEL_MAPPING
-      or SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_ACTION == SAI_OUTBOUND_CA_TO_PA_ENTRY_ACTION_SET_PRIVATE_LINK_MAPPING
-    is_vlan: false
-    deprecated: false
-  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
-    name: SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_OVERLAY_SIP_MASK
-    description: Action parameter overlay sip mask
-    type: sai_ip_address_t
-    attr_value_field: ipaddr
-    default: 0.0.0.0
-    isresourcetype: false
-    flags: CREATE_AND_SET
-    object_name: null
-    allow_null: false
-    valid_only: SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_ACTION == SAI_OUTBOUND_CA_TO_PA_ENTRY_ACTION_SET_PRIVATE_LINK_MAPPING
-    is_vlan: false
-    deprecated: false
-  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
-    name: SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_OVERLAY_DIP_MASK
-    description: Action parameter overlay dip mask
-    type: sai_ip_address_t
-    attr_value_field: ipaddr
-    default: 0.0.0.0
-    isresourcetype: false
-    flags: CREATE_AND_SET
-    object_name: null
-    allow_null: false
-    valid_only: SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_ACTION == SAI_OUTBOUND_CA_TO_PA_ENTRY_ACTION_SET_PRIVATE_LINK_MAPPING
     is_vlan: false
     deprecated: false
   stats: []

--- a/dash-pipeline/SAI/specs/dash_outbound_routing.yaml
+++ b/dash-pipeline/SAI/specs/dash_outbound_routing.yaml
@@ -84,6 +84,22 @@ sai_apis:
     is_vlan: false
     deprecated: false
   - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
+    name: SAI_OUTBOUND_ROUTING_ENTRY_ATTR_DASH_TUNNEL_ID
+    description: Action parameter DASH tunnel id
+    type: sai_object_id_t
+    attr_value_field: u16
+    default: SAI_NULL_OBJECT_ID
+    isresourcetype: false
+    flags: CREATE_AND_SET
+    object_name: SAI_OBJECT_TYPE_DASH_TUNNEL
+    allow_null: true
+    valid_only: SAI_OUTBOUND_ROUTING_ENTRY_ATTR_ACTION == SAI_OUTBOUND_ROUTING_ENTRY_ACTION_ROUTE_VNET
+      or SAI_OUTBOUND_ROUTING_ENTRY_ATTR_ACTION == SAI_OUTBOUND_ROUTING_ENTRY_ACTION_ROUTE_VNET_DIRECT
+      or SAI_OUTBOUND_ROUTING_ENTRY_ATTR_ACTION == SAI_OUTBOUND_ROUTING_ENTRY_ACTION_ROUTE_DIRECT
+      or SAI_OUTBOUND_ROUTING_ENTRY_ATTR_ACTION == SAI_OUTBOUND_ROUTING_ENTRY_ACTION_ROUTE_SERVICE_TUNNEL
+    is_vlan: false
+    deprecated: false
+  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
     name: SAI_OUTBOUND_ROUTING_ENTRY_ATTR_METER_CLASS_OR
     description: Action parameter meter class or
     type: sai_uint32_t
@@ -272,22 +288,6 @@ sai_apis:
     object_name: null
     allow_null: false
     valid_only: null
-    is_vlan: false
-    deprecated: false
-  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
-    name: SAI_OUTBOUND_ROUTING_ENTRY_ATTR_DASH_TUNNEL_ID
-    description: Action parameter DASH tunnel id
-    type: sai_object_id_t
-    attr_value_field: u16
-    default: SAI_NULL_OBJECT_ID
-    isresourcetype: false
-    flags: CREATE_AND_SET
-    object_name: SAI_OBJECT_TYPE_DASH_TUNNEL
-    allow_null: true
-    valid_only: SAI_OUTBOUND_ROUTING_ENTRY_ATTR_ACTION == SAI_OUTBOUND_ROUTING_ENTRY_ACTION_ROUTE_VNET
-      or SAI_OUTBOUND_ROUTING_ENTRY_ATTR_ACTION == SAI_OUTBOUND_ROUTING_ENTRY_ACTION_ROUTE_VNET_DIRECT
-      or SAI_OUTBOUND_ROUTING_ENTRY_ATTR_ACTION == SAI_OUTBOUND_ROUTING_ENTRY_ACTION_ROUTE_DIRECT
-      or SAI_OUTBOUND_ROUTING_ENTRY_ATTR_ACTION == SAI_OUTBOUND_ROUTING_ENTRY_ACTION_ROUTE_SERVICE_TUNNEL
     is_vlan: false
     deprecated: false
   stats: []


### PR DESCRIPTION
Some SAI APIs are merged during the effort of enabling the SAI spec, hence updating the spec manually to make them match.