### PR TITLE
[ha] Fix action param ha_set_id annotation

### DIFF
--- a/dash-pipeline/SAI/specs/dash_ha.yaml
+++ b/dash-pipeline/SAI/specs/dash_ha.yaml
@@ -420,15 +420,15 @@ sai_apis:
   - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
     name: SAI_HA_SCOPE_ATTR_HA_SET_ID
     description: Action parameter HA set id
-    type: sai_uint16_t
+    type: sai_object_id_t
     attr_value_field: u16
-    default: '0'
+    default: SAI_NULL_OBJECT_ID
     isresourcetype: false
     flags: CREATE_AND_SET
-    object_name: null
-    allow_null: false
+    object_name: SAI_OBJECT_TYPE_HA_SET
+    allow_null: true
     valid_only: null
-    is_vlan: true
+    is_vlan: false
     deprecated: false
   - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
     name: SAI_HA_SCOPE_ATTR_DASH_HA_ROLE

--- a/dash-pipeline/bmv2/stages/ha.p4
+++ b/dash-pipeline/bmv2/stages/ha.p4
@@ -8,7 +8,7 @@ control ha_stage(inout headers_t hdr,
     // HA scope:
     //
     action set_ha_scope_attr(
-        @SalVal[type="sai_object_id_t"] bit<16> ha_set_id,
+        @SaiVal[type="sai_object_id_t"] bit<16> ha_set_id,
         @SaiVal[type="sai_dash_ha_role_t"] dash_ha_role_t dash_ha_role,
         @SaiVal[isreadonly="true"] bit<32> flow_version,
         bit<1> flow_reconcile_requested,


### PR DESCRIPTION
Correct annotation tag typo (SalVal -> SaiVal) for action param `ha_set_id`. It generates correct type of `ha_set_id` in ha spec dash_ha.yaml and then in SAI header `saiexperimentaldashha.h`. In the end it fixes the issue https://github.com/opencomputeproject/SAI/issues/2057.