### PR TITLE
Add single_match_priority in SaiTable annotation

### DIFF
--- a/dash-pipeline/SAI/specs/dash_acl.yaml
+++ b/dash-pipeline/SAI/specs/dash_acl.yaml
@@ -28,6 +28,7 @@ sai_apis:
     tables:
     - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
       id: 37949057
+      single_match_priority: false
       stage: null
       keys:
       - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaKey
@@ -211,6 +212,7 @@ sai_apis:
     tables:
     - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
       id: 43936368
+      single_match_priority: false
       stage: acl.stage1
       keys:
       - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaKey
@@ -280,6 +282,7 @@ sai_apis:
           attr_params: {}
     - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
       id: 48549629
+      single_match_priority: false
       stage: acl.stage2
       keys:
       - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaKey
@@ -349,6 +352,7 @@ sai_apis:
           attr_params: {}
     - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
       id: 40869404
+      single_match_priority: false
       stage: acl.stage3
       keys:
       - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaKey
@@ -418,6 +422,7 @@ sai_apis:
           attr_params: {}
     - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
       id: 49672642
+      single_match_priority: false
       stage: acl.stage1
       keys:
       - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaKey
@@ -487,6 +492,7 @@ sai_apis:
           attr_params: {}
     - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
       id: 37932124
+      single_match_priority: false
       stage: acl.stage2
       keys:
       - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaKey
@@ -556,6 +562,7 @@ sai_apis:
           attr_params: {}
     - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
       id: 46113118
+      single_match_priority: false
       stage: acl.stage3
       keys:
       - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaKey

--- a/dash-pipeline/SAI/specs/dash_appliance.yaml
+++ b/dash-pipeline/SAI/specs/dash_appliance.yaml
@@ -28,6 +28,7 @@ sai_apis:
     tables:
     - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
       id: 45177948
+      single_match_priority: false
       stage: null
       keys:
       - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaKey

--- a/dash-pipeline/SAI/specs/dash_direction_lookup.yaml
+++ b/dash-pipeline/SAI/specs/dash_direction_lookup.yaml
@@ -65,6 +65,7 @@ sai_apis:
     tables:
     - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
       id: 49875338
+      single_match_priority: false
       stage: null
       keys:
       - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaKey

--- a/dash-pipeline/SAI/specs/dash_eni.yaml
+++ b/dash-pipeline/SAI/specs/dash_eni.yaml
@@ -65,6 +65,7 @@ sai_apis:
     tables:
     - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
       id: 39883185
+      single_match_priority: false
       stage: null
       keys:
       - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaKey
@@ -1671,6 +1672,7 @@ sai_apis:
     tables:
     - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
       id: 38483381
+      single_match_priority: false
       stage: null
       keys:
       - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaKey

--- a/dash-pipeline/SAI/specs/dash_flow.yaml
+++ b/dash-pipeline/SAI/specs/dash_flow.yaml
@@ -54,6 +54,7 @@ sai_apis:
     tables:
     - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
       id: 38557285
+      single_match_priority: false
       stage: null
       keys:
       - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaKey
@@ -601,6 +602,7 @@ sai_apis:
     tables:
     - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
       id: 49035675
+      single_match_priority: false
       stage: null
       keys:
       - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaKey
@@ -933,6 +935,7 @@ sai_apis:
     tables:
     - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
       id: 38861669
+      single_match_priority: false
       stage: null
       keys:
       - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaKey
@@ -1107,6 +1110,7 @@ sai_apis:
     tables:
     - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
       id: 38230977
+      single_match_priority: false
       stage: null
       keys:
       - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaKey

--- a/dash-pipeline/SAI/specs/dash_ha.yaml
+++ b/dash-pipeline/SAI/specs/dash_ha.yaml
@@ -405,6 +405,7 @@ sai_apis:
     tables:
     - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
       id: 45319666
+      single_match_priority: false
       stage: null
       keys:
       - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaKey
@@ -622,6 +623,7 @@ sai_apis:
     tables:
     - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
       id: 49681752
+      single_match_priority: false
       stage: null
       keys:
       - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaKey

--- a/dash-pipeline/SAI/specs/dash_inbound_routing.yaml
+++ b/dash-pipeline/SAI/specs/dash_inbound_routing.yaml
@@ -142,6 +142,7 @@ sai_apis:
     tables:
     - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
       id: 35881437
+      single_match_priority: false
       stage: null
       keys:
       - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaKey

