### PR TITLE
[dash-p4] Add reverse routing table and reverse tunnel support.

### DIFF
--- a/dash-pipeline/SAI/specs/dash_eni.yaml
+++ b/dash-pipeline/SAI/specs/dash_eni.yaml
@@ -598,6 +598,19 @@ sai_apis:
     valid_only: null
     is_vlan: false
     deprecated: false
+  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
+    name: SAI_ENI_ATTR_OUTBOUND_REVERSE_ROUTING_GROUP_ID
+    description: Action parameter outbound reverse routing group id
+    type: sai_object_id_t
+    attr_value_field: u16
+    default: SAI_NULL_OBJECT_ID
+    isresourcetype: false
+    flags: CREATE_AND_SET
+    object_name: SAI_OBJECT_TYPE_OUTBOUND_REVERSE_ROUTING_GROUP
+    allow_null: true
+    valid_only: null
+    is_vlan: false
+    deprecated: false
   stats:
   - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
     name: SAI_ENI_STAT_RX_BYTES
@@ -1603,6 +1616,45 @@ sai_apis:
   - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
     name: SAI_ENI_STAT_OUTBOUND_ROUTING_GROUP_DISABLED_DROP_PACKETS
     description: DASH ENI OUTBOUND_ROUTING_GROUP_DISABLED_DROP_PACKETS stat count
+    type: sai_uint64_t
+    attr_value_field: u64
+    default: null
+    isresourcetype: false
+    flags: READ_ONLY
+    object_name: null
+    allow_null: false
+    valid_only: null
+    is_vlan: false
+    deprecated: false
+  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
+    name: SAI_ENI_STAT_REVERSE_TUNNEL_MISS_DROP_PACKETS
+    description: DASH ENI REVERSE_TUNNEL_MISS_DROP_PACKETS stat count
+    type: sai_uint64_t
+    attr_value_field: u64
+    default: null
+    isresourcetype: false
+    flags: READ_ONLY
+    object_name: null
+    allow_null: false
+    valid_only: null
+    is_vlan: false
+    deprecated: false
+  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
+    name: SAI_ENI_STAT_REVERSE_TUNNEL_MEMBER_MISS_DROP_PACKETS
+    description: DASH ENI REVERSE_TUNNEL_MEMBER_MISS_DROP_PACKETS stat count
+    type: sai_uint64_t
+    attr_value_field: u64
+    default: null
+    isresourcetype: false
+    flags: READ_ONLY
+    object_name: null
+    allow_null: false
+    valid_only: null
+    is_vlan: false
+    deprecated: false
+  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
+    name: SAI_ENI_STAT_REVERSE_TUNNEL_NEXT_HOP_MISS_DROP_PACKETS
+    description: DASH ENI REVERSE_TUNNEL_NEXT_HOP_MISS_DROP_PACKETS stat count
     type: sai_uint64_t
     attr_value_field: u64
     default: null

