### PR TITLE
[ptftest] Add p4_dash_utils

### DIFF
--- a/dash-pipeline/bmv2/dash_headers.p4
+++ b/dash-pipeline/bmv2/dash_headers.p4
@@ -254,7 +254,6 @@ header dash_packet_meta_t {
 const bit<16> PACKET_META_HDR_SIZE=dash_packet_meta_t.minSizeInBytes();
 
 #define DASH_ETHTYPE 0x876d
-#define DPAPP_MAC 0x02fe23f0e413    /* FIXME temp hardcode */
 
 struct headers_t {
     /* packet metadata headers */

--- a/dash-pipeline/bmv2/dash_metadata.p4
+++ b/dash-pipeline/bmv2/dash_metadata.p4
@@ -243,7 +243,7 @@ struct metadata_t {
     bit<16> dash_tunnel_next_hop_id;
     bit<32> meter_class;
     bit<8> local_region_id;
-    EthernetAddress dpapp_mac;
+    EthernetAddress cpu_mac;
 }
 
 #endif /* _SIRIUS_METADATA_P4_ */

--- a/dash-pipeline/bmv2/dash_metadata.p4
+++ b/dash-pipeline/bmv2/dash_metadata.p4
@@ -243,6 +243,7 @@ struct metadata_t {
     bit<16> dash_tunnel_next_hop_id;
     bit<32> meter_class;
     bit<8> local_region_id;
+    EthernetAddress dpapp_mac;
 }
 
 #endif /* _SIRIUS_METADATA_P4_ */

--- a/dash-pipeline/bmv2/stages/conntrack_lookup.p4
+++ b/dash-pipeline/bmv2/stages/conntrack_lookup.p4
@@ -127,7 +127,7 @@ control conntrack_build_dash_header(inout headers_t hdr, in metadata_t meta,
         hdr.packet_meta.length = length + PACKET_META_HDR_SIZE;
 
         hdr.dp_ethernet.setValid();
-        hdr.dp_ethernet.dst_addr = DPAPP_MAC;
+        hdr.dp_ethernet.dst_addr = meta.dpapp_mac;
         hdr.dp_ethernet.src_addr = meta.u0_encap_data.underlay_smac;
         hdr.dp_ethernet.ether_type = DASH_ETHTYPE;
     }

--- a/dash-pipeline/bmv2/stages/conntrack_lookup.p4
+++ b/dash-pipeline/bmv2/stages/conntrack_lookup.p4
@@ -127,7 +127,7 @@ control conntrack_build_dash_header(inout headers_t hdr, in metadata_t meta,
         hdr.packet_meta.length = length + PACKET_META_HDR_SIZE;
 
         hdr.dp_ethernet.setValid();
-        hdr.dp_ethernet.dst_addr = meta.dpapp_mac;
+        hdr.dp_ethernet.dst_addr = meta.cpu_mac;
         hdr.dp_ethernet.src_addr = meta.u0_encap_data.underlay_smac;
         hdr.dp_ethernet.ether_type = DASH_ETHTYPE;
     }

--- a/dash-pipeline/bmv2/stages/pre_pipeline.p4
+++ b/dash-pipeline/bmv2/stages/pre_pipeline.p4
@@ -27,11 +27,11 @@ control pre_pipeline_stage(inout headers_t hdr,
 
     action set_internal_config(EthernetAddress neighbor_mac,
                             EthernetAddress mac,
-                            EthernetAddress dpapp_mac,
+                            EthernetAddress cpu_mac,
                             bit<1> flow_enabled) {
         meta.u0_encap_data.underlay_dmac = neighbor_mac;
         meta.u0_encap_data.underlay_smac = mac;
-        meta.dpapp_mac = dpapp_mac;
+        meta.cpu_mac = cpu_mac;
         meta.flow_enabled = (bool)flow_enabled;
     }
 

--- a/dash-pipeline/bmv2/stages/pre_pipeline.p4
+++ b/dash-pipeline/bmv2/stages/pre_pipeline.p4
@@ -27,9 +27,11 @@ control pre_pipeline_stage(inout headers_t hdr,
 
     action set_internal_config(EthernetAddress neighbor_mac,
                             EthernetAddress mac,
+                            EthernetAddress dpapp_mac,
                             bit<1> flow_enabled) {
         meta.u0_encap_data.underlay_dmac = neighbor_mac;
         meta.u0_encap_data.underlay_smac = mac;
+        meta.dpapp_mac = dpapp_mac;
         meta.flow_enabled = (bool)flow_enabled;
     }
 

--- a/dash-pipeline/dockerfiles/Dockerfile.saithrift-client-bldr
+++ b/dash-pipeline/dockerfiles/Dockerfile.saithrift-client-bldr
@@ -15,7 +15,7 @@ ADD requirements.txt /tests/
 RUN apt update && apt install -y python3 python3-pip sudo && \
     sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1 && \
     sudo python3 -m pip install -r /tests/requirements.txt && \
-    sudo pip3 install scapy pysubnettree
+    sudo pip3 install scapy pysubnettree p4runtime
 
 WORKDIR /
 

--- a/test/test-cases/functional/ptf/p4_dash_utils.py
+++ b/test/test-cases/functional/ptf/p4_dash_utils.py
@@ -47,7 +47,7 @@ class P4info():
 
 def set_internal_config(neighbor_mac :bytes = None,
                         mac :bytes = None,
-                        dpapp_mac :bytes = None,
+                        cpu_mac :bytes = None,
                         flow_enabled :bytes = None):
     '''
     Set dash pipeline internal config by updating table entry of internal_config.
@@ -91,8 +91,8 @@ def set_internal_config(neighbor_mac :bytes = None,
             changed += 1
 
         param = entry.action.action.params[2]
-        if dpapp_mac and dpapp_mac != param.value:
-            param.value = dpapp_mac
+        if cpu_mac and cpu_mac != param.value:
+            param.value = cpu_mac
             changed += 1
 
         param = entry.action.action.params[3]
@@ -132,8 +132,8 @@ def set_internal_config(neighbor_mac :bytes = None,
 
     param = action.params.add()
     param.param_id = 3
-    if dpapp_mac:
-        param.value = dpapp_mac
+    if cpu_mac:
+        param.value = cpu_mac
     else:   # default value
         param.value = b'\x00\x00\x00\x00\x00\x00'
 
@@ -160,7 +160,7 @@ def use_flow(cls):
         if _setUp is not None:
             _setUp(self, *args, **kwargs)
         print(f'*** Enable Flow lookup')
-        set_internal_config(dpapp_mac = mac_in_bytes(get_mac("veth5")),
+        set_internal_config(cpu_mac = mac_in_bytes(get_mac("veth5")),
                             flow_enabled = b'\x01')
         return
 

--- a/test/test-cases/functional/ptf/p4_dash_utils.py
+++ b/test/test-cases/functional/ptf/p4_dash_utils.py
@@ -1,0 +1,115 @@
+import grpc
+from p4.v1 import p4runtime_pb2
+from p4.v1 import p4runtime_pb2_grpc
+
+class P4info():
+    def __init__(self, stub):
+        self.config = P4info.get_pipeline_config(stub)
+
+    @staticmethod
+    def get_pipeline_config(stub):
+        try:
+            req = p4runtime_pb2.GetForwardingPipelineConfigRequest()
+            req.device_id = 0
+            req.response_type = p4runtime_pb2.GetForwardingPipelineConfigRequest.ResponseType.P4INFO_AND_COOKIE
+            return stub.GetForwardingPipelineConfig(req).config.p4info
+        except Exception as e:
+            print(f'gRPC error: str({e})')
+            return None
+
+    def get_table(self, name):
+        for table in self.config.tables:
+            if table.preamble.name == name:
+                return table
+
+        return None
+
+    def get_action(self, name):
+        for action in self.config.actions:
+            if action.preamble.name == name:
+                return action
+
+        return None
+
+
+def toggle_flow_lookup(enabled):
+    channel = grpc.insecure_channel('localhost:9559')
+    stub = p4runtime_pb2_grpc.P4RuntimeStub(channel)
+
+    p4info = P4info(stub)
+    internal_config = p4info.get_table("dash_ingress.dash_lookup_stage.pre_pipeline_stage.internal_config")
+
+    entry = p4runtime_pb2.TableEntry()
+    entry.table_id = internal_config.preamble.id
+    entry.priority = 1
+
+    match = entry.match.add()
+    match.field_id = 1
+    match.ternary.value = b'\x00'
+    match.ternary.mask = b'\xff'
+
+    req = p4runtime_pb2.ReadRequest()
+    req.device_id = 0
+    entity = req.entities.add()
+    entity.table_entry.CopyFrom(entry)
+    for response in stub.Read(req):
+        if not response.entities:
+            continue
+        entry = response.entities[0].table_entry
+        param = entry.action.action.params[2] #flow_enabled
+        if param.value[0] == enabled:
+            return # none of change
+
+        param.value = b'\x01' if enabled else b'\x00'
+        req = p4runtime_pb2.WriteRequest()
+        req.device_id = 0
+        update = req.updates.add()
+        update.type = p4runtime_pb2.Update.MODIFY
+        update.entity.table_entry.CopyFrom(entry)
+        stub.Write(req)
+        return
+
+    # Add one entry
+    set_internal_config = p4info.get_action("dash_ingress.dash_lookup_stage.pre_pipeline_stage.set_internal_config")
+    entry.action.action.action_id = set_internal_config.preamble.id
+    action = entry.action.action
+    param = action.params.add()
+    param.param_id = 1
+    param.value = b'\x00\x00\x00\x00\x00\x00'
+    param = action.params.add()
+    param.param_id = 2
+    param.value = b'\x00\x00\x00\x00\x00\x00'
+    param = action.params.add()
+    param.param_id = 3
+    param.value = b'\x01' if enabled else b'\x00'
+
+    req = p4runtime_pb2.WriteRequest()
+    req.device_id = 0
+    update = req.updates.add()
+    update.type = p4runtime_pb2.Update.INSERT
+    update.entity.table_entry.CopyFrom(entry)
+    stub.Write(req)
+
+
+def use_flow(cls):
+    _setUp = getattr(cls, "setUp", None)
+    _tearDown = getattr(cls, "tearDown", None)
+
+    def setUp(self, *args, **kwargs):
+        if _setUp is not None:
+            _setUp(self, *args, **kwargs)
+        print(f'*** Enable Flow lookup')
+        toggle_flow_lookup(True)
+        return
+
+    def tearDown(self, *args, **kwargs):
+        print(f'*** Disable Flow lookup')
+        toggle_flow_lookup(False)
+        if _tearDown is not None:
+            _tearDown(self, *args, **kwargs)
+        return
+
+    setattr(cls, "setUp", setUp)
+    setattr(cls, "tearDown", tearDown)
+    return cls
+

--- a/test/test-cases/functional/ptf/p4_dash_utils.py
+++ b/test/test-cases/functional/ptf/p4_dash_utils.py
@@ -47,6 +47,7 @@ class P4info():
 
 def set_internal_config(neighbor_mac :bytes = None,
                         mac :bytes = None,
+                        dpapp_mac :bytes = None,
                         flow_enabled :bytes = None):
     '''
     Set dash pipeline internal config by updating table entry of internal_config.
@@ -90,6 +91,11 @@ def set_internal_config(neighbor_mac :bytes = None,
             changed += 1
 
         param = entry.action.action.params[2]
+        if dpapp_mac and dpapp_mac != param.value:
+            param.value = dpapp_mac
+            changed += 1
+
+        param = entry.action.action.params[3]
         if flow_enabled and flow_enabled != param.value:
             param.value = flow_enabled
             changed += 1
@@ -126,6 +132,13 @@ def set_internal_config(neighbor_mac :bytes = None,
 
     param = action.params.add()
     param.param_id = 3
+    if dpapp_mac:
+        param.value = dpapp_mac
+    else:   # default value
+        param.value = b'\x00\x00\x00\x00\x00\x00'
+
+    param = action.params.add()
+    param.param_id = 4
     if flow_enabled:
         param.value = flow_enabled
     else:   # default value
@@ -147,7 +160,8 @@ def use_flow(cls):
         if _setUp is not None:
             _setUp(self, *args, **kwargs)
         print(f'*** Enable Flow lookup')
-        set_internal_config(flow_enabled = b'\x01')
+        set_internal_config(dpapp_mac = mac_in_bytes(get_mac("veth5")),
+                            flow_enabled = b'\x01')
         return
 
     def tearDown(self, *args, **kwargs):

--- a/test/test-cases/functional/ptf/saidashvnet_sanity.py
+++ b/test/test-cases/functional/ptf/saidashvnet_sanity.py
@@ -25,7 +25,7 @@ class SaiThriftVnetOutboundUdpPktTest(SaiHelperSimplified):
         # SAI address family
         self.sai_ip_addr_family = SAI_IP_ADDR_FAMILY_IPV4
 
-        self.dut_mac   = get_mac("veth0")
+        self.dut_mac = get_mac("veth0")
         self.neighbor_mac = get_mac("veth1")
         set_internal_config(neighbor_mac = mac_in_bytes(self.neighbor_mac),
                             mac = mac_in_bytes(self.dut_mac))

--- a/test/test-cases/functional/ptf/saidashvnet_sanity.py
+++ b/test/test-cases/functional/ptf/saidashvnet_sanity.py
@@ -26,8 +26,8 @@ class SaiThriftVnetOutboundUdpPktTest(SaiHelperSimplified):
         self.sai_ip_addr_family = SAI_IP_ADDR_FAMILY_IPV4
 
         self.dut_mac   = get_mac("veth0")
-        self.host0_mac = get_mac("veth1") # ptf port0
-        set_internal_config(neighbor_mac = mac_in_bytes(self.host0_mac),
+        self.neighbor_mac = get_mac("veth1")
+        set_internal_config(neighbor_mac = mac_in_bytes(self.neighbor_mac),
                             mac = mac_in_bytes(self.dut_mac))
 
         # Flag to indicate whether configureVnet were successful or not.
@@ -170,7 +170,7 @@ class SaiThriftVnetOutboundUdpPktTest(SaiHelperSimplified):
                                         ip_dst=self.dst_ca_ip,
                                         ip_src=src_vm_ip)
         vxlan_pkt = simple_vxlan_packet(eth_dst=self.dut_mac,
-                                        eth_src=self.host0_mac,
+                                        eth_src=self.neighbor_mac,
                                         ip_dst=wrong_vip,
                                         ip_src=self.src_vm_pa_ip,
                                         udp_sport=11638,
@@ -189,7 +189,7 @@ class SaiThriftVnetOutboundUdpPktTest(SaiHelperSimplified):
                                         ip_dst=wrong_dst_ca,
                                         ip_src=src_vm_ip)
         vxlan_pkt = simple_vxlan_packet(eth_dst=self.dut_mac,
-                                        eth_src=self.host0_mac,
+                                        eth_src=self.neighbor_mac,
                                         ip_dst=self.vip,
                                         ip_src=self.src_vm_pa_ip,
                                         udp_sport=11638,
@@ -208,7 +208,7 @@ class SaiThriftVnetOutboundUdpPktTest(SaiHelperSimplified):
                                         ip_dst=wrong_dst_ca,
                                         ip_src=src_vm_ip)
         vxlan_pkt = simple_vxlan_packet(eth_dst=self.dut_mac,
-                                        eth_src=self.host0_mac,
+                                        eth_src=self.neighbor_mac,
                                         ip_dst=self.vip,
                                         ip_src=self.src_vm_pa_ip,
                                         udp_sport=11638,
@@ -226,7 +226,7 @@ class SaiThriftVnetOutboundUdpPktTest(SaiHelperSimplified):
                                         ip_dst=self.dst_ca_ip,
                                         ip_src=src_vm_ip)
         vxlan_pkt = simple_vxlan_packet(eth_dst=self.dut_mac,
-                                        eth_src=self.host0_mac,
+                                        eth_src=self.neighbor_mac,
                                         ip_dst=self.vip,
                                         ip_src=self.src_vm_pa_ip,
                                         udp_sport=11638,
@@ -238,7 +238,7 @@ class SaiThriftVnetOutboundUdpPktTest(SaiHelperSimplified):
                                         eth_src=self.eni_mac,
                                         ip_dst=self.dst_ca_ip,
                                         ip_src=src_vm_ip)
-        vxlan_exp_pkt = simple_vxlan_packet(eth_dst=self.host0_mac,
+        vxlan_exp_pkt = simple_vxlan_packet(eth_dst=self.neighbor_mac,
                                         eth_src=self.dut_mac,
                                         ip_dst=self.dst_pa_ip,
                                         ip_src=self.vip,
@@ -326,7 +326,7 @@ class SaiThriftVnetOutboundUdpV6PktTest(SaiThriftVnetOutboundUdpPktTest):
                                         ipv6_dst=self.dst_ca_ip,
                                         ipv6_src=src_vm_ip)
         vxlan_pkt = simple_vxlan_packet(eth_dst=self.dut_mac,
-                                        eth_src=self.host0_mac,
+                                        eth_src=self.neighbor_mac,
                                         ip_dst=wrong_vip,
                                         ip_src=self.src_vm_pa_ip,
                                         udp_sport=11638,
@@ -345,7 +345,7 @@ class SaiThriftVnetOutboundUdpV6PktTest(SaiThriftVnetOutboundUdpPktTest):
                                         ipv6_dst=wrong_dst_ca,
                                         ipv6_src=src_vm_ip)
         vxlan_pkt = simple_vxlan_packet(eth_dst=self.dut_mac,
-                                        eth_src=self.host0_mac,
+                                        eth_src=self.neighbor_mac,
                                         ip_dst=self.vip,
                                         ip_src=self.src_vm_pa_ip,
                                         udp_sport=11638,
@@ -364,7 +364,7 @@ class SaiThriftVnetOutboundUdpV6PktTest(SaiThriftVnetOutboundUdpPktTest):
                                         ipv6_dst=wrong_dst_ca,
                                         ipv6_src=src_vm_ip)
         vxlan_pkt = simple_vxlan_packet(eth_dst=self.dut_mac,
-                                        eth_src=self.host0_mac,
+                                        eth_src=self.neighbor_mac,
                                         ip_dst=self.vip,
                                         ip_src=self.src_vm_pa_ip,
                                         udp_sport=11638,
@@ -382,7 +382,7 @@ class SaiThriftVnetOutboundUdpV6PktTest(SaiThriftVnetOutboundUdpPktTest):
                                         ipv6_dst=self.dst_ca_ip,
                                         ipv6_src=src_vm_ip)
         vxlan_pkt = simple_vxlan_packet(eth_dst=self.dut_mac,
-                                        eth_src=self.host0_mac,
+                                        eth_src=self.neighbor_mac,
                                         ip_dst=self.vip,
                                         ip_src=self.src_vm_pa_ip,
                                         udp_sport=11638,
@@ -394,7 +394,7 @@ class SaiThriftVnetOutboundUdpV6PktTest(SaiThriftVnetOutboundUdpPktTest):
                                         eth_src=self.eni_mac,
                                         ipv6_dst=self.dst_ca_ip,
                                         ipv6_src=src_vm_ip)
-        vxlan_exp_pkt = simple_vxlan_packet(eth_dst=self.host0_mac,
+        vxlan_exp_pkt = simple_vxlan_packet(eth_dst=self.neighbor_mac,
                                         eth_src=self.dut_mac,
                                         ip_dst=self.dst_pa_ip,
                                         ip_src=self.vip,

--- a/test/test-cases/functional/ptf/saidashvnet_sanity.py
+++ b/test/test-cases/functional/ptf/saidashvnet_sanity.py
@@ -1,5 +1,6 @@
 from sai_thrift.sai_headers import *
 from sai_base_test import *
+from p4_dash_utils import *
 
 class SaiThriftVnetOutboundUdpPktTest(SaiHelperSimplified):
     """ Test saithrift vnet outbound"""
@@ -10,7 +11,6 @@ class SaiThriftVnetOutboundUdpPktTest(SaiHelperSimplified):
         self.outbound_vni = 60
         self.vnet_vni = 100
         self.eni_mac = "00:cc:cc:cc:cc:cc"
-        self.our_mac = "00:00:02:03:04:05"
         self.dst_ca_mac = "00:dd:dd:dd:dd:dd"
         self.vip = "172.16.1.100"
         self.outbound_vni = 100
@@ -24,6 +24,11 @@ class SaiThriftVnetOutboundUdpPktTest(SaiHelperSimplified):
         self.ip_addr_family_attr = 'ip4'
         # SAI address family
         self.sai_ip_addr_family = SAI_IP_ADDR_FAMILY_IPV4
+
+        self.dut_mac   = get_mac("veth0")
+        self.host0_mac = get_mac("veth1") # ptf port0
+        set_internal_config(neighbor_mac = mac_in_bytes(self.host0_mac),
+                            mac = mac_in_bytes(self.dut_mac))
 
         # Flag to indicate whether configureVnet were successful or not.
         self.configured = False
@@ -157,7 +162,6 @@ class SaiThriftVnetOutboundUdpPktTest(SaiHelperSimplified):
     def trafficTest(self):
 
         src_vm_ip = "10.1.1.10"
-        outer_smac = "00:00:05:06:06:06"
 
         # check VIP drop
         wrong_vip = "172.16.100.100"
@@ -165,8 +169,8 @@ class SaiThriftVnetOutboundUdpPktTest(SaiHelperSimplified):
                                         eth_src=self.eni_mac,
                                         ip_dst=self.dst_ca_ip,
                                         ip_src=src_vm_ip)
-        vxlan_pkt = simple_vxlan_packet(eth_dst=self.our_mac,
-                                        eth_src=outer_smac,
+        vxlan_pkt = simple_vxlan_packet(eth_dst=self.dut_mac,
+                                        eth_src=self.host0_mac,
                                         ip_dst=wrong_vip,
                                         ip_src=self.src_vm_pa_ip,
                                         udp_sport=11638,
@@ -184,8 +188,8 @@ class SaiThriftVnetOutboundUdpPktTest(SaiHelperSimplified):
                                         eth_src=self.eni_mac,
                                         ip_dst=wrong_dst_ca,
                                         ip_src=src_vm_ip)
-        vxlan_pkt = simple_vxlan_packet(eth_dst=self.our_mac,
-                                        eth_src=outer_smac,
+        vxlan_pkt = simple_vxlan_packet(eth_dst=self.dut_mac,
+                                        eth_src=self.host0_mac,
                                         ip_dst=self.vip,
                                         ip_src=self.src_vm_pa_ip,
                                         udp_sport=11638,
@@ -203,8 +207,8 @@ class SaiThriftVnetOutboundUdpPktTest(SaiHelperSimplified):
                                         eth_src=self.eni_mac,
                                         ip_dst=wrong_dst_ca,
                                         ip_src=src_vm_ip)
-        vxlan_pkt = simple_vxlan_packet(eth_dst=self.our_mac,
-                                        eth_src=outer_smac,
+        vxlan_pkt = simple_vxlan_packet(eth_dst=self.dut_mac,
+                                        eth_src=self.host0_mac,
                                         ip_dst=self.vip,
                                         ip_src=self.src_vm_pa_ip,
                                         udp_sport=11638,
@@ -221,8 +225,8 @@ class SaiThriftVnetOutboundUdpPktTest(SaiHelperSimplified):
                                         eth_src=self.eni_mac,
                                         ip_dst=self.dst_ca_ip,
                                         ip_src=src_vm_ip)
-        vxlan_pkt = simple_vxlan_packet(eth_dst=self.our_mac,
-                                        eth_src=outer_smac,
+        vxlan_pkt = simple_vxlan_packet(eth_dst=self.dut_mac,
+                                        eth_src=self.host0_mac,
                                         ip_dst=self.vip,
                                         ip_src=self.src_vm_pa_ip,
                                         udp_sport=11638,
@@ -234,8 +238,8 @@ class SaiThriftVnetOutboundUdpPktTest(SaiHelperSimplified):
                                         eth_src=self.eni_mac,
                                         ip_dst=self.dst_ca_ip,
                                         ip_src=src_vm_ip)
-        vxlan_exp_pkt = simple_vxlan_packet(eth_dst="00:00:00:00:00:00",
-                                        eth_src="00:00:00:00:00:00",
+        vxlan_exp_pkt = simple_vxlan_packet(eth_dst=self.host0_mac,
+                                        eth_src=self.dut_mac,
                                         ip_dst=self.dst_pa_ip,
                                         ip_src=self.vip,
                                         udp_sport=0, # TODO: Fix sport in pipeline
@@ -283,6 +287,10 @@ class SaiThriftVnetOutboundUdpPktTest(SaiHelperSimplified):
             # Run standard PTF teardown
             super(SaiThriftVnetOutboundUdpPktTest, self).tearDown()
 
+        # restore default internal_config
+        set_internal_config(neighbor_mac = b'\x00\x00\x00\x00\x00\x00',
+                            mac = b'\x00\x00\x00\x00\x00\x00')
+
 
 class SaiThriftVnetOutboundUdpV6PktTest(SaiThriftVnetOutboundUdpPktTest):
     """ Test saithrift vnet outbound ipv6"""
@@ -293,7 +301,6 @@ class SaiThriftVnetOutboundUdpV6PktTest(SaiThriftVnetOutboundUdpPktTest):
         self.outbound_vni = 60
         self.vnet_vni = 50
         self.eni_mac = "00:aa:aa:aa:aa:aa"
-        self.our_mac = "00:00:06:07:08:09"
         self.dst_ca_mac = "00:bb:bb:bb:bb:bb"
         self.vip = "172.16.1.200"
         self.outbound_vni = 50
@@ -311,7 +318,6 @@ class SaiThriftVnetOutboundUdpV6PktTest(SaiThriftVnetOutboundUdpPktTest):
     def trafficTest(self):
 
         src_vm_ip = "2000:aaaa::10a"
-        outer_smac = "00:00:03:06:06:06"
 
         # check VIP drop
         wrong_vip = "172.16.100.100"
@@ -319,8 +325,8 @@ class SaiThriftVnetOutboundUdpV6PktTest(SaiThriftVnetOutboundUdpPktTest):
                                         eth_src=self.eni_mac,
                                         ipv6_dst=self.dst_ca_ip,
                                         ipv6_src=src_vm_ip)
-        vxlan_pkt = simple_vxlan_packet(eth_dst=self.our_mac,
-                                        eth_src=outer_smac,
+        vxlan_pkt = simple_vxlan_packet(eth_dst=self.dut_mac,
+                                        eth_src=self.host0_mac,
                                         ip_dst=wrong_vip,
                                         ip_src=self.src_vm_pa_ip,
                                         udp_sport=11638,
@@ -338,8 +344,8 @@ class SaiThriftVnetOutboundUdpV6PktTest(SaiThriftVnetOutboundUdpPktTest):
                                         eth_src=self.eni_mac,
                                         ipv6_dst=wrong_dst_ca,
                                         ipv6_src=src_vm_ip)
-        vxlan_pkt = simple_vxlan_packet(eth_dst=self.our_mac,
-                                        eth_src=outer_smac,
+        vxlan_pkt = simple_vxlan_packet(eth_dst=self.dut_mac,
+                                        eth_src=self.host0_mac,
                                         ip_dst=self.vip,
                                         ip_src=self.src_vm_pa_ip,
                                         udp_sport=11638,
@@ -357,8 +363,8 @@ class SaiThriftVnetOutboundUdpV6PktTest(SaiThriftVnetOutboundUdpPktTest):
                                         eth_src=self.eni_mac,
                                         ipv6_dst=wrong_dst_ca,
                                         ipv6_src=src_vm_ip)
-        vxlan_pkt = simple_vxlan_packet(eth_dst=self.our_mac,
-                                        eth_src=outer_smac,
+        vxlan_pkt = simple_vxlan_packet(eth_dst=self.dut_mac,
+                                        eth_src=self.host0_mac,
                                         ip_dst=self.vip,
                                         ip_src=self.src_vm_pa_ip,
                                         udp_sport=11638,
@@ -375,8 +381,8 @@ class SaiThriftVnetOutboundUdpV6PktTest(SaiThriftVnetOutboundUdpPktTest):
                                         eth_src=self.eni_mac,
                                         ipv6_dst=self.dst_ca_ip,
                                         ipv6_src=src_vm_ip)
-        vxlan_pkt = simple_vxlan_packet(eth_dst=self.our_mac,
-                                        eth_src=outer_smac,
+        vxlan_pkt = simple_vxlan_packet(eth_dst=self.dut_mac,
+                                        eth_src=self.host0_mac,
                                         ip_dst=self.vip,
                                         ip_src=self.src_vm_pa_ip,
                                         udp_sport=11638,
@@ -388,8 +394,8 @@ class SaiThriftVnetOutboundUdpV6PktTest(SaiThriftVnetOutboundUdpPktTest):
                                         eth_src=self.eni_mac,
                                         ipv6_dst=self.dst_ca_ip,
                                         ipv6_src=src_vm_ip)
-        vxlan_exp_pkt = simple_vxlan_packet(eth_dst="00:00:00:00:00:00",
-                                        eth_src="00:00:00:00:00:00",
+        vxlan_exp_pkt = simple_vxlan_packet(eth_dst=self.host0_mac,
+                                        eth_src=self.dut_mac,
                                         ip_dst=self.dst_pa_ip,
                                         ip_src=self.vip,
                                         udp_sport=0, # TODO: Fix sport in pipeline


### PR DESCRIPTION
This PR adds a module p4_dash_utils to include helper functions for p4 pipeline. 
* Function `set_internal_config` aims to update pipeline internal configuration, neighbor mac, data port mac, cpu port mac, etc.
* Decorator `use_flow` aims to enable flow lookup stage in p4 pipeline. It wrappers method setUp/tearDown of test class.