--- a/dash-pipeline/SAI/specs/dash_meter.yaml
+++ b/dash-pipeline/SAI/specs/dash_meter.yaml
@@ -84,6 +84,7 @@ sai_apis:
     tables:
     - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
       id: 45482818
+      single_match_priority: false
       stage: null
       keys:
       - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaKey
@@ -132,6 +133,7 @@ sai_apis:
     tables:
     - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
       id: 40733610
+      single_match_priority: false
       stage: null
       keys:
       - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaKey
@@ -243,6 +245,7 @@ sai_apis:
     tables:
     - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
       id: 44484556
+      single_match_priority: false
       stage: null
       keys:
       - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaKey

--- a/dash-pipeline/SAI/specs/dash_outbound_ca_to_pa.yaml
+++ b/dash-pipeline/SAI/specs/dash_outbound_ca_to_pa.yaml
@@ -262,6 +262,7 @@ sai_apis:
     tables:
     - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
       id: 48765007
+      single_match_priority: false
       stage: null
       keys:
       - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaKey

--- a/dash-pipeline/SAI/specs/dash_outbound_routing.yaml
+++ b/dash-pipeline/SAI/specs/dash_outbound_routing.yaml
@@ -295,6 +295,7 @@ sai_apis:
     tables:
     - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
       id: 38546097
+      single_match_priority: false
       stage: null
       keys:
       - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaKey
@@ -521,6 +522,7 @@ sai_apis:
     tables:
     - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
       id: 40572680
+      single_match_priority: false
       stage: null
       keys:
       - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaKey

--- a/dash-pipeline/SAI/specs/dash_pa_validation.yaml
+++ b/dash-pipeline/SAI/specs/dash_pa_validation.yaml
@@ -71,6 +71,7 @@ sai_apis:
     tables:
     - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
       id: 49415809
+      single_match_priority: false
       stage: null
       keys:
       - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaKey

--- a/dash-pipeline/SAI/specs/dash_tunnel.yaml
+++ b/dash-pipeline/SAI/specs/dash_tunnel.yaml
@@ -80,6 +80,7 @@ sai_apis:
     tables:
     - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
       id: 49206552
+      single_match_priority: false
       stage: null
       keys:
       - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaKey
@@ -163,6 +164,7 @@ sai_apis:
     tables:
     - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
       id: 41269458
+      single_match_priority: false
       stage: null
       keys:
       - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaKey
@@ -215,6 +217,7 @@ sai_apis:
     tables:
     - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
       id: 37329198
+      single_match_priority: false
       stage: null
       keys:
       - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaKey

--- a/dash-pipeline/SAI/specs/dash_vip.yaml
+++ b/dash-pipeline/SAI/specs/dash_vip.yaml
@@ -65,6 +65,7 @@ sai_apis:
     tables:
     - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
       id: 36083221
+      single_match_priority: false
       stage: null
       keys:
       - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaKey

--- a/dash-pipeline/SAI/specs/dash_vnet.yaml
+++ b/dash-pipeline/SAI/specs/dash_vnet.yaml
@@ -28,6 +28,7 @@ sai_apis:
     tables:
     - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
       id: 39583935
+      single_match_priority: false
       stage: null
       keys:
       - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaKey

--- a/dash-pipeline/SAI/specs/route.yaml
+++ b/dash-pipeline/SAI/specs/route.yaml
@@ -91,6 +91,7 @@ sai_apis:
     tables:
     - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
       id: 49279256
+      single_match_priority: false
       stage: null
       keys:
       - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaKey

--- a/dash-pipeline/SAI/src/p4meta.h
+++ b/dash-pipeline/SAI/src/p4meta.h
@@ -120,6 +120,12 @@ namespace dash
             _In_ const sai_attribute_value_t &value,
             _Inout_ p4::v1::FieldMatch_LPM *mf_lpm);
 
+    void  set_attr_value_to_p4(
+            _In_ const std::string &field,
+            _In_ uint32_t bitwidth,
+            _In_ const sai_attribute_value_t &value,
+            _Inout_ p4::v1::FieldMatch_Range *mf_range);
+
     template<typename T>
     static inline
     void get_attr_value_from_p4(
@@ -194,6 +200,12 @@ namespace dash
             _In_ const std::string &field,
             _In_ uint32_t bitwidth,
             _In_ const p4::v1::FieldMatch_LPM *mf_lpm,
+            _Out_ sai_attribute_value_t &value);
+
+    void get_attr_value_from_p4(
+            _In_ const std::string &field,
+            _In_ uint32_t bitwidth,
+            _In_ const p4::v1::FieldMatch_Range *mf_range,
             _Out_ sai_attribute_value_t &value);
 
     // set/get only for value.ipaddr.addr_family