--- a/dash-pipeline/SAI/specs/dash_outbound_reverse_routing.yaml
+++ b/dash-pipeline/SAI/specs/dash_outbound_reverse_routing.yaml
@@ -1,0 +1,149 @@
+!!python/object:utils.sai_spec.sai_api_group.SaiApiGroup
+name: dash_outbound_reverse_routing
+description: DASH outbound reverse routing
+api_type: overlay
+sai_apis:
+- !!python/object:utils.sai_spec.sai_api.SaiApi
+  name: outbound_reverse_routing_group
+  description: outbound reverse routing group
+  is_object: true
+  enums: []
+  structs: []
+  attributes:
+  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
+    name: SAI_OUTBOUND_REVERSE_ROUTING_GROUP_ATTR_DISABLED
+    description: Action parameter disabled
+    type: bool
+    attr_value_field: booldata
+    default: 'false'
+    isresourcetype: false
+    flags: CREATE_AND_SET
+    object_name: null
+    allow_null: false
+    valid_only: null
+    is_vlan: false
+    deprecated: false
+  stats: []
+  p4_meta: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4Meta
+    tables:
+    - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
+      id: 39120190
+      actions:
+        default: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaAction
+          name: default
+          id: 29859952
+          attr_param_id: {}
+- !!python/object:utils.sai_spec.sai_api.SaiApi
+  name: outbound_reverse_routing_entry
+  description: outbound reverse routing entry
+  is_object: false
+  enums:
+  - !!python/object:utils.sai_spec.sai_enum.SaiEnum
+    name: sai_outbound_reverse_routing_entry_action_t
+    description: 'Attribute data for #SAI_OUTBOUND_REVERSE_ROUTING_ENTRY_ATTR_ACTION'
+    members:
+    - !!python/object:utils.sai_spec.sai_enum_member.SaiEnumMember
+      name: SAI_OUTBOUND_REVERSE_ROUTING_ENTRY_ACTION_SET_OUTBOUND_REVERSE_ROUTING_ENTRY_ATTR
+      description: ''
+      value: '0'
+  structs:
+  - !!python/object:utils.sai_spec.sai_struct.SaiStruct
+    name: sai_outbound_reverse_routing_entry_t
+    description: Entry for outbound_reverse_routing_entry
+    members:
+    - !!python/object:utils.sai_spec.sai_struct_entry.SaiStructEntry
+      name: switch_id
+      description: Switch ID
+      type: sai_object_id_t
+      objects: SAI_OBJECT_TYPE_SWITCH
+      valid_only: null
+    - !!python/object:utils.sai_spec.sai_struct_entry.SaiStructEntry
+      name: outbound_reverse_routing_group_id
+      description: Exact matched key outbound_reverse_routing_group_id
+      type: sai_object_id_t
+      objects: SAI_OBJECT_TYPE_OUTBOUND_REVERSE_ROUTING_GROUP
+      valid_only: null
+    - !!python/object:utils.sai_spec.sai_struct_entry.SaiStructEntry
+      name: source
+      description: LPM matched key source
+      type: sai_ip_prefix_t
+      objects: null
+      valid_only: null
+  attributes:
+  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
+    name: SAI_OUTBOUND_REVERSE_ROUTING_ENTRY_ATTR_ACTION
+    description: Action
+    type: sai_outbound_reverse_routing_entry_action_t
+    attr_value_field: null
+    default: SAI_OUTBOUND_REVERSE_ROUTING_ENTRY_ACTION_SET_OUTBOUND_REVERSE_ROUTING_ENTRY_ATTR
+    isresourcetype: false
+    flags: CREATE_AND_SET
+    object_name: null
+    allow_null: false
+    valid_only: null
+    is_vlan: false
+    deprecated: false
+  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
+    name: SAI_OUTBOUND_REVERSE_ROUTING_ENTRY_ATTR_DASH_REVERSE_TUNNEL_ID
+    description: Action parameter DASH reverse tunnel id
+    type: sai_object_id_t
+    attr_value_field: u16
+    default: SAI_NULL_OBJECT_ID
+    isresourcetype: false
+    flags: CREATE_AND_SET
+    object_name: SAI_OBJECT_TYPE_DASH_REVERSE_TUNNEL
+    allow_null: true
+    valid_only: null
+    is_vlan: false
+    deprecated: false
+  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
+    name: SAI_OUTBOUND_REVERSE_ROUTING_ENTRY_ATTR_ROUTING_ACTIONS_DISABLED_IN_FLOW_RESIMULATION
+    description: Action parameter routing actions disabled in flow re-simulation
+    type: sai_uint32_t
+    attr_value_field: u32
+    default: '0'
+    isresourcetype: false
+    flags: CREATE_AND_SET
+    object_name: null
+    allow_null: false
+    valid_only: null
+    is_vlan: false
+    deprecated: false
+  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
+    name: SAI_OUTBOUND_REVERSE_ROUTING_ENTRY_ATTR_COUNTER_ID
+    description: Attach a counter. When it is empty, then packet hits won't be counted.
+    type: sai_object_id_t
+    attr_value_field: null
+    default: SAI_NULL_OBJECT_ID
+    isresourcetype: false
+    flags: CREATE_AND_SET
+    object_name: SAI_OBJECT_TYPE_COUNTER
+    allow_null: true
+    valid_only: null
+    is_vlan: false
+    deprecated: false
+  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
+    name: SAI_OUTBOUND_REVERSE_ROUTING_ENTRY_ATTR_IP_ADDR_FAMILY
+    description: IP address family for resource accounting
+    type: sai_ip_addr_family_t
+    attr_value_field: null
+    default: null
+    isresourcetype: true
+    flags: READ_ONLY
+    object_name: null
+    allow_null: false
+    valid_only: null
+    is_vlan: false
+    deprecated: false
+  stats: []
+  p4_meta: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4Meta
+    tables:
+    - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
+      id: 46283501
+      actions:
+        SAI_OUTBOUND_REVERSE_ROUTING_ENTRY_ACTION_SET_OUTBOUND_REVERSE_ROUTING_ENTRY_ATTR: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaAction
+          name: SAI_OUTBOUND_REVERSE_ROUTING_ENTRY_ACTION_SET_OUTBOUND_REVERSE_ROUTING_ENTRY_ATTR
+          id: 24053233
+          attr_param_id:
+            SAI_OUTBOUND_REVERSE_ROUTING_ENTRY_ATTR_DASH_REVERSE_TUNNEL_ID: 1
+            SAI_OUTBOUND_REVERSE_ROUTING_ENTRY_ATTR_ROUTING_ACTIONS_DISABLED_IN_FLOW_RESIMULATION: 2

