### PR TITLE
[debian]: Add saimetadata to libsai debian package

### DIFF
--- a/dash-pipeline/SAI/debian/Makefile
+++ b/dash-pipeline/SAI/debian/Makefile
@@ -21,6 +21,7 @@ libsai_$(VERSION)_amd64.deb: ../lib/libsai.so
 	mkdir -p -m 755 libsai_$(VERSION)_amd64/usr/lib/x86_64-linux-gnu/
 	find -type d |xargs chmod go-w
 	install -vCD ../lib/libsai.so libsai_$(VERSION)_amd64/usr/lib/x86_64-linux-gnu/libsai.so
+	install -vCD ../SAI/meta/libsaimetadata.so libsai_$(VERSION)_amd64/usr/lib/x86_64-linux-gnu/libdashsaimetadata.so
 	cd libsai_$(VERSION)_amd64 && find usr -type f | xargs md5sum > DEBIAN/md5sums
 	dpkg-deb --build --root-owner-group libsai_$(VERSION)_amd64
 


### PR DESCRIPTION
Add shared library saimetadata to libsai debian package. Because when a program is linked to a sai library(such as dash sai), it should also be linked to the corresponding saimetadata library as well. Otherwise, there may be a risk of crashing if the sai library uses an attribute that is not in the saimetadata library.