### PR TITLE
Add HA session parameter Bounceback IP

### DIFF
--- a/dash-pipeline/SAI/specs/dash_ha.yaml
+++ b/dash-pipeline/SAI/specs/dash_ha.yaml
@@ -140,6 +140,19 @@ sai_apis:
     valid_only: null
     is_vlan: false
     deprecated: false
+  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
+    name: SAI_HA_SET_ATTR_PEER_BOUNCEBACK_IP
+    description: Action parameter peer bounceback IP
+    type: sai_ip_address_t
+    attr_value_field: ipaddr
+    default: 0.0.0.0
+    isresourcetype: false
+    flags: CREATE_AND_SET
+    object_name: null
+    allow_null: false
+    valid_only: null
+    is_vlan: false
+    deprecated: false
   stats:
   - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
     name: SAI_HA_SET_STAT_DP_PROBE_REQ_RX_BYTES

--- a/dash-pipeline/bmv2/dash_metadata.p4
+++ b/dash-pipeline/bmv2/dash_metadata.p4
@@ -263,6 +263,8 @@ struct ha_data_t {
     bit<16> dp_channel_dst_port;
     bit<16> dp_channel_src_port_min;
     bit<16> dp_channel_src_port_max;
+    bit<1> peer_bounceback_ip_is_v6;
+    IPv4ORv6Address peer_bounceback_ip;
 
     // HA packet/flow state
     dash_ha_flow_sync_state_t flow_sync_state;

--- a/dash-pipeline/bmv2/stages/ha.p4
+++ b/dash-pipeline/bmv2/stages/ha.p4
@@ -71,10 +71,14 @@ control ha_stage(inout headers_t hdr,
         bit<32> dp_channel_probe_interval_ms,
         bit<32> dp_channel_probe_fail_threshold,
         @SaiVal[isreadonly="true"] bit<1> dp_channel_is_alive,
-        bit<32> dpu_driven_ha_switchover_wait_time_ms
+        bit<32> dpu_driven_ha_switchover_wait_time_ms,
+        bit<1> peer_bounceback_ip_is_v6,
+        @SaiVal[type="sai_ip_address_t"] IPv4ORv6Address peer_bounceback_ip
     ) {
         meta.ha.peer_ip_is_v6 = peer_ip_is_v6;
         meta.ha.peer_ip = peer_ip;
+        meta.ha.peer_bounceback_ip_is_v6 = peer_bounceback_ip_is_v6;
+        meta.ha.peer_bounceback_ip = peer_bounceback_ip;
 
         meta.ha.dp_channel_dst_port = dp_channel_dst_port;
         meta.ha.dp_channel_src_port_min = dp_channel_min_src_port;


### PR DESCRIPTION
Add bounceback IP which is a different IP from
peer IP, to emulate the same network path for data packets as for the SYN packets.