--- a/dash-pipeline/SAI/specs/dash_reverse_tunnel.yaml
+++ b/dash-pipeline/SAI/specs/dash_reverse_tunnel.yaml
@@ -1,0 +1,134 @@
+!!python/object:utils.sai_spec.sai_api_group.SaiApiGroup
+name: dash_reverse_tunnel
+description: DASH reverse tunnel
+api_type: overlay
+sai_apis:
+- !!python/object:utils.sai_spec.sai_api.SaiApi
+  name: dash_reverse_tunnel
+  description: DASH reverse tunnel
+  is_object: true
+  enums: []
+  structs: []
+  attributes:
+  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
+    name: SAI_DASH_REVERSE_TUNNEL_ATTR_DASH_ENCAPSULATION
+    description: Action parameter DASH encapsulation
+    type: sai_dash_encapsulation_t
+    attr_value_field: s32
+    default: SAI_DASH_ENCAPSULATION_VXLAN
+    isresourcetype: false
+    flags: CREATE_AND_SET
+    object_name: null
+    allow_null: false
+    valid_only: null
+    is_vlan: false
+    deprecated: false
+  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
+    name: SAI_DASH_REVERSE_TUNNEL_ATTR_TUNNEL_KEY
+    description: Action parameter tunnel key
+    type: sai_uint32_t
+    attr_value_field: u32
+    default: '0'
+    isresourcetype: false
+    flags: CREATE_AND_SET
+    object_name: null
+    allow_null: false
+    valid_only: null
+    is_vlan: false
+    deprecated: false
+  stats: []
+  p4_meta: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4Meta
+    tables:
+    - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
+      id: 49122034
+      actions:
+        default: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaAction
+          name: default
+          id: 17501974
+          attr_param_id: {}
+- !!python/object:utils.sai_spec.sai_api.SaiApi
+  name: dash_reverse_tunnel_member
+  description: DASH reverse tunnel member
+  is_object: true
+  enums: []
+  structs: []
+  attributes:
+  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
+    name: SAI_DASH_REVERSE_TUNNEL_MEMBER_ATTR_DASH_REVERSE_TUNNEL_ID
+    description: Exact matched key dash_reverse_tunnel_id
+    type: sai_object_id_t
+    attr_value_field: u16
+    default: null
+    isresourcetype: false
+    flags: MANDATORY_ON_CREATE | CREATE_ONLY
+    object_name: SAI_OBJECT_TYPE_DASH_REVERSE_TUNNEL
+    allow_null: false
+    valid_only: null
+    is_vlan: false
+    deprecated: false
+  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
+    name: SAI_DASH_REVERSE_TUNNEL_MEMBER_ATTR_DASH_REVERSE_TUNNEL_NEXT_HOP_ID
+    description: Action parameter DASH reverse tunnel next hop id
+    type: sai_object_id_t
+    attr_value_field: u16
+    default: SAI_NULL_OBJECT_ID
+    isresourcetype: false
+    flags: CREATE_AND_SET
+    object_name: SAI_OBJECT_TYPE_DASH_REVERSE_TUNNEL_NEXT_HOP
+    allow_null: true
+    valid_only: null
+    is_vlan: false
+    deprecated: false
+  stats: []
+  p4_meta: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4Meta
+    tables:
+    - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
+      id: 37338287
+      actions:
+        default: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaAction
+          name: default
+          id: 29566243
+          attr_param_id: {}
+- !!python/object:utils.sai_spec.sai_api.SaiApi
+  name: dash_reverse_tunnel_next_hop
+  description: DASH reverse tunnel next hop
+  is_object: true
+  enums: []
+  structs: []
+  attributes:
+  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
+    name: SAI_DASH_REVERSE_TUNNEL_NEXT_HOP_ATTR_DIP
+    description: Action parameter dip
+    type: sai_ip_address_t
+    attr_value_field: ipaddr
+    default: 0.0.0.0
+    isresourcetype: false
+    flags: CREATE_AND_SET
+    object_name: null
+    allow_null: false
+    valid_only: null
+    is_vlan: false
+    deprecated: false
+  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
+    name: SAI_DASH_REVERSE_TUNNEL_NEXT_HOP_ATTR_SIP
+    description: Action parameter sip
+    type: sai_ip_address_t
+    attr_value_field: ipaddr
+    default: 0.0.0.0
+    isresourcetype: false
+    flags: CREATE_AND_SET
+    object_name: null
+    allow_null: false
+    valid_only: null
+    is_vlan: false
+    deprecated: false
+  stats: []
+  p4_meta: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4Meta
+    tables:
+    - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
+      id: 37313152
+      actions:
+        default: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaAction
+          name: default
+          id: 25630550
+          attr_param_id: {}

--- a/dash-pipeline/SAI/specs/sai_spec.yaml
+++ b/dash-pipeline/SAI/specs/sai_spec.yaml
@@ -14,6 +14,8 @@ api_types:
 - SAI_API_DASH_VIP
 - SAI_API_DASH_TUNNEL
 - SAI_API_DASH_FLOW
+- SAI_API_DASH_OUTBOUND_REVERSE_ROUTING
+- SAI_API_DASH_REVERSE_TUNNEL
 object_types:
 - SAI_OBJECT_TYPE_DASH_ACL_GROUP
 - SAI_OBJECT_TYPE_DASH_ACL_RULE
@@ -38,6 +40,11 @@ object_types:
 - SAI_OBJECT_TYPE_FLOW_ENTRY
 - SAI_OBJECT_TYPE_FLOW_ENTRY_BULK_GET_SESSION_FILTER
 - SAI_OBJECT_TYPE_FLOW_ENTRY_BULK_GET_SESSION
+- SAI_OBJECT_TYPE_OUTBOUND_REVERSE_ROUTING_GROUP
+- SAI_OBJECT_TYPE_OUTBOUND_REVERSE_ROUTING_ENTRY
+- SAI_OBJECT_TYPE_DASH_REVERSE_TUNNEL
+- SAI_OBJECT_TYPE_DASH_REVERSE_TUNNEL_MEMBER
+- SAI_OBJECT_TYPE_DASH_REVERSE_TUNNEL_NEXT_HOP
 object_entries:
 - !!python/object:utils.sai_spec.sai_struct_entry.SaiStructEntry
   name: direction_lookup_entry
@@ -93,6 +100,12 @@ object_entries:
   type: sai_flow_entry_t
   objects: null
   valid_only: object_type == SAI_OBJECT_TYPE_FLOW_ENTRY,
+- !!python/object:utils.sai_spec.sai_struct_entry.SaiStructEntry
+  name: outbound_reverse_routing_entry
+  description: Object entry for DASH API outbound_reverse_routing_entry
+  type: sai_outbound_reverse_routing_entry_t
+  objects: null
+  valid_only: object_type == SAI_OBJECT_TYPE_OUTBOUND_REVERSE_ROUTING_ENTRY,
 enums:
 - !!python/object:utils.sai_spec.sai_enum.SaiEnum
   name: sai_dash_direction_t
