### PR TITLE
[libsai] Make helper function for bulk object create and removal to simplify libsai generation.

### DIFF
--- a/dash-pipeline/SAI/src/dashsai.cpp
+++ b/dash-pipeline/SAI/src/dashsai.cpp
@@ -904,3 +904,60 @@ std::vector<sai_attribute_t> DashSai::populateDefaultAttributes(
 
     return attrs;
 }
+
+sai_status_t DashSai::bulk_create_objects(
+    _In_ DashSai::sai_create_object_fn create_fn,
+    _In_ sai_object_id_t switch_id,
+    _In_ uint32_t object_count,
+    _In_ const uint32_t *attr_count,
+    _In_ const sai_attribute_t **attr_list,
+    _In_ sai_bulk_op_error_mode_t mode,
+    _Out_ sai_object_id_t *object_id,
+    _Out_ sai_status_t *object_statuses)
+{
+    sai_status_t agg_status = SAI_STATUS_SUCCESS;
+
+    for (uint32_t i = 0; i < object_count; i++)
+    {
+        object_statuses[i] = create_fn(&object_id[i], switch_id, attr_count[i], attr_list[i]);
+
+        if (object_statuses[i] != SAI_STATUS_SUCCESS)
+        {
+            agg_status = SAI_STATUS_FAILURE;
+        }
+
+        if (agg_status == SAI_STATUS_FAILURE && mode == SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR)
+        {
+            return agg_status;
+        }
+    }
+
+    return agg_status;
+}
+
+sai_status_t DashSai::bulk_remove_objects(
+    _In_ DashSai::sai_remove_object_fn remove_fn,
+    _In_ uint32_t object_count,
+    _In_ const sai_object_id_t *object_id,
+    _In_ sai_bulk_op_error_mode_t mode,
+    _Out_ sai_status_t *object_statuses)
+{
+    sai_status_t agg_status = SAI_STATUS_SUCCESS;
+
+    for (uint32_t i = 0; i < object_count; i++)
+    {
+        object_statuses[i] = remove_fn(object_id[i]);
+
+        if (object_statuses[i] != SAI_STATUS_SUCCESS)
+        {
+            agg_status = SAI_STATUS_FAILURE;
+        }
+
+        if (agg_status == SAI_STATUS_FAILURE && mode == SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR)
+        {
+            return agg_status;
+        }
+    }
+
+    return agg_status;
+}

--- a/dash-pipeline/SAI/src/dashsai.h
+++ b/dash-pipeline/SAI/src/dashsai.h
@@ -102,6 +102,32 @@ namespace dash
                     _In_ uint32_t attr_count,
                     _In_ const sai_attribute_t *attr_list);
 
+            typedef sai_status_t (*sai_create_object_fn)(
+                _Out_ sai_object_id_t *object_id,
+                _In_ sai_object_id_t switch_id,
+                _In_ uint32_t attr_count,
+                _In_ const sai_attribute_t *attr_list);
+
+            typedef sai_status_t (*sai_remove_object_fn)(
+                _In_ sai_object_id_t object_id);
+
+            static sai_status_t bulk_create_objects(
+                _In_ sai_create_object_fn create_fn,
+                _In_ sai_object_id_t switch_id,
+                _In_ uint32_t object_count,
+                _In_ const uint32_t *attr_count,
+                _In_ const sai_attribute_t **attr_list,
+                _In_ sai_bulk_op_error_mode_t mode,
+                _Out_ sai_object_id_t *object_id,
+                _Out_ sai_status_t *object_statuses);
+
+            static sai_status_t bulk_remove_objects(
+                _In_ sai_remove_object_fn remove_fn,
+                _In_ uint32_t object_count,
+                _In_ const sai_object_id_t *object_id,
+                _In_ sai_bulk_op_error_mode_t mode,
+                _Out_ sai_status_t *object_statuses);
+
         private: // private helper methods
 
             static std::shared_ptr<p4::config::v1::P4Info> parse_p4info(

--- a/dash-pipeline/SAI/templates/saiapi.cpp.j2
+++ b/dash-pipeline/SAI/templates/saiapi.cpp.j2
@@ -255,25 +255,7 @@ static sai_status_t dash_sai_create_{{ table.name }}s(
         _Out_ sai_status_t *object_statuses)
 {
     DASH_LOG_ENTER();
-
-    sai_status_t agg_status = SAI_STATUS_SUCCESS;
-
-    for (uint32_t i = 0; i < object_count; i++)
-    {
-        object_statuses[i] = dash_sai_create_{{ table.name }}(&object_id[i], switch_id, attr_count[i], attr_list[i]);
-
-        if (object_statuses[i] != SAI_STATUS_SUCCESS)
-        {
-            agg_status = SAI_STATUS_FAILURE;
-        }
-
-        if (agg_status == SAI_STATUS_FAILURE && mode == SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR)
-        {
-            return agg_status;
-        }
-    }
-
-    return agg_status;
+    return dash::DashSai::bulk_create_objects(dash_sai_create_{{ table.name }}, switch_id, object_count, attr_count, attr_list, mode, object_id, object_statuses);
 }
 
 static sai_status_t dash_sai_remove_{{ table.name }}(
@@ -296,25 +278,7 @@ static sai_status_t dash_sai_remove_{{ table.name }}s(
         _Out_ sai_status_t *object_statuses)
 {
     DASH_LOG_ENTER();
-
-    sai_status_t agg_status = SAI_STATUS_SUCCESS;
-
-    for (uint32_t i = 0; i < object_count; i++)
-    {
-        object_statuses[i] = dash_sai_remove_{{ table.name }}(object_id[i]);
-
-        if (object_statuses[i] != SAI_STATUS_SUCCESS)
-        {
-            agg_status = SAI_STATUS_FAILURE;
-        }
-
-        if (agg_status == SAI_STATUS_FAILURE && mode == SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR)
-        {
-            return agg_status;
-        }
-    }
-
-    return agg_status;
+    return dash::DashSai::bulk_remove_objects(dash_sai_remove_{{ table.name }}, object_count, object_id, mode, object_statuses);
 }
 
 static sai_status_t dash_sai_set_{{ table.name }}_attribute (


### PR DESCRIPTION
All bulk create/removal objects SAI implementation is essentially the same. Hence making some helper functions for simplify the generated libsai.

With more changes coming, we should be able to make the libsai templates and generations more maintainable.