### PR TITLE
[DASH Flow] Add SaiVal derivative before some arguments of set_flow_entry_attr to make configuration easier

### DIFF
--- a/dash-pipeline/SAI/specs/dash_flow.yaml
+++ b/dash-pipeline/SAI/specs/dash_flow.yaml
@@ -311,9 +311,9 @@ sai_apis:
   - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
     name: SAI_FLOW_ENTRY_ATTR_UNDERLAY0_SIP
     description: Action parameter underlay0 sip
-    type: sai_uint32_t
-    attr_value_field: u32
-    default: '0'
+    type: sai_ip_address_t
+    attr_value_field: ipaddr
+    default: 0.0.0.0
     isresourcetype: false
     flags: CREATE_AND_SET
     object_name: null
@@ -324,9 +324,9 @@ sai_apis:
   - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
     name: SAI_FLOW_ENTRY_ATTR_UNDERLAY0_DIP
     description: Action parameter underlay0 dip
-    type: sai_uint32_t
-    attr_value_field: u32
-    default: '0'
+    type: sai_ip_address_t
+    attr_value_field: ipaddr
+    default: 0.0.0.0
     isresourcetype: false
     flags: CREATE_AND_SET
     object_name: null
@@ -363,9 +363,9 @@ sai_apis:
   - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
     name: SAI_FLOW_ENTRY_ATTR_UNDERLAY1_SIP
     description: Action parameter underlay1 sip
-    type: sai_uint32_t
-    attr_value_field: u32
-    default: '0'
+    type: sai_ip_address_t
+    attr_value_field: ipaddr
+    default: 0.0.0.0
     isresourcetype: false
     flags: CREATE_AND_SET
     object_name: null
@@ -376,9 +376,9 @@ sai_apis:
   - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
     name: SAI_FLOW_ENTRY_ATTR_UNDERLAY1_DIP
     description: Action parameter underlay1 dip
-    type: sai_uint32_t
-    attr_value_field: u32
-    default: '0'
+    type: sai_ip_address_t
+    attr_value_field: ipaddr
+    default: 0.0.0.0
     isresourcetype: false
     flags: CREATE_AND_SET
     object_name: null

--- a/dash-pipeline/bmv2/stages/conntrack_lookup.p4
+++ b/dash-pipeline/bmv2/stages/conntrack_lookup.p4
@@ -239,15 +239,15 @@ control conntrack_lookup_stage(inout headers_t hdr, inout metadata_t meta) {
 
         /* Flow encap related attributes */
         bit<24> underlay0_vnet_id,
-        IPv4Address underlay0_sip,
-        IPv4Address underlay0_dip,
+        @SaiVal[type="sai_ip_address_t"] IPv4Address underlay0_sip,
+        @SaiVal[type="sai_ip_address_t"] IPv4Address underlay0_dip,
         EthernetAddress underlay0_smac,
         EthernetAddress underlay0_dmac,
         @SaiVal[type="sai_dash_encapsulation_t"] dash_encapsulation_t underlay0_dash_encapsulation,
 
         bit<24> underlay1_vnet_id,
-        IPv4Address underlay1_sip,
-        IPv4Address underlay1_dip,
+        @SaiVal[type="sai_ip_address_t"] IPv4Address underlay1_sip,
+        @SaiVal[type="sai_ip_address_t"] IPv4Address underlay1_dip,
         EthernetAddress underlay1_smac,
         EthernetAddress underlay1_dmac,
         @SaiVal[type="sai_dash_encapsulation_t"] dash_encapsulation_t underlay1_dash_encapsulation,


### PR DESCRIPTION
This PR adds `@SaiVal[type="sai_ip_address_t"]` before the following arguments of action `set_flow_entry_attr` in dash flow:
- underlay0_sip
- underlay0_dip
- underlay1_sip
- underlay1_dip

There are mainly two reasons for doing this:
- Other parts of the dash pipeline do so. For example, in action `set_eni_attrs`, every argument of type `IPv4Address` is added a `@SaiVal[type="sai_ip_address_t"]` before it.
- Generated saithrift rpc can use IP address-related helper functions to assign a value to corresponding arguments instead of directly using a u32 type value, making the code more readable.