### PR TITLE
[dash-p4] Add ENI mac override support on direction lookup stage.

### DIFF
--- a/dash-pipeline/SAI/specs/dash_direction_lookup.yaml
+++ b/dash-pipeline/SAI/specs/dash_direction_lookup.yaml
@@ -16,6 +16,10 @@ sai_apis:
       name: SAI_DIRECTION_LOOKUP_ENTRY_ACTION_SET_OUTBOUND_DIRECTION
       description: ''
       value: '0'
+    - !!python/object:utils.sai_spec.sai_enum_member.SaiEnumMember
+      name: SAI_DIRECTION_LOOKUP_ENTRY_ACTION_SET_INBOUND_DIRECTION
+      description: ''
+      value: '1'
   structs:
   - !!python/object:utils.sai_spec.sai_struct.SaiStruct
     name: sai_direction_lookup_entry_t
@@ -47,6 +51,20 @@ sai_apis:
     valid_only: null
     deprecated: false
     is_vlan: false
+  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
+    name: SAI_DIRECTION_LOOKUP_ENTRY_ATTR_DASH_ENI_MAC_OVERRIDE_TYPE
+    description: Action parameter DASH ENI MAC override type
+    type: sai_dash_eni_mac_override_type_t
+    attr_value_field: s32
+    default: SAI_DASH_ENI_MAC_OVERRIDE_TYPE_NONE
+    isresourcetype: false
+    flags: CREATE_AND_SET
+    object_name: null
+    allow_null: false
+    valid_only: SAI_DIRECTION_LOOKUP_ENTRY_ATTR_ACTION == SAI_DIRECTION_LOOKUP_ENTRY_ACTION_SET_OUTBOUND_DIRECTION
+      or SAI_DIRECTION_LOOKUP_ENTRY_ATTR_ACTION == SAI_DIRECTION_LOOKUP_ENTRY_ACTION_SET_INBOUND_DIRECTION
+    is_vlan: false
+    deprecated: false
   stats: []
   p4_meta: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4Meta
     tables:
@@ -56,4 +74,10 @@ sai_apis:
         SAI_DIRECTION_LOOKUP_ENTRY_ACTION_SET_OUTBOUND_DIRECTION: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaAction
           name: SAI_DIRECTION_LOOKUP_ENTRY_ACTION_SET_OUTBOUND_DIRECTION
           id: 17408972
-          attr_param_id: {}
+          attr_param_id:
+            SAI_DIRECTION_LOOKUP_ENTRY_ATTR_DASH_ENI_MAC_OVERRIDE_TYPE: 1
+        SAI_DIRECTION_LOOKUP_ENTRY_ACTION_SET_INBOUND_DIRECTION: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaAction
+          name: SAI_DIRECTION_LOOKUP_ENTRY_ACTION_SET_INBOUND_DIRECTION
+          id: 21063902
+          attr_param_id:
+            SAI_DIRECTION_LOOKUP_ENTRY_ATTR_DASH_ENI_MAC_OVERRIDE_TYPE: 1

--- a/dash-pipeline/SAI/specs/dash_direction_lookup.yaml
+++ b/dash-pipeline/SAI/specs/dash_direction_lookup.yaml
@@ -16,10 +16,6 @@ sai_apis:
       name: SAI_DIRECTION_LOOKUP_ENTRY_ACTION_SET_OUTBOUND_DIRECTION
       description: ''
       value: '0'
-    - !!python/object:utils.sai_spec.sai_enum_member.SaiEnumMember
-      name: SAI_DIRECTION_LOOKUP_ENTRY_ACTION_SET_INBOUND_DIRECTION
-      description: ''
-      value: '1'
   structs:
   - !!python/object:utils.sai_spec.sai_struct.SaiStruct
     name: sai_direction_lookup_entry_t
@@ -61,8 +57,7 @@ sai_apis:
     flags: CREATE_AND_SET
     object_name: null
     allow_null: false
