### PR TITLE
[dash-p4] Add attributes on ENI for reverse tunnel information.

### DIFF
--- a/dash-pipeline/SAI/specs/dash_eni.yaml
+++ b/dash-pipeline/SAI/specs/dash_eni.yaml
@@ -598,7 +598,6 @@ sai_apis:
     valid_only: null
     is_vlan: false
     deprecated: false
-    deprecated: false
   - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
     name: SAI_ENI_ATTR_ENABLE_REVERSE_TUNNEL_LEARNING
     description: Action parameter enable reverse tunnel learning
@@ -624,6 +623,7 @@ sai_apis:
     allow_null: false
     valid_only: null
     is_vlan: false
+    deprecated: false
   stats:
   - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
     name: SAI_ENI_STAT_RX_BYTES

--- a/dash-pipeline/SAI/specs/dash_eni.yaml
+++ b/dash-pipeline/SAI/specs/dash_eni.yaml
@@ -598,6 +598,20 @@ sai_apis:
     valid_only: null
     is_vlan: false
     deprecated: false
+    deprecated: false
+  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
+    name: SAI_ENI_ATTR_ENABLE_REVERSE_TUNNEL_LEARNING
+    description: Action parameter enable reverse tunnel learning
+    type: bool
+    attr_value_field: booldata
+    default: 'false'
+    isresourcetype: false
+    flags: CREATE_AND_SET
+    object_name: null
+    allow_null: false
+    valid_only: null
+    is_vlan: false
+    deprecated: false
   - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
     name: SAI_ENI_ATTR_REVERSE_TUNNEL_SIP
     description: Action parameter reverse tunnel sip
@@ -610,7 +624,6 @@ sai_apis:
     allow_null: false
     valid_only: null
     is_vlan: false
-    deprecated: false
   stats:
   - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
     name: SAI_ENI_STAT_RX_BYTES

--- a/dash-pipeline/SAI/specs/dash_eni.yaml
+++ b/dash-pipeline/SAI/specs/dash_eni.yaml
@@ -598,6 +598,19 @@ sai_apis:
     valid_only: null
     is_vlan: false
     deprecated: false
+  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
+    name: SAI_ENI_ATTR_REVERSE_TUNNEL_SIP
+    description: Action parameter reverse tunnel sip
+    type: sai_ip_address_t
+    attr_value_field: ipaddr
+    default: 0.0.0.0
+    isresourcetype: false
+    flags: CREATE_AND_SET
+    object_name: null
+    allow_null: false
+    valid_only: null
+    is_vlan: false
+    deprecated: false
   stats:
   - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
     name: SAI_ENI_STAT_RX_BYTES

--- a/dash-pipeline/SAI/specs/sai_spec.yaml
+++ b/dash-pipeline/SAI/specs/sai_spec.yaml
@@ -195,6 +195,14 @@ enums:
     name: NAT_PORT
     description: ''
     value: '16'
+  - !!python/object:utils.sai_spec.sai_enum_member.SaiEnumMember
+    name: TUNNEL
+    description: ''
+    value: '32'
+  - !!python/object:utils.sai_spec.sai_enum_member.SaiEnumMember
+    name: REVERSE_TUNNEL
+    description: ''
+    value: '64'
 - !!python/object:utils.sai_spec.sai_enum.SaiEnum
   name: sai_dash_flow_enabled_key_t
   description: ''