@@ -186,6 +199,14 @@ enums:
     name: NAT_PORT
     description: ''
     value: '16'
+  - !!python/object:utils.sai_spec.sai_enum_member.SaiEnumMember
+    name: TUNNEL
+    description: ''
+    value: '32'
+  - !!python/object:utils.sai_spec.sai_enum_member.SaiEnumMember
+    name: REVERSE_TUNNEL
+    description: ''
+    value: '64'
 - !!python/object:utils.sai_spec.sai_enum.SaiEnum
   name: sai_dash_flow_enabled_key_t
   description: ''
@@ -466,3 +487,5 @@ api_groups:
 - !inc '/SAI/specs/dash_vip.yaml'
 - !inc '/SAI/specs/dash_tunnel.yaml'
 - !inc '/SAI/specs/dash_flow.yaml'
+- !inc '/SAI/specs/dash_outbound_reverse_routing.yaml'
+- !inc '/SAI/specs/dash_reverse_tunnel.yaml'

--- a/dash-pipeline/SAI/templates/saiapi.cpp.j2
+++ b/dash-pipeline/SAI/templates/saiapi.cpp.j2
@@ -59,14 +59,14 @@ static sai_status_t dash_sai_create_{{ table.name }}(
 
     matchActionEntry->set_table_id(tableId);
 
-    {% if table['keys'] | length== 1 %}
+    {% if table['object_id_key'] != None %}
     // SAI object table with single P4 key - object ID itself is the P4 table key
     // Generate a SAI object ID and fill it as the P4 table key
     auto mf = matchActionEntry->add_match();
     mf->set_field_id({{table['keys'][0].id}});
     auto mf_exact = mf->mutable_exact();
     //{{table['keys'][0].field}}SetVal(objId, mf_exact, {{table['keys'][0].bitwidth}});
-      {{table['keys'][0].field}}SetVal(static_cast<uint{{ table['keys'][0].bitwidth }}_t>(objId), mf_exact, {{ table['keys'][0].bitwidth }}); 
+    {{table['keys'][0].field}}SetVal(static_cast<uint{{ table['keys'][0].bitwidth }}_t>(objId), mf_exact, {{ table['keys'][0].bitwidth }}); 
     {% else %}
     // SAI object table with multiple P4 table keys
     // Copy P4 table keys from appropriate SAI attributes

--- a/dash-pipeline/SAI/utils/dash_p4/dash_p4_table.py
+++ b/dash-pipeline/SAI/utils/dash_p4/dash_p4_table.py
@@ -21,6 +21,7 @@ class DashP4Table(DashP4Object):
         self.api_name: str = ""
         self.ipaddr_family_attr: str = "false"
         self.keys: List[DashP4TableKey] = []
+        self.object_id_key: Optional[DashP4TableKey] = None
         self.actions: List[DashP4TableAction] = []
         self.action_params: List[DashP4TableActionParam] = []
         self.counters: List[DashP4Counter] = []
@@ -372,8 +373,12 @@ class DashP4Table(DashP4Object):
 
     def create_sai_attributes(self, sai_api: SaiApi) -> None:
         # If the table is an object with more one key (table entry id), we need to add all the keys into the attributes.
-        if self.is_object == "true" and len(self.keys) > 1:
+        if self.is_object == "true":
             for key in self.keys:
+                if key.name.endswith("_id") and key.name[:-3].upper().endswith(self.name.upper()):
+                    print(f"Found object id key for table {self.name}: {key.name}")
+                    self.object_id_key = key
+                    continue
                 sai_api.attributes.extend(key.to_sai_attribute(self.name, create_only=True))
 
         # Add all the action parameters into the attributes.

--- a/dash-pipeline/bmv2/dash_counters.p4
+++ b/dash-pipeline/bmv2/dash_counters.p4
@@ -102,5 +102,8 @@ DEFINE_ENI_PACKET_COUNTER(outbound_ca_pa_entry_miss_drop)
 DEFINE_ENI_PACKET_COUNTER(inbound_routing_entry_miss_drop)
 DEFINE_ENI_PACKET_COUNTER(outbound_routing_group_miss_drop)
 DEFINE_ENI_PACKET_COUNTER(outbound_routing_group_disabled_drop)
+DEFINE_ENI_PACKET_COUNTER(reverse_tunnel_miss_drop)
+DEFINE_ENI_PACKET_COUNTER(reverse_tunnel_member_miss_drop)
+DEFINE_ENI_PACKET_COUNTER(reverse_tunnel_next_hop_miss_drop)
 
 #endif // __DASH_COUNTERS__

--- a/dash-pipeline/bmv2/dash_metadata.p4
+++ b/dash-pipeline/bmv2/dash_metadata.p4
@@ -11,7 +11,9 @@ enum bit<32> dash_routing_actions_t {
     NAT = (1 << 1),
     NAT46 = (1 << 2),
     NAT64 = (1 << 3),
-    NAT_PORT = (1 << 4)
+    NAT_PORT = (1 << 4),
+    TUNNEL = (1 << 5),
+    REVERSE_TUNNEL = (1 << 6)
 };
 
 enum bit<16> dash_direction_t {
@@ -155,6 +157,11 @@ struct eni_data_t {
     outbound_routing_group_data_t outbound_routing_group_data;
 }
 
+struct outbound_reverse_routing_data_t {
+    bit<16> routing_group_id;
+    bool disabled;
+};
+
 struct meter_context_t {
     bit<32> meter_class_or;
     bit<32> meter_class_and;
@@ -265,6 +272,7 @@ struct metadata_t {
     bit<16> dst_vnet_id;
     bit<16> eni_id;
     eni_data_t eni_data;
+    outbound_reverse_routing_data_t outbound_reverse_routing_data;
     bit<16> inbound_vm_id;
     bit<8> appliance_id;
     bit<1> is_overlay_ip_v6;
@@ -303,9 +311,13 @@ struct metadata_t {
     // encap_data is for underlay
     encap_data_t encap_data;
     // tunnel_data is used by dash_tunnel_id
-    encap_data_t tunnel_data;
-    overlay_rewrite_data_t overlay_data;
     bit<16> dash_tunnel_id;
+    encap_data_t tunnel_data;
+    bit<16> dash_reverse_tunnel_id;
+    bit<16> dash_reverse_tunnel_member_id;
+    bit<16> dash_reverse_tunnel_next_hop_id;
+    encap_data_t reverse_tunnel_data;
+    overlay_rewrite_data_t overlay_data;
     bit<32> meter_class;
 }
 

--- a/dash-pipeline/bmv2/dash_metadata.p4
+++ b/dash-pipeline/bmv2/dash_metadata.p4
@@ -304,6 +304,7 @@ struct metadata_t {
 
     // Actions
     bit<32> routing_actions;
+    bit<32> routing_actions_disabled_in_flow_resimulation;
     bit<32> flow_actions;
 
     // Action data

--- a/dash-pipeline/bmv2/dash_pipeline.p4
+++ b/dash-pipeline/bmv2/dash_pipeline.p4
@@ -114,7 +114,8 @@ control dash_ingress(
                          bit<1> full_flow_resimulation_requested,
                          bit<64> max_resimulated_flow_per_second,
                          @SaiVal[type="sai_object_id_t"] bit<16> outbound_routing_group_id,
-                         bit<1> is_ha_flow_owner)
+                         bit<1> is_ha_flow_owner,
+                         @SaiVal[type="sai_object_id_t"] bit<16> outbound_reverse_routing_group_id)
     {
         meta.eni_data.cps                                                   = cps;
         meta.eni_data.pps                                                   = pps;

--- a/dash-pipeline/bmv2/routing_actions/routing_action_reverse_tunnel.p4
+++ b/dash-pipeline/bmv2/routing_actions/routing_action_reverse_tunnel.p4
@@ -1,0 +1,107 @@
+#ifndef _DASH_ROUTING_ACTION_REVERSE_TUNNEL_P4_
+#define _DASH_ROUTING_ACTION_REVERSE_TUNNEL_P4_
+
+action push_action_reverse_tunnel(
+    in headers_t hdr,
+    inout metadata_t meta,
+    in bit<16> dash_reverse_tunnel_id)
+{
+    meta.routing_actions = meta.routing_actions | dash_routing_actions_t.REVERSE_TUNNEL;
+
+    meta.dash_reverse_tunnel_id = dash_reverse_tunnel_id;
+}
+
+control do_action_reverse_tunnel(
+    inout headers_t hdr,
+    inout metadata_t meta)
+{
+    //
+    // Reverse Tunnel
+    //
+    action set_reverse_tunnel_attrs(
+        @SaiVal[type="sai_dash_encapsulation_t", default_value="SAI_DASH_ENCAPSULATION_VXLAN"] dash_encapsulation_t dash_encapsulation,
+        bit<24> tunnel_key
+    ) {
+        meta.reverse_tunnel_data.dash_encapsulation = dash_encapsulation;
+        meta.reverse_tunnel_data.vni = tunnel_key;
+    }
+
+    @SaiTable[name = "dash_reverse_tunnel", api = "dash_reverse_tunnel", order = 0, isobject="true"]
+    table reverse_tunnel {
+        key = {
+            meta.dash_reverse_tunnel_id : exact @SaiVal[type="sai_object_id_t"];
+        }
+
+        actions = {
+            set_reverse_tunnel_attrs;
+        }
+    }
+
+    //
+    // Reverse tunnel member
+    //
+    action set_reverse_tunnel_member_attrs(
+        @SaiVal[type="sai_object_id_t"] bit<16> dash_reverse_tunnel_next_hop_id
+    ) {
+        meta.dash_reverse_tunnel_next_hop_id = dash_reverse_tunnel_next_hop_id;
+    }
+
+    @SaiTable[name = "dash_reverse_tunnel", api = "dash_reverse_tunnel", order = 1, isobject="true"]
+    table reverse_tunnel_member {
+        key = {
+            meta.dash_reverse_tunnel_id : exact @SaiVal[type="sai_object_id_t"];
+            meta.dash_reverse_tunnel_member_id : exact @SaiVal[type="sai_object_id_t"];
+        }
+
+        actions = {
+            set_reverse_tunnel_member_attrs;
+        }
+    }
+
+    //
+    // Reverse tunnel next hop
+    //
+    action set_reverse_tunnel_next_hop_attrs(
+        @SaiVal[type="sai_ip_address_t"] IPv4Address dip,
+        @SaiVal[type="sai_ip_address_t"] IPv4Address sip
+    ) {
+        meta.reverse_tunnel_data.underlay_dip = dip;
+        meta.reverse_tunnel_data.underlay_sip = sip;
+    }
+
+    @SaiTable[name = "dash_reverse_tunnel", api = "dash_reverse_tunnel", order = 2, isobject="true"]
+    table reverse_tunnel_next_hop {
+        key = {
+            meta.dash_reverse_tunnel_next_hop_id : exact @SaiVal[type="sai_object_id_t"];
+        }
+
+        actions = {
+            set_reverse_tunnel_next_hop_attrs;
+        }
+    }
+
+    apply {
+        if (meta.routing_actions & dash_routing_actions_t.REVERSE_TUNNEL == 0) {
+            return;
+        }
+    
+        if (!reverse_tunnel.apply().hit) {
+            UPDATE_ENI_COUNTER(reverse_tunnel_miss_drop);
+            return;
+        }
+
+        meta.dash_reverse_tunnel_member_id = 0; // TODO: ECMP group selection!
+
+        if (!reverse_tunnel_member.apply().hit) {
+            UPDATE_ENI_COUNTER(reverse_tunnel_member_miss_drop);
+            return;
+        }
+    
+        if (!reverse_tunnel_next_hop.apply().hit) {
+            UPDATE_ENI_COUNTER(reverse_tunnel_next_hop_miss_drop);
+            return;
+        }
+    }
+}
+
+#endif /* _DASH_ROUTING_ACTION_REVERSE_TUNNEL_P4_ */

--- a/dash-pipeline/bmv2/routing_actions/routing_action_reverse_tunnel.p4
+++ b/dash-pipeline/bmv2/routing_actions/routing_action_reverse_tunnel.p4
@@ -46,7 +46,7 @@ control do_action_reverse_tunnel(
         meta.dash_reverse_tunnel_next_hop_id = dash_reverse_tunnel_next_hop_id;
     }
 
-    @SaiTable[name = "dash_reverse_tunnel", api = "dash_reverse_tunnel", order = 1, isobject="true"]
+    @SaiTable[name = "dash_reverse_tunnel_member", api = "dash_reverse_tunnel", order = 1, isobject="true"]
     table reverse_tunnel_member {
         key = {
             meta.dash_reverse_tunnel_id : exact @SaiVal[type="sai_object_id_t"];
@@ -69,7 +69,7 @@ control do_action_reverse_tunnel(
         meta.reverse_tunnel_data.underlay_sip = sip;
     }
 
-    @SaiTable[name = "dash_reverse_tunnel", api = "dash_reverse_tunnel", order = 2, isobject="true"]
+    @SaiTable[name = "dash_reverse_tunnel_next_hop", api = "dash_reverse_tunnel", order = 2, isobject="true"]
     table reverse_tunnel_next_hop {
         key = {
             meta.dash_reverse_tunnel_next_hop_id : exact @SaiVal[type="sai_object_id_t"];

--- a/dash-pipeline/bmv2/routing_actions/routing_action_reverse_tunnel.p4
+++ b/dash-pipeline/bmv2/routing_actions/routing_action_reverse_tunnel.p4
@@ -67,6 +67,8 @@ control do_action_reverse_tunnel(
     ) {
         meta.reverse_tunnel_data.underlay_dip = dip;
         meta.reverse_tunnel_data.underlay_sip = sip;
+
+        // TODO: Push flow action here. Waiting for flow API P4 implementation.
     }
 
     @SaiTable[name = "dash_reverse_tunnel_next_hop", api = "dash_reverse_tunnel", order = 2, isobject="true"]

--- a/dash-pipeline/bmv2/routing_actions/routing_action_reverse_tunnel.p4
+++ b/dash-pipeline/bmv2/routing_actions/routing_action_reverse_tunnel.p4
@@ -91,8 +91,9 @@ control do_action_reverse_tunnel(
             UPDATE_ENI_COUNTER(reverse_tunnel_miss_drop);
             return;
         }
-
-        meta.dash_reverse_tunnel_member_id = 0; // TODO: ECMP group selection!
+        
+        // TODO: Select reverse tunnel member as ECMP
+        meta.dash_reverse_tunnel_member_id = 0;
 
         if (!reverse_tunnel_member.apply().hit) {
             UPDATE_ENI_COUNTER(reverse_tunnel_member_miss_drop);

--- a/dash-pipeline/bmv2/routing_actions/routing_actions.p4
+++ b/dash-pipeline/bmv2/routing_actions/routing_actions.p4
@@ -4,5 +4,6 @@
 #include "routing_action_static_encap.p4"
 #include "routing_action_nat46.p4"
 #include "routing_action_nat64.p4"
+#include "routing_action_reverse_tunnel.p4"
 
 #endif /* _DASH_ROUTING_ACTIONS_P4_ */

--- a/dash-pipeline/bmv2/stages/conntrack_lookup.p4
+++ b/dash-pipeline/bmv2/stages/conntrack_lookup.p4
@@ -20,7 +20,7 @@ control conntrack_lookup_stage(inout headers_t hdr, inout metadata_t meta) {
     @SaiTable[name = "flow_table", api = "dash_flow", order = 0, isobject="true"]
     table flow_table {
         key = {
-            meta.conntrack_data.flow_table.id : exact;
+            meta.conntrack_data.flow_table.id : exact @SaiVal[name="flow_table_id"];
         }
 
         actions = {
@@ -169,7 +169,7 @@ control conntrack_lookup_stage(inout headers_t hdr, inout metadata_t meta) {
     @SaiTable[name = "flow_entry_bulk_get_session_filter", api = "dash_flow", order = 2, isobject="true"]
     table flow_entry_bulk_get_session_filter {
         key = {
-            meta.conntrack_data.bulk_get_session_filter_id: exact @SaiVal[name = "bulk_get_session_filter_id", type="sai_object_id_t"];
+            meta.conntrack_data.bulk_get_session_filter_id: exact @SaiVal[name = "flow_entry_bulk_get_session_filter_id", type="sai_object_id_t"];
         }
 
         actions = {
@@ -180,7 +180,7 @@ control conntrack_lookup_stage(inout headers_t hdr, inout metadata_t meta) {
    @SaiTable[name = "flow_entry_bulk_get_session", api = "dash_flow", order = 3, isobject="true"]
     table flow_entry_bulk_get_session {
         key = {
-            meta.conntrack_data.bulk_get_session_id: exact @SaiVal[name = "bulk_get_session_id", type="sai_object_id_t"];
+            meta.conntrack_data.bulk_get_session_id: exact @SaiVal[name = "flow_entry_bulk_get_session_id", type="sai_object_id_t"];
         }
 
         actions = {

--- a/dash-pipeline/bmv2/stages/outbound_pre_routing_action_apply.p4
+++ b/dash-pipeline/bmv2/stages/outbound_pre_routing_action_apply.p4
@@ -1,6 +1,8 @@
 #ifndef _DASH_STAGE_OUTBOUND_PRE_ROUTING_ACTION_APPLY_P4_
 #define _DASH_STAGE_OUTBOUND_PRE_ROUTING_ACTION_APPLY_P4_
 
+#include "outbound_reverse_routing.p4"
+
 control outbound_pre_routing_action_apply_stage(
     inout headers_t hdr,
     inout metadata_t meta)
@@ -10,6 +12,8 @@ control outbound_pre_routing_action_apply_stage(
         if (meta.target_stage != dash_pipeline_stage_t.OUTBOUND_PRE_ROUTING_ACTION_APPLY) {
             return;
         }
+
+        outbound_reverse_routing_stage.apply(hdr, meta);
 
         // Once it is done, move to routing action apply stage.
         meta.target_stage = dash_pipeline_stage_t.ROUTING_ACTION_APPLY;

--- a/dash-pipeline/bmv2/stages/outbound_reverse_routing.p4
+++ b/dash-pipeline/bmv2/stages/outbound_reverse_routing.p4
@@ -1,5 +1,5 @@
-#ifndef _DASH_STAGE_OUTBOUND_REVERSE_reverse_routing_P4_
-#define _DASH_STAGE_OUTBOUND_REVERSE_reverse_routing_P4_
+#ifndef _DASH_STAGE_OUTBOUND_REVERSE_ROUTING_P4_
+#define _DASH_STAGE_OUTBOUND_REVERSE_ROUTING_P4_
 
 control outbound_reverse_routing_stage(
     inout headers_t hdr,
@@ -68,4 +68,4 @@ control outbound_reverse_routing_stage(
     }
 }
 
-#endif /* _DASH_STAGE_OUTBOUND_REVERSE_reverse_routing_P4_ */
+#endif /* _DASH_STAGE_OUTBOUND_REVERSE_ROUTING_P4_ */

--- a/dash-pipeline/bmv2/stages/outbound_reverse_routing.p4
+++ b/dash-pipeline/bmv2/stages/outbound_reverse_routing.p4
@@ -12,7 +12,7 @@ control outbound_reverse_routing_stage(
         meta.outbound_reverse_routing_data.disabled = (bool)disabled;
     }
 
-    @SaiTable[name = "outbound_reverse_routing_group", api = "dash_outbound_reverse_routing", order = 1, isobject="true"]
+    @SaiTable[name = "outbound_reverse_routing_group", api = "dash_outbound_reverse_routing", order = 0, isobject="true"]
     table outbound_reverse_routing_group {
         key = {
             meta.outbound_reverse_routing_data.routing_group_id: exact @SaiVal[type="sai_object_id_t"];
@@ -35,7 +35,7 @@ control outbound_reverse_routing_stage(
 
     DEFINE_TABLE_COUNTER(reverse_routing_counter)
 
-    @SaiTable[name = "outbound_reverse_routing", api = "dash_outbound_reverse_routing"]
+    @SaiTable[name = "outbound_reverse_routing", api = "dash_outbound_reverse_routing", order = 1]
     table reverse_routing {
         key = {
             meta.outbound_reverse_routing_data.routing_group_id : exact @SaiVal[type="sai_object_id_t"];

--- a/dash-pipeline/bmv2/stages/outbound_reverse_routing.p4
+++ b/dash-pipeline/bmv2/stages/outbound_reverse_routing.p4
@@ -15,7 +15,7 @@ control outbound_reverse_routing_stage(
     @SaiTable[name = "outbound_reverse_routing_group", api = "dash_outbound_reverse_routing", order = 0, isobject="true"]
     table outbound_reverse_routing_group {
         key = {
-            meta.outbound_reverse_routing_data.routing_group_id: exact @SaiVal[type="sai_object_id_t"];
+            meta.outbound_reverse_routing_data.routing_group_id: exact @SaiVal[name="outbound_reverse_routing_group_id", type="sai_object_id_t"];
         }
 
         actions = {

--- a/dash-pipeline/bmv2/stages/outbound_reverse_routing.p4
+++ b/dash-pipeline/bmv2/stages/outbound_reverse_routing.p4
@@ -1,0 +1,70 @@
+#ifndef _DASH_STAGE_OUTBOUND_REVERSE_reverse_routing_P4_
+#define _DASH_STAGE_OUTBOUND_REVERSE_reverse_routing_P4_
+
+control outbound_reverse_routing_stage(
+    inout headers_t hdr,
+    inout metadata_t meta
+) {
+    //
+    // Reverse routing group table
+    //
+    action set_outbound_reverse_routing_group_attr(bit<1> disabled) {
+        meta.outbound_reverse_routing_data.disabled = (bool)disabled;
+    }
+
+    @SaiTable[name = "outbound_reverse_routing_group", api = "dash_outbound_reverse_routing", order = 1, isobject="true"]
+    table outbound_reverse_routing_group {
+        key = {
+            meta.outbound_reverse_routing_data.routing_group_id: exact @SaiVal[type="sai_object_id_t"];
+        }
+
+        actions = {
+            set_outbound_reverse_routing_group_attr;
+        }
+    }
+
+    //
+    // Reverse routing table
+    //
+    action set_outbound_reverse_routing_entry_attr(
+        @SaiVal[type="sai_object_id_t"] bit<16> dash_reverse_tunnel_id,
+        dash_routing_actions_t routing_actions_disabled_in_flow_resimulation
+    ) {
+        push_action_reverse_tunnel(hdr, meta, dash_reverse_tunnel_id);
+    }
+
+    DEFINE_TABLE_COUNTER(reverse_routing_counter)
+
+    @SaiTable[name = "outbound_reverse_routing", api = "dash_outbound_reverse_routing"]
+    table reverse_routing {
+        key = {
+            meta.outbound_reverse_routing_data.routing_group_id : exact @SaiVal[type="sai_object_id_t"];
+            meta.is_overlay_ip_v6 : exact @SaiVal[name = "source_is_v6"];
+            meta.src_ip_addr : lpm @SaiVal[name = "source"];
+        }
+
+        actions = {
+            set_outbound_reverse_routing_entry_attr;
+        }
+
+        size = 4 * 1024 * 1024;
+
+        ATTACH_TABLE_COUNTER(reverse_routing_counter)
+    }
+
+    apply {
+        // If reverse routing stage tables are not hit, we don't need to drop the packet.
+        // This simply means no reverse routing is needed, and we can continue to the next stage.
+        if (!outbound_reverse_routing_group.apply().hit) {
+            return;
+        }
+
+        if (meta.outbound_reverse_routing_data.disabled) {
+            return;
+        }
+        
+        reverse_routing.apply();
+    }
+}
+
+#endif /* _DASH_STAGE_OUTBOUND_REVERSE_reverse_routing_P4_ */

--- a/dash-pipeline/bmv2/stages/outbound_reverse_routing.p4
+++ b/dash-pipeline/bmv2/stages/outbound_reverse_routing.p4
@@ -31,6 +31,7 @@ control outbound_reverse_routing_stage(
         dash_routing_actions_t routing_actions_disabled_in_flow_resimulation
     ) {
         push_action_reverse_tunnel(hdr, meta, dash_reverse_tunnel_id);
+        meta.routing_actions_disabled_in_flow_resimulation = meta.routing_actions_disabled_in_flow_resimulation | routing_actions_disabled_in_flow_resimulation;
     }
 
     DEFINE_TABLE_COUNTER(reverse_routing_counter)

--- a/dash-pipeline/bmv2/stages/outbound_reverse_routing.p4
+++ b/dash-pipeline/bmv2/stages/outbound_reverse_routing.p4
@@ -39,7 +39,7 @@ control outbound_reverse_routing_stage(
     @SaiTable[name = "outbound_reverse_routing", api = "dash_outbound_reverse_routing", order = 1]
     table reverse_routing {
         key = {
-            meta.outbound_reverse_routing_data.routing_group_id : exact @SaiVal[type="sai_object_id_t"];
+            meta.outbound_reverse_routing_data.routing_group_id : exact @SaiVal[name="outbound_reverse_routing_group_id", type="sai_object_id_t"];
             meta.is_overlay_ip_v6 : exact @SaiVal[name = "source_is_v6"];
             meta.src_ip_addr : lpm @SaiVal[name = "source"];
         }

--- a/dash-pipeline/bmv2/stages/routing_action_apply.p4
+++ b/dash-pipeline/bmv2/stages/routing_action_apply.p4
@@ -16,6 +16,8 @@ control routing_action_apply(
         // because it requires the transforms on the inner packet to be finished in order to
         // get the correct inner packet size and other informations.
         do_action_static_encap.apply(hdr, meta);
+
+        do_action_reverse_tunnel.apply(hdr, meta);
     }
 }
 


### PR DESCRIPTION
The reverse routing table and reverse tunnel are added for supporting the express route gateway bypass scenario for handling the MSEE failover.

The design follows the HLD defined here: https://github.com/sonic-net/DASH/pull/601.

This PR adds the P4 code for API generation and the pipeline design. And the tests will be updated later, due to time limitation.

There are a few known issues in the current implementation:

1. Due to flow API is not fully supported in the P4, the reverse tunnel info could not be applied to the packet, as it only affects the return packets.
2. The ECMP support is not simple to support with our API design, because we don't know the count of the next hops in this tunnel in P4 pipeline. Either we need to have a predefined size, so we can create a fully populated table, which complicates the libsai generation a ton. Or, we somehow pass in the count, whenever a new member is added.

The 2 known issues are marked as TODO in the code.