### PR TITLE
Add tunnel type control between VM and SmartSwitch

### DIFF
--- a/dash-pipeline/SAI/specs/dash_eni.yaml
+++ b/dash-pipeline/SAI/specs/dash_eni.yaml
@@ -639,6 +639,19 @@ sai_apis:
     valid_only: null
     is_vlan: false
     deprecated: false
+  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
+    name: SAI_ENI_ATTR_INBOUND_DASH_ENCAPSULATION
+    description: Action parameter inbound DASH encapsulation
+    type: sai_dash_encapsulation_t
+    attr_value_field: s32
+    default: SAI_DASH_ENCAPSULATION_VXLAN
+    isresourcetype: false
+    flags: CREATE_AND_SET
+    object_name: null
+    allow_null: false
+    valid_only: null
+    is_vlan: false
+    deprecated: false
   stats:
   - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
     name: SAI_ENI_STAT_RX_BYTES
@@ -1923,5 +1936,11 @@ sai_apis:
               id: 42
               field: booldata
               bitwidth: 1
+              ip_is_v6_field_id: 0
+              skipattr: null
+            SAI_ENI_ATTR_INBOUND_DASH_ENCAPSULATION: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaActionParam
+              id: 43
+              field: s32
+              bitwidth: 16
               ip_is_v6_field_id: 0
               skipattr: null

--- a/dash-pipeline/bmv2/dash_inbound.p4
+++ b/dash-pipeline/bmv2/dash_inbound.p4
@@ -44,7 +44,7 @@ control inbound(inout headers_t hdr,
                      meta.u0_encap_data.underlay_smac,
                      meta.u0_encap_data.underlay_dip,
                      meta.u0_encap_data.underlay_sip,
-                     dash_encapsulation_t.VXLAN,
+                     meta.eni_data.inbound_dash_encapsulation,
                      meta.u0_encap_data.vni);
     }
 }

--- a/dash-pipeline/bmv2/dash_metadata.p4
+++ b/dash-pipeline/bmv2/dash_metadata.p4
@@ -64,6 +64,7 @@ struct eni_data_t {
     dash_tunnel_dscp_mode_t dscp_mode;
     outbound_routing_group_data_t outbound_routing_group_data;
     IPv4Address vip;
+    dash_encapsulation_t inbound_dash_encapsulation;
 }
 
 struct meter_context_t {

--- a/dash-pipeline/bmv2/dash_parser.p4
+++ b/dash-pipeline/bmv2/dash_parser.p4
@@ -103,6 +103,7 @@ parser dash_parser(
         transition select(hd.u0_ipv6.next_header) {
             UDP_PROTO: parse_u0_udp;
             TCP_PROTO: parse_u0_tcp;
+            NVGRE_PROTO: parse_u0_nvgre;
             default: accept;
         }
     }
@@ -122,6 +123,11 @@ parser dash_parser(
 
     state parse_u0_vxlan {
         packet.extract(hd.u0_vxlan);
+        transition parse_customer_ethernet;
+    }
+
+    state parse_u0_nvgre {
+        packet.extract(hd.u0_nvgre);
         transition parse_customer_ethernet;
     }
 


### PR DESCRIPTION
Allow choosing between different encapsulation
types for the tunnel used in inbound direction.