--- a/dash-pipeline/bmv2/dash_metadata.p4
+++ b/dash-pipeline/bmv2/dash_metadata.p4
@@ -13,7 +13,7 @@ enum bit<32> dash_routing_actions_t {
     NAT64 = (1 << 3),
     NAT_PORT = (1 << 4),
     TUNNEL = (1 << 5),
-    REVERSE_TUNNEL = (1 << 6),
+    REVERSE_TUNNEL = (1 << 6)
 };
 
 enum bit<16> dash_direction_t {

--- a/dash-pipeline/bmv2/dash_metadata.p4
+++ b/dash-pipeline/bmv2/dash_metadata.p4
@@ -322,6 +322,7 @@ struct metadata_t {
     encap_data_t encap_data;
     // tunnel_data is used by dash_tunnel_id
     encap_data_t tunnel_data;
+    bit<1> enable_reverse_tunnel_learning;
     IPv4Address reverse_tunnel_sip;
     overlay_rewrite_data_t overlay_data;
     bit<16> dash_tunnel_id;

--- a/dash-pipeline/bmv2/dash_metadata.p4
+++ b/dash-pipeline/bmv2/dash_metadata.p4
@@ -11,7 +11,9 @@ enum bit<32> dash_routing_actions_t {
     NAT = (1 << 1),
     NAT46 = (1 << 2),
     NAT64 = (1 << 3),
-    NAT_PORT = (1 << 4)
+    NAT_PORT = (1 << 4),
+    TUNNEL = (1 << 5),
+    REVERSE_TUNNEL = (1 << 6),
 };
 
 enum bit<16> dash_direction_t {
@@ -320,6 +322,7 @@ struct metadata_t {
     encap_data_t encap_data;
     // tunnel_data is used by dash_tunnel_id
     encap_data_t tunnel_data;
+    IPv4Address reverse_tunnel_sip;
     overlay_rewrite_data_t overlay_data;
     bit<16> dash_tunnel_id;
     bit<32> meter_class;

--- a/dash-pipeline/bmv2/dash_pipeline.p4
+++ b/dash-pipeline/bmv2/dash_pipeline.p4
@@ -80,6 +80,8 @@ control dash_ingress(
                          bit<1> full_flow_resimulation_requested,
                          bit<64> max_resimulated_flow_per_second,
                          @SaiVal[type="sai_object_id_t"] bit<16> outbound_routing_group_id,
+                         @SaiVal[type="sai_ip_address_t"] IPv4ORv6Address reverse_tunnel_sip,
+                         bit<1> reverse_tunnel_sip_is_v6,
                          bit<1> is_ha_flow_owner)
     {
         meta.eni_data.cps                                                   = cps;

--- a/dash-pipeline/bmv2/dash_pipeline.p4
+++ b/dash-pipeline/bmv2/dash_pipeline.p4
@@ -80,8 +80,7 @@ control dash_ingress(
                          bit<1> full_flow_resimulation_requested,
                          bit<64> max_resimulated_flow_per_second,
                          @SaiVal[type="sai_object_id_t"] bit<16> outbound_routing_group_id,
-                         @SaiVal[type="sai_ip_address_t"] IPv4ORv6Address reverse_tunnel_sip,
-                         bit<1> reverse_tunnel_sip_is_v6,
+                         @SaiVal[type="sai_ip_address_t"] IPv4Address reverse_tunnel_sip,
                          bit<1> is_ha_flow_owner)
     {
         meta.eni_data.cps                                                   = cps;
@@ -100,6 +99,9 @@ control dash_ingress(
          * and not a VNET identifier */
         meta.encap_data.vni           = vm_vni;
         meta.vnet_id                  = vnet_id;
+
+        meta.reverse_tunnel_sip       = reverse_tunnel_sip;
+        meta.routing_actions = meta.routing_actions | dash_routing_actions_t.REVERSE_TUNNEL;
 
         if (meta.is_overlay_ip_v6 == 1) {
             if (meta.direction == dash_direction_t.OUTBOUND) {

--- a/dash-pipeline/bmv2/dash_pipeline.p4
+++ b/dash-pipeline/bmv2/dash_pipeline.p4
@@ -81,6 +81,7 @@ control dash_ingress(
                          bit<64> max_resimulated_flow_per_second,
                          @SaiVal[type="sai_object_id_t"] bit<16> outbound_routing_group_id,
                          @SaiVal[type="sai_ip_address_t"] IPv4Address reverse_tunnel_sip,
+                         bit<1> enable_reverse_tunnel_learning,
                          bit<1> is_ha_flow_owner)
     {
         meta.eni_data.cps                                                   = cps;

--- a/dash-pipeline/bmv2/dash_pipeline.p4
+++ b/dash-pipeline/bmv2/dash_pipeline.p4
@@ -80,8 +80,8 @@ control dash_ingress(
                          bit<1> full_flow_resimulation_requested,
                          bit<64> max_resimulated_flow_per_second,
                          @SaiVal[type="sai_object_id_t"] bit<16> outbound_routing_group_id,
-                         @SaiVal[type="sai_ip_address_t"] IPv4Address reverse_tunnel_sip,
                          bit<1> enable_reverse_tunnel_learning,
+                         @SaiVal[type="sai_ip_address_t"] IPv4Address reverse_tunnel_sip,
                          bit<1> is_ha_flow_owner)
     {
         meta.eni_data.cps                                                   = cps;
@@ -101,7 +101,9 @@ control dash_ingress(
         meta.encap_data.vni           = vm_vni;
         meta.vnet_id                  = vnet_id;
 
-        meta.reverse_tunnel_sip       = reverse_tunnel_sip;
+        meta.enable_reverse_tunnel_learning = enable_reverse_tunnel_learning;
+        meta.reverse_tunnel_sip             = reverse_tunnel_sip;
+
         meta.routing_actions = meta.routing_actions | dash_routing_actions_t.REVERSE_TUNNEL;
 
         if (meta.is_overlay_ip_v6 == 1) {


### PR DESCRIPTION
Per HLD update: https://github.com/sonic-net/DASH/pull/619. This PR adds the reverse tunnel information on ENI.

The packet transformation requires data plane app to create the flow, hence not included in this PR.