### PR TITLE
[libsai] dummy implementation for ACL_TABLE

### DIFF
--- a/dash-pipeline/SAI/src/sai_dash_acl.cpp
+++ b/dash-pipeline/SAI/src/sai_dash_acl.cpp
@@ -1,0 +1,38 @@
+#include "saiimpl.h"
+
+DASH_GENERIC_QUAD(ACL_TABLE,acl_table);
+
+sai_acl_api_t dash_sai_acl_api_impl = {
+
+    DASH_GENERIC_QUAD_API(acl_table)
+
+    .create_acl_entry = 0,
+    .remove_acl_entry = 0,
+    .set_acl_entry_attribute = 0,
+    .get_acl_entry_attribute = 0,
+
+    .create_acl_counter = 0,
+    .remove_acl_counter = 0,
+    .set_acl_counter_attribute = 0,
+    .get_acl_counter_attribute = 0,
+
+    .create_acl_range = 0,
+    .remove_acl_range = 0,
+    .set_acl_range_attribute = 0,
+    .get_acl_range_attribute = 0,
+
+    .create_acl_table_group = 0,
+    .remove_acl_table_group = 0,
+    .set_acl_table_group_attribute = 0,
+    .get_acl_table_group_attribute = 0,
+
+    .create_acl_table_group_member = 0,
+    .remove_acl_table_group_member = 0,
+    .set_acl_table_group_member_attribute = 0,
+    .get_acl_table_group_member_attribute = 0,
+
+    .create_acl_table_chain_group = 0,
+    .remove_acl_table_chain_group = 0,
+    .set_acl_table_chain_group_attribute = 0,
+    .get_acl_table_chain_group_attribute = 0,
+};

--- a/dash-pipeline/SAI/templates/impls/p4_table_util.cpp.j2
+++ b/dash-pipeline/SAI/templates/impls/p4_table_util.cpp.j2
@@ -18,7 +18,7 @@
         {
             // https://github.com/p4lang/PI/blob/24e0a3c08c964e36d235973556b90e0ae922b894/proto/frontend/src/device_mgr.cpp#L2242-L2246
             DASH_LOG_WARN("Invalid reprsentation of 'don't care' LPM match, omit match field instead of using a prefix length of 0");
-            return SAI_STATUS_SUCCESS;
+            return SAI_STATUS_NOT_SUPPORTED;
         }
     {% endif %}
         auto mf_lpm = mf->mutable_lpm();

--- a/dash-pipeline/SAI/templates/impls/sai_api_func_quad.cpp.j2
+++ b/dash-pipeline/SAI/templates/impls/sai_api_func_quad.cpp.j2
@@ -28,7 +28,11 @@ static sai_status_t dash_sai_create_{{ api.name }}(
     std::shared_ptr<p4::v1::TableEntry> matchActionEntry = std::make_shared<p4::v1::TableEntry>();
     matchActionEntry->set_table_id({{meta_table}}.id);
 
-    table_{{api.name}}_add_keys({{ api.name }}, matchActionEntry);
+    if (table_{{api.name}}_add_keys({{ api.name }}, matchActionEntry) == SAI_STATUS_NOT_SUPPORTED)
+    {
+        DASH_LOG_WARN("match field in {{ api.name }} not supported, API does nothing!");
+        return SAI_STATUS_SUCCESS;  // bypass
+    }
     return dashSai->create({{meta_table}}, obj_type, matchActionEntry, attr_count, attr_list);
 {% endif %}
 }
@@ -42,7 +46,11 @@ static sai_status_t dash_sai_remove_{{ api.name }}(
     std::shared_ptr<p4::v1::TableEntry> matchActionEntry = std::make_shared<p4::v1::TableEntry>();
     matchActionEntry->set_table_id({{meta_table}}.id);
 
-    table_{{api.name}}_add_keys({{ api.name }}, matchActionEntry);
+    if (table_{{api.name}}_add_keys({{ api.name }}, matchActionEntry) == SAI_STATUS_NOT_SUPPORTED)
+    {
+        DASH_LOG_WARN("match field in {{ api.name }} not supported, API does nothing!");
+        return SAI_STATUS_SUCCESS;  // bypass
+    }
     return dashSai->remove({{meta_table}}, matchActionEntry);
 {% endif %}
 }
@@ -57,7 +65,11 @@ static sai_status_t dash_sai_set_{{ api.name }}_attribute(
     std::shared_ptr<p4::v1::TableEntry> matchActionEntry = std::make_shared<p4::v1::TableEntry>();
     matchActionEntry->set_table_id({{meta_table}}.id);
 
-    table_{{api.name}}_add_keys({{ api.name }}, matchActionEntry);
+    if (table_{{api.name}}_add_keys({{ api.name }}, matchActionEntry) == SAI_STATUS_NOT_SUPPORTED)
+    {
+        DASH_LOG_WARN("match field in {{ api.name }} not supported, API does nothing!");
+        return SAI_STATUS_SUCCESS;  // bypass
+    }
     return dashSai->set({{meta_table}}, matchActionEntry, attr);
 {% endif %}
 }
