### PR TITLE
[dash-p4] Correctly set meta.dst_ip_addr for underlay routing lookup

### DIFF
--- a/dash-pipeline/bmv2/dash_inbound.p4
+++ b/dash-pipeline/bmv2/dash_inbound.p4
@@ -37,6 +37,7 @@ control inbound(inout headers_t hdr,
 
         inbound_routing_stage.apply(hdr, meta);
 
+        meta.routing_actions = dash_routing_actions_t.ENCAP_U0;
         do_tunnel_encap(hdr,
                      meta,
                      meta.u0_encap_data.underlay_dmac,

--- a/dash-pipeline/bmv2/dash_pipeline.p4
+++ b/dash-pipeline/bmv2/dash_pipeline.p4
@@ -300,7 +300,12 @@ control dash_ingress(
         routing_action_apply.apply(hdr, meta);
 
         /* Underlay routing */
-        meta.dst_ip_addr = (bit<128>)hdr.u0_ipv4.dst_addr;
+        if (meta.routing_actions & dash_routing_actions_t.ENCAP_U1 != 0) {
+            meta.dst_ip_addr = (bit<128>)hdr.u1_ipv4.dst_addr;
+        }
+        else if (meta.routing_actions & dash_routing_actions_t.ENCAP_U0 != 0) {
+            meta.dst_ip_addr = (bit<128>)hdr.u0_ipv4.dst_addr;
+        }
 
         underlay.apply(
               hdr

--- a/dash-pipeline/bmv2/dash_pipeline.p4
+++ b/dash-pipeline/bmv2/dash_pipeline.p4
@@ -299,7 +299,7 @@ control dash_ingress(
 
         routing_action_apply.apply(hdr, meta);
 
-        /* Underlay routing */
+        /* Underlay routing, using meta.dst_ip_addr as lookup key */
         if (meta.routing_actions & dash_routing_actions_t.ENCAP_U1 != 0) {
             meta.dst_ip_addr = (bit<128>)hdr.u1_ipv4.dst_addr;
         }


### PR DESCRIPTION
The key of underlay routing lookup is meta.dst_ip_addr. It should be updated to underlay destination IP only if underlay1/0 encapsulation is taken.