### PR TITLE
Define table size per scaling test 

### DIFF
--- a/dash-pipeline/Makefile
+++ b/dash-pipeline/Makefile
@@ -103,7 +103,7 @@ sai-submodule:
 # P4 Source code compile TARGETS
 ######################################
 
-P4_SRC=$(wildcard bmv2/**/*.p4)
+P4_SRC=$(wildcard bmv2/**/*.p4) $(wildcard bmv2/*.h)
 P4_MAIN=bmv2/dash_pipeline.p4
 P4_OUTDIR=bmv2/dash_pipeline.bmv2
 P4_ARTIFACTS=$(P4_OUTDIR)/dash_pipeline.json $(P4_OUTDIR)/dash_pipeline_p4rt.txt

--- a/dash-pipeline/bmv2/defines.h
+++ b/dash-pipeline/bmv2/defines.h
@@ -1,0 +1,15 @@
+#ifndef _DASH_DEFINES_H_
+#define _DASH_DEFINES_H_
+
+#ifdef TABLE_FULL_SCALE
+#define TABLE_CA_TO_PA_SIZE     (8 * 1024 * 1024)
+#define TABLE_ROUTING_SIZE      (4 * 1024 * 1024)
+
+#else   /* default size */
+#define TABLE_CA_TO_PA_SIZE     (8 * 1024)
+#define TABLE_ROUTING_SIZE      (4 * 1024)
+
+#endif
+
+
+#endif /* _DASH_DEFINES_H_ */

--- a/dash-pipeline/bmv2/defines.h
+++ b/dash-pipeline/bmv2/defines.h
@@ -1,13 +1,17 @@
 #ifndef _DASH_DEFINES_H_
 #define _DASH_DEFINES_H_
 
-#ifdef TABLE_FULL_SCALE
+#if defined(TABLE_HERO_SCALE)
 #define TABLE_CA_TO_PA_SIZE     (8 * 1024 * 1024)
 #define TABLE_ROUTING_SIZE      (4 * 1024 * 1024)
 
-#else   /* default size */
-#define TABLE_CA_TO_PA_SIZE     (8 * 1024)
-#define TABLE_ROUTING_SIZE      (4 * 1024)
+#elif defined(TABLE_BABY_HERO_SCALE)
+#define TABLE_CA_TO_PA_SIZE     (8 * 1024 * 10)
+#define TABLE_ROUTING_SIZE      (4 * 1024 * 10)
+
+#else   /* default/minimum size */
+#define TABLE_CA_TO_PA_SIZE     1024
+#define TABLE_ROUTING_SIZE      1024
 
 #endif
 

--- a/dash-pipeline/bmv2/stages/outbound_mapping.p4
+++ b/dash-pipeline/bmv2/stages/outbound_mapping.p4
@@ -2,6 +2,7 @@
 #define _DASH_STAGE_OUTBOUND_MAPPING_P4_
 
 #include "../dash_routing_types.p4"
+#include "../defines.h"
 
 control outbound_mapping_stage(
     inout headers_t hdr,
@@ -23,7 +24,7 @@ control outbound_mapping_stage(
             set_private_link_mapping(hdr, meta);
             @defaultonly drop(meta);
         }
-        size = 8 * 1024 * 1024;
+        size = TABLE_CA_TO_PA_SIZE;
         const default_action = drop(meta);
 
         ATTACH_TABLE_COUNTER(ca_to_pa_counter)

--- a/dash-pipeline/bmv2/stages/outbound_routing.p4
+++ b/dash-pipeline/bmv2/stages/outbound_routing.p4
@@ -2,6 +2,7 @@
 #define _DASH_STAGE_OUTBOUND_ROUTING_P4_
 
 #include "../dash_routing_types.p4"
+#include "../defines.h"
 
 control outbound_routing_stage(
     inout headers_t hdr,
@@ -40,7 +41,7 @@ control outbound_routing_stage(
             route_service_tunnel(hdr, meta);
             drop(meta);
         }
-        size = 4 * 1024 * 1024;
+        size = TABLE_ROUTING_SIZE;
         const default_action = drop(meta);
 
         ATTACH_TABLE_COUNTER(routing_counter)


### PR DESCRIPTION
This pull request adds a new header file `defines.h` for constants definitions. It defines different table sizes for outbound routing and ca_to_pa mapping according to [hero-implementation-details](https://github.com/sonic-net/DASH/blob/main/documentation/general/program-scale-testing-requirements/hero-implementation-details.md).

The hardcoded table sizes of outbound routing and ca_to_pa mapping, whose size 4M and 8M respectively (from https://github.com/sonic-net/DASH/pull/592) take up too much memory by default. This memory pressure could make low-RAM KVM DPU crash and be unusable with sonic mgmt test. 

The below shows the dash pipeline memory usage of the container `simple_switch` with different scale number of routing and mapping.
```
1. 4M/8M 
junhuazhai@junhuazhai-dev-vm:~/workspace/DASH/dash-pipeline$ docker stats --no-stream simple_switch-junhuazhai
CONTAINER ID   NAME                       CPU %     MEM USAGE / LIMIT     MEM %     NET I/O   BLOCK I/O   PIDS
00016dc28662   simple_switch-junhuazhai   0.08%     1.799GiB / 62.78GiB   2.87%     0B / 0B   0B / 0B     20

2. 4K/8K
junhuazhai@junhuazhai-dev-vm:~/workspace/DASH/dash-pipeline$ docker stats --no-stream simple_switch-junhuazhai
CONTAINER ID   NAME                       CPU %     MEM USAGE / LIMIT     MEM %     NET I/O   BLOCK I/O   PIDS
bcb858280193   simple_switch-junhuazhai   0.08%     46.63MiB / 62.78GiB   0.07%     0B / 0B   0B / 0B     20
``` 