-    valid_only: SAI_DIRECTION_LOOKUP_ENTRY_ATTR_ACTION == SAI_DIRECTION_LOOKUP_ENTRY_ACTION_SET_OUTBOUND_DIRECTION
-      or SAI_DIRECTION_LOOKUP_ENTRY_ATTR_ACTION == SAI_DIRECTION_LOOKUP_ENTRY_ACTION_SET_INBOUND_DIRECTION
+    valid_only: null
     is_vlan: false
     deprecated: false
   stats: []
@@ -74,10 +69,5 @@ sai_apis:
         SAI_DIRECTION_LOOKUP_ENTRY_ACTION_SET_OUTBOUND_DIRECTION: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaAction
           name: SAI_DIRECTION_LOOKUP_ENTRY_ACTION_SET_OUTBOUND_DIRECTION
           id: 17408972
-          attr_param_id:
-            SAI_DIRECTION_LOOKUP_ENTRY_ATTR_DASH_ENI_MAC_OVERRIDE_TYPE: 1
-        SAI_DIRECTION_LOOKUP_ENTRY_ACTION_SET_INBOUND_DIRECTION: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaAction
-          name: SAI_DIRECTION_LOOKUP_ENTRY_ACTION_SET_INBOUND_DIRECTION
-          id: 21063902
           attr_param_id:
             SAI_DIRECTION_LOOKUP_ENTRY_ATTR_DASH_ENI_MAC_OVERRIDE_TYPE: 1

--- a/dash-pipeline/SAI/specs/sai_spec.yaml
+++ b/dash-pipeline/SAI/specs/sai_spec.yaml
@@ -377,6 +377,22 @@ enums:
     name: SWITCHING_TO_STANDALONE
     description: ''
     value: '12'
+- !!python/object:utils.sai_spec.sai_enum.SaiEnum
+  name: sai_dash_eni_mac_override_type_t
+  description: ''
+  members:
+  - !!python/object:utils.sai_spec.sai_enum_member.SaiEnumMember
+    name: NONE
+    description: ''
+    value: '0'
+  - !!python/object:utils.sai_spec.sai_enum_member.SaiEnumMember
+    name: SRC_MAC
+    description: ''
+    value: '1'
+  - !!python/object:utils.sai_spec.sai_enum_member.SaiEnumMember
+    name: DST_MAC
+    description: ''
+    value: '2'
 port_extenstion: !!python/object:utils.sai_spec.sai_api_extension.SaiApiExtension
   attributes: []
   stats:

--- a/dash-pipeline/bmv2/dash_metadata.p4
+++ b/dash-pipeline/bmv2/dash_metadata.p4
@@ -119,6 +119,17 @@ enum bit<8> dash_flow_entry_bulk_get_session_op_key_t
     FILTER_OP_LESS_THAN_OR_EQUAL_TO = 5
 }
 
