### PR TITLE
[dash-p4] Add flow_table_id attribute on ENI

### DIFF
--- a/dash-pipeline/SAI/specs/dash_eni.yaml
+++ b/dash-pipeline/SAI/specs/dash_eni.yaml
@@ -639,6 +639,19 @@ sai_apis:
     valid_only: null
     is_vlan: false
     deprecated: false
+  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
+    name: SAI_ENI_ATTR_FLOW_TABLE_ID
+    description: Action parameter flow table id
+    type: sai_object_id_t
+    attr_value_field: u16
+    default: SAI_NULL_OBJECT_ID
+    isresourcetype: false
+    flags: CREATE_AND_SET
+    object_name: SAI_OBJECT_TYPE_FLOW_TABLE
+    allow_null: true
+    valid_only: null
+    is_vlan: false
+    deprecated: false
   stats:
   - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
     name: SAI_ENI_STAT_RX_BYTES
@@ -1923,5 +1936,11 @@ sai_apis:
               id: 42
               field: booldata
               bitwidth: 1
+              ip_is_v6_field_id: 0
+              skipattr: null
+            SAI_ENI_ATTR_FLOW_TABLE_ID: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaActionParam
+              id: 43
+              field: u16
+              bitwidth: 16
               ip_is_v6_field_id: 0
               skipattr: null

--- a/dash-pipeline/bmv2/dash_pipeline.p4
+++ b/dash-pipeline/bmv2/dash_pipeline.p4
@@ -66,7 +66,8 @@ control dash_eni_stage(
                          @SaiVal[type="sai_object_id_t"] bit<16> outbound_routing_group_id,
                          bit<1> enable_reverse_tunnel_learning,
                          @SaiVal[type="sai_ip_address_t"] IPv4Address reverse_tunnel_sip,
-                         bit<1> is_ha_flow_owner)
+                         bit<1> is_ha_flow_owner,
+                         @SaiVal[type="sai_object_id_t"] bit<16> flow_table_id)
     {
         meta.eni_data.cps                                                   = cps;
         meta.eni_data.pps                                                   = pps;
@@ -112,6 +113,8 @@ control dash_eni_stage(
 
         meta.ha.ha_scope_id = ha_scope_id;
         meta.fast_path_icmp_flow_redirection_disabled = disable_fast_path_icmp_flow_redirection;
+
+        meta.flow_table.id = flow_table_id;
     }
 
     @SaiTable[name = "eni", api = "dash_eni", order=1, isobject="true"]

--- a/test/test-cases/functional/ptf/saidashdpapp_sanity.py
+++ b/test/test-cases/functional/ptf/saidashdpapp_sanity.py
@@ -117,6 +117,19 @@ class SaiThriftDpappPktTest(SaiHelperSimplified):
                                          max_resimulated_flow_per_second=0,
                                          outbound_routing_group_id=self.outbound_routing_group)
 
+        self.flow_table = sai_thrift_create_flow_table(self.client,
+                    max_flow_count=128,
+                    dash_flow_enabled_key = SAI_DASH_FLOW_ENABLED_KEY_ENI_MAC
+                                           |SAI_DASH_FLOW_ENABLED_KEY_VNI
+                                           |SAI_DASH_FLOW_ENABLED_KEY_PROTOCOL
+                                           |SAI_DASH_FLOW_ENABLED_KEY_SRC_IP
+                                           |SAI_DASH_FLOW_ENABLED_KEY_DST_IP
+                                           |SAI_DASH_FLOW_ENABLED_KEY_SRC_PORT
+                                           |SAI_DASH_FLOW_ENABLED_KEY_DST_PORT,
+                    flow_ttl_in_milliseconds=5000)
+        assert (self.flow_table != SAI_NULL_OBJECT_ID)
+        sai_thrift_set_eni_attribute(self.client, eni_oid = self.eni, flow_table_id=self.flow_table)
+
         self.eam = sai_thrift_eni_ether_address_map_entry_t(switch_id=self.switch_id, address = self.eni_mac)
         status = sai_thrift_create_eni_ether_address_map_entry(self.client,
                                                                eni_ether_address_map_entry=self.eam,


### PR DESCRIPTION
By adding `flow_table_id` attribute on ENI object, ENI can be associated with a specific flow table 

