### PR TITLE
[ci] Use actions/upload-artifact v4 in workflow dash-bmv2-ci

### DIFF
--- a/.github/workflows/dash-bmv2-ci.yml
+++ b/.github/workflows/dash-bmv2-ci.yml
@@ -100,7 +100,7 @@ jobs:
       run:  DOCKER_FLAGS=$docker_fg_root_flags make run-saichallenger-tests
     - name: Build libsai debian packages
       run:  DOCKER_FLAGS=$docker_fg_root_flags make libsai-debs
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: libsai-debian-packages
         path: /home/runner/work/DASH/DASH/dash-pipeline/SAI/debian/*deb


### PR DESCRIPTION
While raising PRs, workflow dash-bmv2-ci will fail during job setup with the following error:

Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/, that says:

> Starting January 30th, 2025, GitHub Actions customers will no longer be able to use v3 of [actions/upload-artifact](https://github.com/actions/upload-artifact) or [actions/download-artifact](https://github.com/actions/download-artifact). Customers should update workflows to begin using [v4 of the artifact actions](https://github.blog/2024-02-12-get-started-with-v4-of-github-actions-artifacts/) as soon as possible.