+enum bit<8> dash_eni_mac_override_type_t {
+    NONE = 0,
+    SRC_MAC = 1,
+    DST_MAC = 2
+};
+
+enum bit<8> dash_eni_mac_type_t {
+    SRC_MAC = 0,
+    DST_MAC = 1
+};
+
 struct conntrack_data_t {
     bool allow_in;
     bool allow_out;
@@ -260,6 +271,8 @@ struct metadata_t {
 
     // Lookup context
     dash_direction_t direction;
+    dash_eni_mac_type_t eni_mac_type;
+    dash_eni_mac_override_type_t eni_mac_override_type;
     EthernetAddress eni_addr;
     bit<16> vnet_id;
     bit<16> dst_vnet_id;

--- a/dash-pipeline/bmv2/stages/direction_lookup.p4
+++ b/dash-pipeline/bmv2/stages/direction_lookup.p4
@@ -27,7 +27,7 @@ control direction_lookup_stage(
 
     action set_inbound_direction() {
         meta.direction = dash_direction_t.INBOUND;
-        set_eni_mac_type(dash_eni_mac_type_t.DST_MAC, dash_eni_mac_override_type_t.NONE);
+        meta.eni_mac_type = dash_eni_mac_type_t.DST_MAC;
     }
 
     @SaiTable[name = "direction_lookup", api = "dash_direction_lookup"]

--- a/dash-pipeline/bmv2/stages/direction_lookup.p4
+++ b/dash-pipeline/bmv2/stages/direction_lookup.p4
@@ -25,11 +25,9 @@ control direction_lookup_stage(
         set_eni_mac_type(dash_eni_mac_type_t.SRC_MAC, dash_eni_mac_override_type);
     }
 
-    action set_inbound_direction(
-        @SaiVal[type="sai_dash_eni_mac_override_type_t"] dash_eni_mac_override_type_t dash_eni_mac_override_type 
-    ) {
+    action set_inbound_direction() {
         meta.direction = dash_direction_t.INBOUND;
-        set_eni_mac_type(dash_eni_mac_type_t.DST_MAC, dash_eni_mac_override_type);
+        set_eni_mac_type(dash_eni_mac_type_t.DST_MAC, dash_eni_mac_override_type_t.NONE);
     }
 
     @SaiTable[name = "direction_lookup", api = "dash_direction_lookup"]
@@ -40,8 +38,10 @@ control direction_lookup_stage(
 
         actions = {
             set_outbound_direction;
-            set_inbound_direction;
+            @defaultonly set_inbound_direction;
         }
+
+        const default_action = set_inbound_direction;
     }
 
     apply {

--- a/dash-pipeline/bmv2/stages/eni_lookup.p4
+++ b/dash-pipeline/bmv2/stages/eni_lookup.p4
@@ -28,9 +28,11 @@ control eni_lookup_stage(
 
     apply {
         /* Put VM's MAC in the direction agnostic metadata field */
-        meta.eni_addr = meta.direction == dash_direction_t.OUTBOUND  ?
-                                          hdr.customer_ethernet.src_addr :
-                                          hdr.customer_ethernet.dst_addr;
+        if (meta.eni_mac_type == dash_eni_mac_type_t.SRC_MAC) { 
+            meta.eni_addr = hdr.customer_ethernet.src_addr;
+        } else {
+            meta.eni_addr = hdr.customer_ethernet.dst_addr;
+        }
                                           
         if (!eni_ether_address_map.apply().hit) {
             UPDATE_COUNTER(eni_miss_drop, 0);

--- a/dash-pipeline/bmv2/stages/outbound_mapping.p4
+++ b/dash-pipeline/bmv2/stages/outbound_mapping.p4
@@ -3,8 +3,9 @@
 
 #include "../dash_routing_types.p4"
 
-control outbound_mapping_stage(inout headers_t hdr,
-                      inout metadata_t meta)
+control outbound_mapping_stage(
+    inout headers_t hdr,
+    inout metadata_t meta)
 {
     DEFINE_TABLE_COUNTER(ca_to_pa_counter)
 

--- a/dash-pipeline/bmv2/stages/outbound_routing.p4
+++ b/dash-pipeline/bmv2/stages/outbound_routing.p4
@@ -3,10 +3,10 @@
 
 #include "../dash_routing_types.p4"
 
-control outbound_routing_stage(inout headers_t hdr,
-                               inout metadata_t meta)
+control outbound_routing_stage(
+    inout headers_t hdr,
+    inout metadata_t meta)
 {
-
     action set_outbound_routing_group_attr(bit<1> disabled) {
         meta.eni_data.outbound_routing_group_data.disabled = (bool)disabled;
     }
@@ -64,7 +64,7 @@ control outbound_routing_stage(inout headers_t hdr,
         }
             
         if (!routing.apply().hit) {
-                UPDATE_ENI_COUNTER(outbound_routing_entry_miss_drop);
+            UPDATE_ENI_COUNTER(outbound_routing_entry_miss_drop);
         }
     }
 


### PR DESCRIPTION
This PR adds support to select which MAC address to use for looking up the ENI in the direction lookup stage.

This change follows the ExpressRoute gateway bypass HLD defined in this PR here: https://github.com/sonic-net/DASH/pull/601.