### PR TITLE
[dash-flow] Rename ENI_ADDR to ENI_MAC

### DIFF
--- a/dash-pipeline/SAI/specs/dash_flow.yaml
+++ b/dash-pipeline/SAI/specs/dash_flow.yaml
@@ -28,7 +28,7 @@ sai_apis:
     description: Action parameter DASH flow enabled key
     type: sai_dash_flow_enabled_key_t
     attr_value_field: s32
-    default: SAI_DASH_FLOW_ENABLED_KEY_ENI_ADDR
+    default: SAI_DASH_FLOW_ENABLED_KEY_ENI_MAC
     isresourcetype: false
     flags: CREATE_AND_SET
     object_name: null

--- a/dash-pipeline/SAI/specs/sai_spec.yaml
+++ b/dash-pipeline/SAI/specs/sai_spec.yaml
@@ -198,7 +198,7 @@ enums:
   description: ''
   members:
   - !!python/object:utils.sai_spec.sai_enum_member.SaiEnumMember
-    name: ENI_ADDR
+    name: ENI_MAC
     description: ''
     value: '1'
   - !!python/object:utils.sai_spec.sai_enum_member.SaiEnumMember
@@ -238,7 +238,7 @@ enums:
     description: ''
     value: '1'
   - !!python/object:utils.sai_spec.sai_enum_member.SaiEnumMember
-    name: ENI_ADDR
+    name: ENI_MAC
     description: ''
     value: '2'
   - !!python/object:utils.sai_spec.sai_enum_member.SaiEnumMember

--- a/dash-pipeline/bmv2/dash_metadata.p4
+++ b/dash-pipeline/bmv2/dash_metadata.p4
@@ -100,7 +100,7 @@ enum bit<16> dash_flow_entry_bulk_get_session_filter_key_t
 {
     INVAILD = 0,
     FLOW_TABLE_ID = 1,
-    ENI_ADDR = 2,
+    ENI_MAC = 2,
     IP_PROTOCOL = 3,
     SRC_IP_ADDR = 4,
     DST_IP_ADDR = 5,

--- a/dash-pipeline/bmv2/dash_metadata.p4
+++ b/dash-pipeline/bmv2/dash_metadata.p4
@@ -52,7 +52,7 @@ enum bit<16> dash_pipeline_stage_t {
 };
 
 enum bit<16> dash_flow_enabled_key_t {
-    ENI_ADDR = (1 << 0),
+    ENI_MAC = (1 << 0),
     VNI = (1 << 1),
     PROTOCOL = (1 << 2),
     SRC_IP = (1 << 3),

--- a/dash-pipeline/bmv2/stages/conntrack_lookup.p4
+++ b/dash-pipeline/bmv2/stages/conntrack_lookup.p4
@@ -191,7 +191,7 @@ control conntrack_lookup_stage(inout headers_t hdr, inout metadata_t meta) {
     apply {
         flow_table.apply();
 
-        if (meta.conntrack_data.flow_table.flow_enabled_key & dash_flow_enabled_key_t.ENI_ADDR != 0) {
+        if (meta.conntrack_data.flow_table.flow_enabled_key & dash_flow_enabled_key_t.ENI_MAC != 0) {
             meta.conntrack_data.flow_key.eni_mac = meta.eni_addr;
         }
 

--- a/documentation/dataplane/dash-flow-api.md
+++ b/documentation/dataplane/dash-flow-api.md
@@ -97,7 +97,7 @@ typedef enum _sai_dash_flow_enabled_key_t
 {
     SAI_DASH_FLOW_ENABLED_KEY_NONE = 0,
 
-    SAI_DASH_FLOW_ENABLED_KEY_ENI_ADDR = 1 << 1,
+    SAI_DASH_FLOW_ENABLED_KEY_ENI_MAC = 1 << 1,
   
     SAI_DASH_FLOW_ENABLED_KEY_VNI = 1 << 2,
 
@@ -517,7 +517,7 @@ uint32_t attr_count = 3;
 sai_attribute_t attr_list[3];
 attr_list[0].id = SAI_FLOW_TABLE_ATTR_DASH_FLOW_ENABLED_KEY;
 attr_list[0].value = SAI_DASH_FLOW_ENABLED_KEY_PROTOCOL |
-                         SAI_DASH_FLOW_ENABLED_KEY_ENI_ADDR |
+                         SAI_DASH_FLOW_ENABLED_KEY_ENI_MAC |
                          SAI_DASH_FLOW_ENABLED_KEY_VNI |
                          SAI_DASH_FLOW_ENABLED_KEY_SRC_IP | 
                          SAI_DASH_FLOW_ENABLED_KEY_DST_IP | 


### PR DESCRIPTION
The term ENI_ADDR was found to be unclear, so we have updated it to ENI_MAC in both the code and documentation.