--- a/dash-pipeline/SAI/src/utils.h
+++ b/dash-pipeline/SAI/src/utils.h
@@ -283,6 +283,29 @@ namespace dash
             }
 
         template<typename T>
+            void u32rangeSetVal(const sai_u32_range_t &range, T &t, int bits = 32)
+            {
+                assert(bits <= 32);
+
+                uint32_t val;
+                int bytes = (bits + 7) / 8;
+
+                val = htonl(range.min);
+                val = val >> (32 - bits);
+                t->set_low(&val, bytes);
+
+                val = htonl(range.max);
+                val = val >> (32 - bits);
+                t->set_high(&val, bytes);
+            }
+
+        template<typename T>
+            void u32rangeSetVal(const sai_attribute_value_t &value, T &t, int bits = 32)
+            {
+                u32rangeSetVal(value.u32range, t, bits);
+            }
+
+        template<typename T>
             void u8listSetVal(const sai_attribute_value_t &value, T &t, int bits = -1)
             {
                 t->set_value(value.u8list.list, value.u8list.count);

--- a/dash-pipeline/SAI/templates/impls/p4_table_entry_match.cpp.j2
+++ b/dash-pipeline/SAI/templates/impls/p4_table_entry_match.cpp.j2
@@ -9,6 +9,7 @@
         {% elif key.match_type == 'ternary' %}{{ util.set_key_ternary(key, value) }}
         {% elif key.match_type == 'optional' %}{{ util.set_key_optional(key, value) }}
         {% elif key.match_type == 'list' %}{{ util.set_key_list(key, value) }}
+        {% elif key.match_type == 'range' %}{{ util.set_key_range(table, key, value) }}
         {% elif key.match_type == 'range_list' %}{{ util.set_key_range_list(key, value) }}
         {% endif %}
     }

--- a/dash-pipeline/SAI/templates/impls/p4_table_util.cpp.j2
+++ b/dash-pipeline/SAI/templates/impls/p4_table_util.cpp.j2
@@ -61,6 +61,16 @@
     {%- endif %}
 {%- endmacro -%}
 
+{% macro set_key_range(table, key, value) %}
+        auto mf_range = mf->mutable_range();
+        {{key.field}}SetVal({{value}}, mf_range, {{key.bitwidth}});
+    {% if table.single_match_priority %}
+        matchActionEntry->set_priority(1); // set default priority
+    {%- else %}
+        matchActionEntry->set_priority(tableEntry->priority);
+    {%- endif %}
+{%- endmacro -%}
+
 {% macro set_key_range_list(key, value) %}
         // BMv2 doesn't support "range_list" match type, and we are using "optional" match in v1model as our implementation.
         // Hence, here we only take the first item from the list and program the range start as optional match.

--- a/dash-pipeline/SAI/utils/sai_spec/sai_api_p4_meta.py
+++ b/dash-pipeline/SAI/utils/sai_spec/sai_api_p4_meta.py
@@ -29,8 +29,9 @@ class SaiApiP4MetaKey:
         self.is_object_key: bool = is_object_key
 
 class SaiApiP4MetaTable:
-    def __init__(self, id: int, stage: Optional[str] = None):
+    def __init__(self, id: int, single_match_priority: bool, stage: Optional[str] = None):
         self.id: int = id
+        self.single_match_priority: bool = single_match_priority
         self.stage: Optional[str] = stage
         self.keys: List[SaiApiP4MetaKey] = []
         self.actions: Dict[str, SaiApiP4MetaAction] = {}


### PR DESCRIPTION
If at least one of the match fields is Optional, Ternary or Range, p4runtime v1 model requires 'priority' to be set for each table entry. But in some dash scenarios, 'priority' is not required and is not exposed to dash sai. For these special cases, we add a single_match_priority field in SaiTable annotation to mark it. If it is 'true', the behavior changes are: 

- Not generate attribute PRIORITY in SAI object
- Not generate field priority in SAI entry struct
- Set the priority of all table entries to a default (fixed) value 1 in dash p4 libsai

It also adds the set/get support of p4 match kind `range`.