@@ -73,7 +85,11 @@ static sai_status_t dash_sai_get_{{ api.name }}_attribute(
     std::shared_ptr<p4::v1::TableEntry> matchActionEntry = std::make_shared<p4::v1::TableEntry>();
     matchActionEntry->set_table_id({{meta_table}}.id);
 
-    table_{{api.name}}_add_keys({{ api.name }}, matchActionEntry);
+    if (table_{{api.name}}_add_keys({{ api.name }}, matchActionEntry) == SAI_STATUS_NOT_SUPPORTED)
+    {
+        DASH_LOG_WARN("match field in {{ api.name }} not supported, API does nothing!");
+        return SAI_STATUS_SUCCESS;  // bypass
+    }
     return dashSai->get({{meta_table}}, matchActionEntry, attr_count, attr_list);
 {% endif %}
 }

--- a/dash-pipeline/SAI/templates/impls/sai_api_func_quad.cpp.j2
+++ b/dash-pipeline/SAI/templates/impls/sai_api_func_quad.cpp.j2
@@ -31,7 +31,7 @@ static sai_status_t dash_sai_create_{{ api.name }}(
     if (table_{{api.name}}_add_keys({{ api.name }}, matchActionEntry) == SAI_STATUS_NOT_SUPPORTED)
     {
         DASH_LOG_WARN("match field in {{ api.name }} not supported, API does nothing!");
-        return SAI_STATUS_SUCCESS;  // bypass
+        return SAI_STATUS_SUCCESS;  // bypass, temporary workaround for issue #656
     }
     return dashSai->create({{meta_table}}, obj_type, matchActionEntry, attr_count, attr_list);
 {% endif %}
@@ -49,7 +49,7 @@ static sai_status_t dash_sai_remove_{{ api.name }}(
     if (table_{{api.name}}_add_keys({{ api.name }}, matchActionEntry) == SAI_STATUS_NOT_SUPPORTED)
     {
         DASH_LOG_WARN("match field in {{ api.name }} not supported, API does nothing!");
-        return SAI_STATUS_SUCCESS;  // bypass
+        return SAI_STATUS_SUCCESS;  // bypass, temporary workaround for issue #656
     }
     return dashSai->remove({{meta_table}}, matchActionEntry);
 {% endif %}
@@ -68,7 +68,7 @@ static sai_status_t dash_sai_set_{{ api.name }}_attribute(
     if (table_{{api.name}}_add_keys({{ api.name }}, matchActionEntry) == SAI_STATUS_NOT_SUPPORTED)
     {
         DASH_LOG_WARN("match field in {{ api.name }} not supported, API does nothing!");
-        return SAI_STATUS_SUCCESS;  // bypass
+        return SAI_STATUS_SUCCESS;  // bypass, temporary workaround for issue #656
     }
     return dashSai->set({{meta_table}}, matchActionEntry, attr);
 {% endif %}
@@ -88,7 +88,7 @@ static sai_status_t dash_sai_get_{{ api.name }}_attribute(
     if (table_{{api.name}}_add_keys({{ api.name }}, matchActionEntry) == SAI_STATUS_NOT_SUPPORTED)
     {
         DASH_LOG_WARN("match field in {{ api.name }} not supported, API does nothing!");
-        return SAI_STATUS_SUCCESS;  // bypass
+        return SAI_STATUS_SUCCESS;  // bypass, temporary workaround for issue #656
     }
     return dashSai->get({{meta_table}}, matchActionEntry, attr_count, attr_list);
 {% endif %}

--- a/dash-pipeline/SAI/templates/saifixedapis.cpp.j2
+++ b/dash-pipeline/SAI/templates/saifixedapis.cpp.j2
@@ -29,6 +29,7 @@ sai_status_t sai_api_query(
         API(SWITCH,switch);
         API(BUFFER,buffer);
         API(DTEL,dtel);
+        API(ACL,acl);
 
 {% for api in api_names %}
         case SAI_API_{{ api | upper }}:

--- a/dash-pipeline/SAI/templates/saiimpl.h.j2
+++ b/dash-pipeline/SAI/templates/saiimpl.h.j2
@@ -13,6 +13,7 @@ DASH_PRIVATE extern sai_router_interface_api_t        dash_sai_router_interface_
 DASH_PRIVATE extern sai_switch_api_t                  dash_sai_switch_api_impl;
 DASH_PRIVATE extern sai_dtel_api_t                    dash_sai_dtel_api_impl;
 DASH_PRIVATE extern sai_buffer_api_t                  dash_sai_buffer_api_impl;
+DASH_PRIVATE extern sai_acl_api_t                     dash_sai_acl_api_impl;
 
 {% for api in api_names %}
 DASH_PRIVATE extern sai_{{ api }}_api_t dash_sai_{{ api }}_api_impl;


### PR DESCRIPTION
1. Fix #655 , by adding dummy implementation for SAI_OBJECT_TYPE_ACL_TABLE
2. Fix #656, by bypassing creation of route entry with prefix length 0