### PR TITLE
[dash-p4] Add flow idle timeout support in behavior model

### DIFF
--- a/dash-pipeline/bmv2/dash_headers.p4
+++ b/dash-pipeline/bmv2/dash_headers.p4
@@ -241,7 +241,7 @@ header flow_data_t {
     bit<32> version;
     dash_flow_action_t actions;
     dash_meter_class_t meter_class;
-    bit<32> idle_timeout;
+    bit<32> idle_timeout_in_ms;
 }
 const bit<16> FLOW_DATA_HDR_SIZE=flow_data_t.minSizeInBytes();
 

--- a/dash-pipeline/bmv2/dash_headers.p4
+++ b/dash-pipeline/bmv2/dash_headers.p4
@@ -241,6 +241,7 @@ header flow_data_t {
     bit<32> version;
     dash_flow_action_t actions;
     dash_meter_class_t meter_class;
+    bit<32> idle_timeout;
 }
 const bit<16> FLOW_DATA_HDR_SIZE=flow_data_t.minSizeInBytes();
 

--- a/dash-pipeline/bmv2/dash_metadata.p4
+++ b/dash-pipeline/bmv2/dash_metadata.p4
@@ -139,6 +139,7 @@ struct meta_flow_data_t {
     bit<32> version;
     dash_flow_action_t actions;
     dash_meter_class_t meter_class;
+    bit<32> idle_timeout;
 }
 struct meta_encap_data_t {
     bit<24> vni;

--- a/dash-pipeline/bmv2/dash_metadata.p4
+++ b/dash-pipeline/bmv2/dash_metadata.p4
@@ -139,7 +139,7 @@ struct meta_flow_data_t {
     bit<32> version;
     dash_flow_action_t actions;
     dash_meter_class_t meter_class;
-    bit<32> idle_timeout;
+    bit<32> idle_timeout_in_ms;
 }
 struct meta_encap_data_t {
     bit<24> vni;

--- a/dash-pipeline/bmv2/stages/conntrack_lookup.p4
+++ b/dash-pipeline/bmv2/stages/conntrack_lookup.p4
@@ -71,6 +71,7 @@ control conntrack_build_dash_header(inout headers_t hdr, in metadata_t meta,
         hdr.flow_data.direction = meta.direction;
         hdr.flow_data.actions = (dash_flow_action_t)meta.routing_actions;
         hdr.flow_data.meter_class = meta.meter_class;
+        hdr.flow_data.idle_timeout = meta.flow_data.idle_timeout;
         length = length + FLOW_DATA_HDR_SIZE;
 
         if (meta.routing_actions & dash_routing_actions_t.ENCAP_U0 != 0) {
@@ -386,48 +387,56 @@ control conntrack_lookup_stage(inout headers_t hdr, inout metadata_t meta) {
         }
     }
 
-    action set_flow_key()
+    action set_flow_key(bit<16> flow_enabled_key)
     {
         hdr.flow_key.setValid();
         hdr.flow_key.is_ip_v6 = meta.is_overlay_ip_v6;
-        // TODO remove hardcode flow_enabled_key later
-        meta.flow_table.flow_enabled_key = dash_flow_enabled_key_t.ENI_MAC |
-                                           dash_flow_enabled_key_t.VNI |
-                                           dash_flow_enabled_key_t.PROTOCOL |
-                                           dash_flow_enabled_key_t.SRC_IP |
-                                           dash_flow_enabled_key_t.DST_IP |
-                                           dash_flow_enabled_key_t.SRC_PORT |
-                                           dash_flow_enabled_key_t.DST_PORT;
 
-        if (meta.flow_table.flow_enabled_key & dash_flow_enabled_key_t.ENI_MAC != 0) {
+        if (flow_enabled_key & dash_flow_enabled_key_t.ENI_MAC != 0) {
             hdr.flow_key.eni_mac = meta.eni_addr;
         }
-        if (meta.flow_table.flow_enabled_key & dash_flow_enabled_key_t.VNI != 0) {
+        if (flow_enabled_key & dash_flow_enabled_key_t.VNI != 0) {
             hdr.flow_key.vnet_id = meta.vnet_id;
         }
-        if (meta.flow_table.flow_enabled_key & dash_flow_enabled_key_t.PROTOCOL != 0) {
+        if (flow_enabled_key & dash_flow_enabled_key_t.PROTOCOL != 0) {
             hdr.flow_key.ip_proto = meta.ip_protocol;
         }
-        if (meta.flow_table.flow_enabled_key & dash_flow_enabled_key_t.SRC_IP != 0) {
+        if (flow_enabled_key & dash_flow_enabled_key_t.SRC_IP != 0) {
             hdr.flow_key.src_ip = meta.src_ip_addr;
         }
-        if (meta.flow_table.flow_enabled_key & dash_flow_enabled_key_t.DST_IP != 0) {
+        if (flow_enabled_key & dash_flow_enabled_key_t.DST_IP != 0) {
             hdr.flow_key.dst_ip = meta.dst_ip_addr;
         }
 
-        if (meta.flow_table.flow_enabled_key & dash_flow_enabled_key_t.SRC_PORT != 0) {
+        if (flow_enabled_key & dash_flow_enabled_key_t.SRC_PORT != 0) {
             hdr.flow_key.src_port = meta.src_l4_port;
         }
 
-        if (meta.flow_table.flow_enabled_key & dash_flow_enabled_key_t.DST_PORT != 0) {
+        if (flow_enabled_key & dash_flow_enabled_key_t.DST_PORT != 0) {
             hdr.flow_key.dst_port = meta.dst_l4_port;
         }
     }
 
     apply {
         if (!hdr.flow_key.isValid()) {
-            flow_table.apply();
-            set_flow_key();
+            bit<16> flow_enabled_key;
+
+            if (flow_table.apply().hit) {
+                meta.flow_data.idle_timeout = meta.flow_table.flow_ttl_in_milliseconds;
+                flow_enabled_key = meta.flow_table.flow_enabled_key;
+            }
+            else {
+                // Enable all keys by default
+                flow_enabled_key = dash_flow_enabled_key_t.ENI_MAC |
+                                   dash_flow_enabled_key_t.VNI |
+                                   dash_flow_enabled_key_t.PROTOCOL |
+                                   dash_flow_enabled_key_t.SRC_IP |
+                                   dash_flow_enabled_key_t.DST_IP |
+                                   dash_flow_enabled_key_t.SRC_PORT |
+                                   dash_flow_enabled_key_t.DST_PORT;
+            }
+
+            set_flow_key(flow_enabled_key);
         }
 
         flow_entry.apply();

--- a/dash-pipeline/bmv2/stages/conntrack_lookup.p4
+++ b/dash-pipeline/bmv2/stages/conntrack_lookup.p4
@@ -71,7 +71,7 @@ control conntrack_build_dash_header(inout headers_t hdr, in metadata_t meta,
         hdr.flow_data.direction = meta.direction;
         hdr.flow_data.actions = (dash_flow_action_t)meta.routing_actions;
         hdr.flow_data.meter_class = meta.meter_class;
-        hdr.flow_data.idle_timeout = meta.flow_data.idle_timeout;
+        hdr.flow_data.idle_timeout_in_ms = meta.flow_data.idle_timeout_in_ms;
         length = length + FLOW_DATA_HDR_SIZE;
 
         if (meta.routing_actions & dash_routing_actions_t.ENCAP_U0 != 0) {
@@ -422,7 +422,7 @@ control conntrack_lookup_stage(inout headers_t hdr, inout metadata_t meta) {
             bit<16> flow_enabled_key;
 
             if (flow_table.apply().hit) {
-                meta.flow_data.idle_timeout = meta.flow_table.flow_ttl_in_milliseconds;
+                meta.flow_data.idle_timeout_in_ms = meta.flow_table.flow_ttl_in_milliseconds;
                 flow_enabled_key = meta.flow_table.flow_enabled_key;
             }
             else {

--- a/dash-pipeline/dpapp/dash/flow.c
+++ b/dash-pipeline/dpapp/dash/flow.c
@@ -65,8 +65,8 @@ dash_flow_create (dash_flow_table_t *flow_table, const dash_header_t *dh)
 
     clib_memcpy_fast(&flow->flow_data, &dh->flow_data, sizeof(dh->flow_data));
 
-    if (flow->flow_data.idle_timeout != 0) {
-        flow->timeout = ntohl(flow->flow_data.idle_timeout)/1000;
+    if (flow->flow_data.idle_timeout_in_ms != 0) {
+        flow->timeout = ntohl(flow->flow_data.idle_timeout_in_ms)/1000;
         if (flow->timeout > DASH_FLOW_MAX_TIMEOUT) {
             flow->timeout = DASH_FLOW_MAX_TIMEOUT;
         }

--- a/dash-pipeline/dpapp/dash/flow.c
+++ b/dash-pipeline/dpapp/dash/flow.c
@@ -65,6 +65,13 @@ dash_flow_create (dash_flow_table_t *flow_table, const dash_header_t *dh)
 
     clib_memcpy_fast(&flow->flow_data, &dh->flow_data, sizeof(dh->flow_data));
 
+    if (flow->flow_data.idle_timeout != 0) {
+        flow->timeout = ntohl(flow->flow_data.idle_timeout)/1000;
+        if (flow->timeout > DASH_FLOW_MAX_TIMEOUT) {
+            flow->timeout = DASH_FLOW_MAX_TIMEOUT;
+        }
+    }
+
     /* FIXME
      * Assume overlay_data, u0_encap_data, u1_encap_data in order if exists
      * Need to add their offset in generic.
@@ -209,7 +216,7 @@ dash_flow_table_init (dash_flow_table_t *flow_table)
 
     TW (tw_timer_wheel_init) (&flow_table->flow_tw,
                               dash_flow_expired_timer_callback,
-                              1.0 /* timer interval */, 1024);
+                              1.0 /* timer interval */, DASH_FLOW_MAX_TIMEOUT);
 }
 
 int

--- a/dash-pipeline/dpapp/dash/flow.h
+++ b/dash-pipeline/dpapp/dash/flow.h
@@ -12,7 +12,7 @@
 /* Default timeout in seconds */
 #define DASH_FLOW_TIMEOUT   30
 /* Max timeout in seconds */
-#define DASH_FLOW_MAX_TIMEOUT   1024
+#define DASH_FLOW_MAX_TIMEOUT   1800
 
 typedef enum _dash_packet_source_t {
     EXTERNAL = 0,           // Packets from external sources.
@@ -91,7 +91,7 @@ typedef struct flow_data {
     u32 version;
     u32 actions;
     u32 meter_class;
-    u32 idle_timeout;
+    u32 idle_timeout_in_ms;
 } __clib_packed flow_data_t;
 
 typedef struct encap_data {

--- a/dash-pipeline/dpapp/dash/flow.h
+++ b/dash-pipeline/dpapp/dash/flow.h
@@ -11,6 +11,8 @@
 
 /* Default timeout in seconds */
 #define DASH_FLOW_TIMEOUT   30
+/* Max timeout in seconds */
+#define DASH_FLOW_MAX_TIMEOUT   1024
 
 typedef enum _dash_packet_source_t {
     EXTERNAL = 0,           // Packets from external sources.
@@ -89,6 +91,7 @@ typedef struct flow_data {
     u32 version;
     u32 actions;
     u32 meter_class;
+    u32 idle_timeout;
 } __clib_packed flow_data_t;
 
 typedef struct encap_data {


### PR DESCRIPTION
Support customized flow idle timeout in flow creation. The value can be propagated from `flow_ttl_in_milliseconds` attribute of the flow table. Also update flow entry key selection from `flow_enabled_key` attribute of the flow table.