### PR TITLE
[dash-p4] Add ENI mode and trusted vni stage

### DIFF
--- a/dash-pipeline/SAI/specs/dash_direction_lookup.yaml
+++ b/dash-pipeline/SAI/specs/dash_direction_lookup.yaml
@@ -16,6 +16,10 @@ sai_apis:
       name: SAI_DIRECTION_LOOKUP_ENTRY_ACTION_SET_OUTBOUND_DIRECTION
       description: ''
       value: '0'
+    - !!python/object:utils.sai_spec.sai_enum_member.SaiEnumMember
+      name: SAI_DIRECTION_LOOKUP_ENTRY_ACTION_SET_INBOUND_DIRECTION
+      description: ''
+      value: '1'
   structs:
   - !!python/object:utils.sai_spec.sai_struct.SaiStruct
     name: sai_direction_lookup_entry_t
@@ -57,7 +61,8 @@ sai_apis:
     flags: CREATE_AND_SET
     object_name: null
     allow_null: false
-    valid_only: null
+    valid_only: SAI_DIRECTION_LOOKUP_ENTRY_ATTR_ACTION == SAI_DIRECTION_LOOKUP_ENTRY_ACTION_SET_OUTBOUND_DIRECTION
+      or SAI_DIRECTION_LOOKUP_ENTRY_ATTR_ACTION == SAI_DIRECTION_LOOKUP_ENTRY_ACTION_SET_INBOUND_DIRECTION
     is_vlan: false
     deprecated: false
   stats: []
@@ -80,6 +85,16 @@ sai_apis:
         SAI_DIRECTION_LOOKUP_ENTRY_ACTION_SET_OUTBOUND_DIRECTION: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaAction
           name: SAI_DIRECTION_LOOKUP_ENTRY_ACTION_SET_OUTBOUND_DIRECTION
           id: 32588257
+          attr_params:
+            SAI_DIRECTION_LOOKUP_ENTRY_ATTR_DASH_ENI_MAC_OVERRIDE_TYPE: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaActionParam
+              id: 1
+              field: s32
+              bitwidth: 8
+              ip_is_v6_field_id: 0
+              skipattr: null
+        SAI_DIRECTION_LOOKUP_ENTRY_ACTION_SET_INBOUND_DIRECTION: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaAction
+          name: SAI_DIRECTION_LOOKUP_ENTRY_ACTION_SET_INBOUND_DIRECTION
+          id: 30583207
           attr_params:
             SAI_DIRECTION_LOOKUP_ENTRY_ATTR_DASH_ENI_MAC_OVERRIDE_TYPE: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaActionParam
               id: 1

--- a/dash-pipeline/SAI/specs/dash_eni.yaml
+++ b/dash-pipeline/SAI/specs/dash_eni.yaml
@@ -660,7 +660,7 @@ sai_apis:
     attr_value_field: s32
     default: SAI_DASH_ENI_MODE_VM
     isresourcetype: false
-    flags: CREATE_AND_SET
+    flags: CREATE_ONLY
     object_name: null
     allow_null: false
     valid_only: null

--- a/dash-pipeline/SAI/specs/dash_eni.yaml
+++ b/dash-pipeline/SAI/specs/dash_eni.yaml
@@ -1708,6 +1708,19 @@ sai_apis:
     valid_only: null
     is_vlan: false
     deprecated: false
+  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
+    name: SAI_ENI_STAT_ENI_TRUSTED_VNI_ENTRY_MISS_DROP_PACKETS
+    description: DASH ENI ENI_TRUSTED_VNI_ENTRY_MISS_DROP_PACKETS stat count
+    type: sai_uint64_t
+    attr_value_field: u64
+    default: null
+    isresourcetype: false
+    flags: READ_ONLY
+    object_name: null
+    allow_null: false
+    valid_only: null
+    is_vlan: false
+    deprecated: false
   p4_meta: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4Meta
     tables:
     - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable

--- a/dash-pipeline/SAI/specs/dash_eni.yaml
+++ b/dash-pipeline/SAI/specs/dash_eni.yaml
@@ -653,6 +653,19 @@ sai_apis:
     valid_only: null
     is_vlan: false
     deprecated: false
+  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
+    name: SAI_ENI_ATTR_DASH_ENI_MODE
+    description: Action parameter DASH ENI mode
+    type: sai_dash_eni_mode_t
+    attr_value_field: s32
+    default: SAI_DASH_ENI_MODE_VM
+    isresourcetype: false
+    flags: CREATE_AND_SET
+    object_name: null
+    allow_null: false
+    valid_only: null
+    is_vlan: false
+    deprecated: false
   stats:
   - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
     name: SAI_ENI_STAT_RX_BYTES
@@ -1971,5 +1984,11 @@ sai_apis:
               id: 43
               field: u16
               bitwidth: 16
+              ip_is_v6_field_id: 0
+              skipattr: null
+            SAI_ENI_ATTR_DASH_ENI_MODE: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaActionParam
+              id: 44
+              field: s32
+              bitwidth: 8
               ip_is_v6_field_id: 0
               skipattr: null

--- a/dash-pipeline/SAI/specs/dash_trusted_vni.yaml
+++ b/dash-pipeline/SAI/specs/dash_trusted_vni.yaml
@@ -4,6 +4,71 @@ description: DASH trusted VNI
 api_type: overlay
 sai_apis:
 - !!python/object:utils.sai_spec.sai_api.SaiApi
+  name: global_trusted_vni_entry
+  description: global trusted VNI entry
+  is_object: false
+  enums:
+  - !!python/object:utils.sai_spec.sai_enum.SaiEnum
+    name: sai_global_trusted_vni_entry_action_t
+    description: 'Attribute data for #SAI_GLOBAL_TRUSTED_VNI_ENTRY_ATTR_ACTION'
+    members:
+    - !!python/object:utils.sai_spec.sai_enum_member.SaiEnumMember
+      name: SAI_GLOBAL_TRUSTED_VNI_ENTRY_ACTION_PERMIT
+      description: ''
+      value: '0'
+  structs:
+  - !!python/object:utils.sai_spec.sai_struct.SaiStruct
+    name: sai_global_trusted_vni_entry_t
+    description: Entry for global_trusted_vni_entry
+    members:
+    - !!python/object:utils.sai_spec.sai_struct_entry.SaiStructEntry
+      name: switch_id
+      description: Switch ID
+      type: sai_object_id_t
+      objects: SAI_OBJECT_TYPE_SWITCH
+      valid_only: null
+    - !!python/object:utils.sai_spec.sai_struct_entry.SaiStructEntry
+      name: vni_range
+      description: Range matched key vni_range
+      type: sai_u32_range_t
+      objects: null
+      valid_only: null
+  attributes:
+  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
+    name: SAI_GLOBAL_TRUSTED_VNI_ENTRY_ATTR_ACTION
+    description: Action
+    type: sai_global_trusted_vni_entry_action_t
+    attr_value_field: null
+    default: SAI_GLOBAL_TRUSTED_VNI_ENTRY_ACTION_PERMIT
+    isresourcetype: false
+    flags: CREATE_AND_SET
+    object_name: null
+    allow_null: false
+    valid_only: null
+    is_vlan: false
+    deprecated: false
+  stats: []
+  p4_meta: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4Meta
+    tables:
+    - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
+      id: 45800410
+      single_match_priority: true
+      stage: null
+      keys:
+      - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaKey
+        name: vni_range
+        id: 1
+        match_type: range
+        field: u32range
+        bitwidth: 24
+        ip_is_v6_field_id: 0
+        is_object_key: false
+      actions:
+        SAI_GLOBAL_TRUSTED_VNI_ENTRY_ACTION_PERMIT: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaAction
+          name: SAI_GLOBAL_TRUSTED_VNI_ENTRY_ACTION_PERMIT
+          id: 29028174
+          attr_params: {}
+- !!python/object:utils.sai_spec.sai_api.SaiApi
   name: eni_trusted_vni_entry
   description: ENI trusted VNI entry
   is_object: false
@@ -80,70 +145,5 @@ sai_apis:
       actions:
         SAI_ENI_TRUSTED_VNI_ENTRY_ACTION_PERMIT: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaAction
           name: SAI_ENI_TRUSTED_VNI_ENTRY_ACTION_PERMIT
-          id: 29028174
-          attr_params: {}
-- !!python/object:utils.sai_spec.sai_api.SaiApi
-  name: global_trusted_vni_entry
-  description: global trusted VNI entry
-  is_object: false
-  enums:
-  - !!python/object:utils.sai_spec.sai_enum.SaiEnum
-    name: sai_global_trusted_vni_entry_action_t
-    description: 'Attribute data for #SAI_GLOBAL_TRUSTED_VNI_ENTRY_ATTR_ACTION'
-    members:
-    - !!python/object:utils.sai_spec.sai_enum_member.SaiEnumMember
-      name: SAI_GLOBAL_TRUSTED_VNI_ENTRY_ACTION_PERMIT
-      description: ''
-      value: '0'
-  structs:
-  - !!python/object:utils.sai_spec.sai_struct.SaiStruct
-    name: sai_global_trusted_vni_entry_t
-    description: Entry for global_trusted_vni_entry
-    members:
-    - !!python/object:utils.sai_spec.sai_struct_entry.SaiStructEntry
-      name: switch_id
-      description: Switch ID
-      type: sai_object_id_t
-      objects: SAI_OBJECT_TYPE_SWITCH
-      valid_only: null
-    - !!python/object:utils.sai_spec.sai_struct_entry.SaiStructEntry
-      name: vni_range
-      description: Range matched key vni_range
-      type: sai_u32_range_t
-      objects: null
-      valid_only: null
-  attributes:
-  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
-    name: SAI_GLOBAL_TRUSTED_VNI_ENTRY_ATTR_ACTION
-    description: Action
-    type: sai_global_trusted_vni_entry_action_t
-    attr_value_field: null
-    default: SAI_GLOBAL_TRUSTED_VNI_ENTRY_ACTION_PERMIT
-    isresourcetype: false
-    flags: CREATE_AND_SET
-    object_name: null
-    allow_null: false
-    valid_only: null
-    is_vlan: false
-    deprecated: false
-  stats: []
-  p4_meta: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4Meta
-    tables:
-    - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
-      id: 45800410
-      single_match_priority: true
-      stage: null
-      keys:
-      - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaKey
-        name: vni_range
-        id: 1
-        match_type: range
-        field: u32range
-        bitwidth: 24
-        ip_is_v6_field_id: 0
-        is_object_key: false
-      actions:
-        SAI_GLOBAL_TRUSTED_VNI_ENTRY_ACTION_PERMIT: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaAction
-          name: SAI_GLOBAL_TRUSTED_VNI_ENTRY_ACTION_PERMIT
           id: 29028174
           attr_params: {}

--- a/dash-pipeline/SAI/specs/dash_trusted_vni.yaml
+++ b/dash-pipeline/SAI/specs/dash_trusted_vni.yaml
@@ -4,22 +4,22 @@ description: DASH trusted VNI
 api_type: overlay
 sai_apis:
 - !!python/object:utils.sai_spec.sai_api.SaiApi
-  name: trusted_vni_entry
-  description: trusted VNI entry
+  name: eni_trusted_vni_entry
+  description: ENI trusted VNI entry
   is_object: false
   enums:
   - !!python/object:utils.sai_spec.sai_enum.SaiEnum
-    name: sai_trusted_vni_entry_action_t
-    description: 'Attribute data for #SAI_TRUSTED_VNI_ENTRY_ATTR_ACTION'
+    name: sai_eni_trusted_vni_entry_action_t
+    description: 'Attribute data for #SAI_ENI_TRUSTED_VNI_ENTRY_ATTR_ACTION'
     members:
     - !!python/object:utils.sai_spec.sai_enum_member.SaiEnumMember
-      name: SAI_TRUSTED_VNI_ENTRY_ACTION_PERMIT
+      name: SAI_ENI_TRUSTED_VNI_ENTRY_ACTION_PERMIT
       description: ''
       value: '0'
   structs:
   - !!python/object:utils.sai_spec.sai_struct.SaiStruct
-    name: sai_trusted_vni_entry_t
-    description: Entry for trusted_vni_entry
+    name: sai_eni_trusted_vni_entry_t
+    description: Entry for eni_trusted_vni_entry
     members:
     - !!python/object:utils.sai_spec.sai_struct_entry.SaiStructEntry
       name: switch_id
@@ -41,11 +41,11 @@ sai_apis:
       valid_only: null
   attributes:
   - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
-    name: SAI_TRUSTED_VNI_ENTRY_ATTR_ACTION
+    name: SAI_ENI_TRUSTED_VNI_ENTRY_ATTR_ACTION
     description: Action
-    type: sai_trusted_vni_entry_action_t
+    type: sai_eni_trusted_vni_entry_action_t
     attr_value_field: null
-    default: SAI_TRUSTED_VNI_ENTRY_ACTION_PERMIT
+    default: SAI_ENI_TRUSTED_VNI_ENTRY_ACTION_PERMIT
     isresourcetype: false
     flags: CREATE_AND_SET
     object_name: null
@@ -57,7 +57,7 @@ sai_apis:
   p4_meta: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4Meta
     tables:
     - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
-      id: 49370429
+      id: 49840895
       single_match_priority: true
       stage: null
       keys:
@@ -78,8 +78,8 @@ sai_apis:
         ip_is_v6_field_id: 0
         is_object_key: false
       actions:
-        SAI_TRUSTED_VNI_ENTRY_ACTION_PERMIT: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaAction
-          name: SAI_TRUSTED_VNI_ENTRY_ACTION_PERMIT
+        SAI_ENI_TRUSTED_VNI_ENTRY_ACTION_PERMIT: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaAction
+          name: SAI_ENI_TRUSTED_VNI_ENTRY_ACTION_PERMIT
           id: 29028174
           attr_params: {}
 - !!python/object:utils.sai_spec.sai_api.SaiApi

--- a/dash-pipeline/SAI/specs/dash_trusted_vni.yaml
+++ b/dash-pipeline/SAI/specs/dash_trusted_vni.yaml
@@ -57,7 +57,7 @@ sai_apis:
   p4_meta: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4Meta
     tables:
     - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
-      id: 38326132
+      id: 49370429
       single_match_priority: true
       stage: null
       keys:
@@ -80,5 +80,70 @@ sai_apis:
       actions:
         SAI_TRUSTED_VNI_ENTRY_ACTION_PERMIT: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaAction
           name: SAI_TRUSTED_VNI_ENTRY_ACTION_PERMIT
-          id: 24633826
+          id: 29028174
+          attr_params: {}
+- !!python/object:utils.sai_spec.sai_api.SaiApi
+  name: global_trusted_vni_entry
+  description: global trusted VNI entry
+  is_object: false
+  enums:
+  - !!python/object:utils.sai_spec.sai_enum.SaiEnum
+    name: sai_global_trusted_vni_entry_action_t
+    description: 'Attribute data for #SAI_GLOBAL_TRUSTED_VNI_ENTRY_ATTR_ACTION'
+    members:
+    - !!python/object:utils.sai_spec.sai_enum_member.SaiEnumMember
+      name: SAI_GLOBAL_TRUSTED_VNI_ENTRY_ACTION_PERMIT
+      description: ''
+      value: '0'
+  structs:
+  - !!python/object:utils.sai_spec.sai_struct.SaiStruct
+    name: sai_global_trusted_vni_entry_t
+    description: Entry for global_trusted_vni_entry
+    members:
+    - !!python/object:utils.sai_spec.sai_struct_entry.SaiStructEntry
+      name: switch_id
+      description: Switch ID
+      type: sai_object_id_t
+      objects: SAI_OBJECT_TYPE_SWITCH
+      valid_only: null
+    - !!python/object:utils.sai_spec.sai_struct_entry.SaiStructEntry
+      name: vni_range
+      description: Range matched key vni_range
+      type: sai_u32_range_t
+      objects: null
+      valid_only: null
+  attributes:
+  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
+    name: SAI_GLOBAL_TRUSTED_VNI_ENTRY_ATTR_ACTION
+    description: Action
+    type: sai_global_trusted_vni_entry_action_t
+    attr_value_field: null
+    default: SAI_GLOBAL_TRUSTED_VNI_ENTRY_ACTION_PERMIT
+    isresourcetype: false
+    flags: CREATE_AND_SET
+    object_name: null
+    allow_null: false
+    valid_only: null
+    is_vlan: false
+    deprecated: false
+  stats: []
+  p4_meta: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4Meta
+    tables:
+    - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
+      id: 45800410
+      single_match_priority: true
+      stage: null
+      keys:
+      - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaKey
+        name: vni_range
+        id: 1
+        match_type: range
+        field: u32range
+        bitwidth: 24
+        ip_is_v6_field_id: 0
+        is_object_key: false
+      actions:
+        SAI_GLOBAL_TRUSTED_VNI_ENTRY_ACTION_PERMIT: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaAction
+          name: SAI_GLOBAL_TRUSTED_VNI_ENTRY_ACTION_PERMIT
+          id: 29028174
           attr_params: {}

--- a/dash-pipeline/SAI/specs/dash_trusted_vni.yaml
+++ b/dash-pipeline/SAI/specs/dash_trusted_vni.yaml
@@ -1,0 +1,84 @@
+!!python/object:utils.sai_spec.sai_api_group.SaiApiGroup
+name: dash_trusted_vni
+description: DASH trusted VNI
+api_type: overlay
+sai_apis:
+- !!python/object:utils.sai_spec.sai_api.SaiApi
+  name: trusted_vni_entry
+  description: trusted VNI entry
+  is_object: false
+  enums:
+  - !!python/object:utils.sai_spec.sai_enum.SaiEnum
+    name: sai_trusted_vni_entry_action_t
+    description: 'Attribute data for #SAI_TRUSTED_VNI_ENTRY_ATTR_ACTION'
+    members:
+    - !!python/object:utils.sai_spec.sai_enum_member.SaiEnumMember
+      name: SAI_TRUSTED_VNI_ENTRY_ACTION_PERMIT
+      description: ''
+      value: '0'
+  structs:
+  - !!python/object:utils.sai_spec.sai_struct.SaiStruct
+    name: sai_trusted_vni_entry_t
+    description: Entry for trusted_vni_entry
+    members:
+    - !!python/object:utils.sai_spec.sai_struct_entry.SaiStructEntry
+      name: switch_id
+      description: Switch ID
+      type: sai_object_id_t
+      objects: SAI_OBJECT_TYPE_SWITCH
+      valid_only: null
+    - !!python/object:utils.sai_spec.sai_struct_entry.SaiStructEntry
+      name: eni_id
+      description: Exact matched key eni_id
+      type: sai_object_id_t
+      objects: SAI_OBJECT_TYPE_ENI
+      valid_only: null
+    - !!python/object:utils.sai_spec.sai_struct_entry.SaiStructEntry
+      name: vni_range
+      description: Range matched key vni_range
+      type: sai_u32_range_t
+      objects: null
+      valid_only: null
+  attributes:
+  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
+    name: SAI_TRUSTED_VNI_ENTRY_ATTR_ACTION
+    description: Action
+    type: sai_trusted_vni_entry_action_t
+    attr_value_field: null
+    default: SAI_TRUSTED_VNI_ENTRY_ACTION_PERMIT
+    isresourcetype: false
+    flags: CREATE_AND_SET
+    object_name: null
+    allow_null: false
+    valid_only: null
+    is_vlan: false
+    deprecated: false
+  stats: []
+  p4_meta: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4Meta
+    tables:
+    - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaTable
+      id: 38326132
+      single_match_priority: true
+      stage: null
+      keys:
+      - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaKey
+        name: eni_id
+        id: 1
+        match_type: exact
+        field: u16
+        bitwidth: 16
+        ip_is_v6_field_id: 0
+        is_object_key: false
+      - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaKey
+        name: vni_range
+        id: 2
+        match_type: range
+        field: u32range
+        bitwidth: 24
+        ip_is_v6_field_id: 0
+        is_object_key: false
+      actions:
+        SAI_TRUSTED_VNI_ENTRY_ACTION_PERMIT: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaAction
+          name: SAI_TRUSTED_VNI_ENTRY_ACTION_PERMIT
+          id: 24633826
+          attr_params: {}

--- a/dash-pipeline/SAI/specs/sai_spec.yaml
+++ b/dash-pipeline/SAI/specs/sai_spec.yaml
@@ -47,7 +47,7 @@ object_types:
 - SAI_OBJECT_TYPE_DASH_TUNNEL_NEXT_HOP
 - SAI_OBJECT_TYPE_OUTBOUND_PORT_MAP
 - SAI_OBJECT_TYPE_OUTBOUND_PORT_MAP_PORT_RANGE_ENTRY
-- SAI_OBJECT_TYPE_TRUSTED_VNI_ENTRY
+- SAI_OBJECT_TYPE_ENI_TRUSTED_VNI_ENTRY
 - SAI_OBJECT_TYPE_GLOBAL_TRUSTED_VNI_ENTRY
 object_entries:
 - !!python/object:utils.sai_spec.sai_struct_entry.SaiStructEntry
@@ -117,11 +117,11 @@ object_entries:
   objects: null
   valid_only: object_type == SAI_OBJECT_TYPE_OUTBOUND_PORT_MAP_PORT_RANGE_ENTRY,
 - !!python/object:utils.sai_spec.sai_struct_entry.SaiStructEntry
-  name: trusted_vni_entry
-  description: Object entry for DASH API trusted_vni_entry
-  type: sai_trusted_vni_entry_t
+  name: eni_trusted_vni_entry
+  description: Object entry for DASH API eni_trusted_vni_entry
+  type: sai_eni_trusted_vni_entry_t
   objects: null
-  valid_only: object_type == SAI_OBJECT_TYPE_TRUSTED_VNI_ENTRY,
+  valid_only: object_type == SAI_OBJECT_TYPE_ENI_TRUSTED_VNI_ENTRY,
 - !!python/object:utils.sai_spec.sai_struct_entry.SaiStructEntry
   name: global_trusted_vni_entry
   description: Object entry for DASH API global_trusted_vni_entry

--- a/dash-pipeline/SAI/specs/sai_spec.yaml
+++ b/dash-pipeline/SAI/specs/sai_spec.yaml
@@ -48,6 +48,7 @@ object_types:
 - SAI_OBJECT_TYPE_OUTBOUND_PORT_MAP
 - SAI_OBJECT_TYPE_OUTBOUND_PORT_MAP_PORT_RANGE_ENTRY
 - SAI_OBJECT_TYPE_TRUSTED_VNI_ENTRY
+- SAI_OBJECT_TYPE_GLOBAL_TRUSTED_VNI_ENTRY
 object_entries:
 - !!python/object:utils.sai_spec.sai_struct_entry.SaiStructEntry
   name: direction_lookup_entry
@@ -121,6 +122,12 @@ object_entries:
   type: sai_trusted_vni_entry_t
   objects: null
   valid_only: object_type == SAI_OBJECT_TYPE_TRUSTED_VNI_ENTRY,
+- !!python/object:utils.sai_spec.sai_struct_entry.SaiStructEntry
+  name: global_trusted_vni_entry
+  description: Object entry for DASH API global_trusted_vni_entry
+  type: sai_global_trusted_vni_entry_t
+  objects: null
+  valid_only: object_type == SAI_OBJECT_TYPE_GLOBAL_TRUSTED_VNI_ENTRY,
 enums:
 - !!python/object:utils.sai_spec.sai_enum.SaiEnum
   name: sai_dash_direction_t

--- a/dash-pipeline/SAI/specs/sai_spec.yaml
+++ b/dash-pipeline/SAI/specs/sai_spec.yaml
@@ -16,6 +16,7 @@ api_types:
 - SAI_API_DASH_FLOW
 - SAI_API_DASH_APPLIANCE
 - SAI_API_DASH_OUTBOUND_PORT_MAP
+- SAI_API_DASH_TRUSTED_VNI
 object_types:
 - SAI_OBJECT_TYPE_DASH_ACL_GROUP
 - SAI_OBJECT_TYPE_DASH_ACL_RULE
@@ -46,6 +47,7 @@ object_types:
 - SAI_OBJECT_TYPE_DASH_TUNNEL_NEXT_HOP
 - SAI_OBJECT_TYPE_OUTBOUND_PORT_MAP
 - SAI_OBJECT_TYPE_OUTBOUND_PORT_MAP_PORT_RANGE_ENTRY
+- SAI_OBJECT_TYPE_TRUSTED_VNI_ENTRY
 object_entries:
 - !!python/object:utils.sai_spec.sai_struct_entry.SaiStructEntry
   name: direction_lookup_entry
@@ -113,6 +115,12 @@ object_entries:
   type: sai_outbound_port_map_port_range_entry_t
   objects: null
   valid_only: object_type == SAI_OBJECT_TYPE_OUTBOUND_PORT_MAP_PORT_RANGE_ENTRY,
+- !!python/object:utils.sai_spec.sai_struct_entry.SaiStructEntry
+  name: trusted_vni_entry
+  description: Object entry for DASH API trusted_vni_entry
+  type: sai_trusted_vni_entry_t
+  objects: null
+  valid_only: object_type == SAI_OBJECT_TYPE_TRUSTED_VNI_ENTRY,
 enums:
 - !!python/object:utils.sai_spec.sai_enum.SaiEnum
   name: sai_dash_direction_t
@@ -478,6 +486,18 @@ enums:
     name: FLOW_PENDING_RESIMULATION
     description: ''
     value: '4'
+- !!python/object:utils.sai_spec.sai_enum.SaiEnum
+  name: sai_dash_eni_mode_t
+  description: ''
+  members:
+  - !!python/object:utils.sai_spec.sai_enum_member.SaiEnumMember
+    name: VM
+    description: ''
+    value: '0'
+  - !!python/object:utils.sai_spec.sai_enum_member.SaiEnumMember
+    name: FNIC
+    description: ''
+    value: '1'
 port_extenstion: !!python/object:utils.sai_spec.sai_api_extension.SaiApiExtension
   attributes: []
   stats:
@@ -576,3 +596,4 @@ api_groups:
 - !inc 'dash_flow.yaml'
 - !inc 'dash_appliance.yaml'
 - !inc 'dash_outbound_port_map.yaml'
+- !inc 'dash_trusted_vni.yaml'

--- a/dash-pipeline/SAI/specs/sai_spec.yaml
+++ b/dash-pipeline/SAI/specs/sai_spec.yaml
@@ -47,8 +47,8 @@ object_types:
 - SAI_OBJECT_TYPE_DASH_TUNNEL_NEXT_HOP
 - SAI_OBJECT_TYPE_OUTBOUND_PORT_MAP
 - SAI_OBJECT_TYPE_OUTBOUND_PORT_MAP_PORT_RANGE_ENTRY
-- SAI_OBJECT_TYPE_ENI_TRUSTED_VNI_ENTRY
 - SAI_OBJECT_TYPE_GLOBAL_TRUSTED_VNI_ENTRY
+- SAI_OBJECT_TYPE_ENI_TRUSTED_VNI_ENTRY
 object_entries:
 - !!python/object:utils.sai_spec.sai_struct_entry.SaiStructEntry
   name: direction_lookup_entry
@@ -117,17 +117,17 @@ object_entries:
   objects: null
   valid_only: object_type == SAI_OBJECT_TYPE_OUTBOUND_PORT_MAP_PORT_RANGE_ENTRY,
 - !!python/object:utils.sai_spec.sai_struct_entry.SaiStructEntry
-  name: eni_trusted_vni_entry
-  description: Object entry for DASH API eni_trusted_vni_entry
-  type: sai_eni_trusted_vni_entry_t
-  objects: null
-  valid_only: object_type == SAI_OBJECT_TYPE_ENI_TRUSTED_VNI_ENTRY,
-- !!python/object:utils.sai_spec.sai_struct_entry.SaiStructEntry
   name: global_trusted_vni_entry
   description: Object entry for DASH API global_trusted_vni_entry
   type: sai_global_trusted_vni_entry_t
   objects: null
   valid_only: object_type == SAI_OBJECT_TYPE_GLOBAL_TRUSTED_VNI_ENTRY,
+- !!python/object:utils.sai_spec.sai_struct_entry.SaiStructEntry
+  name: eni_trusted_vni_entry
+  description: Object entry for DASH API eni_trusted_vni_entry
+  type: sai_eni_trusted_vni_entry_t
+  objects: null
+  valid_only: object_type == SAI_OBJECT_TYPE_ENI_TRUSTED_VNI_ENTRY,
 enums:
 - !!python/object:utils.sai_spec.sai_enum.SaiEnum
   name: sai_dash_direction_t

--- a/dash-pipeline/bmv2/dash_counters.p4
+++ b/dash-pipeline/bmv2/dash_counters.p4
@@ -104,5 +104,6 @@ DEFINE_ENI_PACKET_COUNTER(outbound_routing_group_miss_drop)
 DEFINE_ENI_PACKET_COUNTER(outbound_routing_group_disabled_drop)
 DEFINE_ENI_PACKET_COUNTER(outbound_port_map_miss_drop)
 DEFINE_ENI_PACKET_COUNTER(outbound_port_map_port_range_entry_miss_drop)
+DEFINE_ENI_PACKET_COUNTER(eni_trusted_vni_entry_miss_drop)
 
 #endif // __DASH_COUNTERS__

--- a/dash-pipeline/bmv2/dash_metadata.p4
+++ b/dash-pipeline/bmv2/dash_metadata.p4
@@ -263,4 +263,8 @@ struct metadata_t {
     EthernetAddress cpu_mac;
 }
 
+action deny(inout metadata_t meta) {
+    meta.dropped = true;
+}
+
 #endif /* _SIRIUS_METADATA_P4_ */

--- a/dash-pipeline/bmv2/dash_metadata.p4
+++ b/dash-pipeline/bmv2/dash_metadata.p4
@@ -37,6 +37,11 @@ enum bit<8> dash_eni_mac_type_t {
     DST_MAC = 1
 };
 
+enum bit<8> dash_eni_mode_t {
+    VM = 0,
+    FNIC = 1
+};
+
 struct conntrack_data_t {
     bool allow_in;
     bool allow_out;
@@ -64,6 +69,7 @@ struct eni_data_t {
     dash_tunnel_dscp_mode_t dscp_mode;
     outbound_routing_group_data_t outbound_routing_group_data;
     IPv4Address vip;
+    dash_eni_mode_t eni_mode;
 }
 
 struct port_map_context_t {

--- a/dash-pipeline/bmv2/dash_pipeline.p4
+++ b/dash-pipeline/bmv2/dash_pipeline.p4
@@ -24,10 +24,6 @@ control dash_eni_stage(
     , inout metadata_t meta
     )
 {
-    action deny() {
-        meta.dropped = true;
-    }
-
 #define ACL_GROUPS_PARAM(prefix) \
     @SaiVal[type="sai_object_id_t"] bit<16> ## prefix ##_stage1_dash_acl_group_id, \
     @SaiVal[type="sai_object_id_t"] bit<16> ## prefix ##_stage2_dash_acl_group_id, \
@@ -128,9 +124,9 @@ control dash_eni_stage(
 
         actions = {
             set_eni_attrs;
-            @defaultonly deny;
+            @defaultonly deny(meta);
         }
-        const default_action = deny;
+        const default_action = deny(meta);
     }
 
     apply {
@@ -146,10 +142,6 @@ control dash_lookup_stage(
     , inout metadata_t meta
     )
 {
-    action deny() {
-        meta.dropped = true;
-    }
-
     apply {
         pre_pipeline_stage.apply(hdr, meta);
         direction_lookup_stage.apply(hdr, meta);
@@ -158,7 +150,7 @@ control dash_lookup_stage(
         dash_eni_stage.apply(hdr, meta);
 
         if (meta.eni_data.admin_state == 0) {
-            deny();
+            deny(meta);
         }
         
         UPDATE_ENI_COUNTER(eni_rx);

--- a/dash-pipeline/bmv2/dash_pipeline.p4
+++ b/dash-pipeline/bmv2/dash_pipeline.p4
@@ -277,6 +277,7 @@ control dash_ingress(
             (meta.flow_sync_state == dash_flow_sync_state_t.FLOW_MISS &&
              hdr.packet_meta.packet_source == dash_packet_source_t.EXTERNAL))
         {
+            // TODO: revisit it after inbound route HLD done
             trusted_vni_stage.apply(hdr, meta);
             dash_match_stage.apply(hdr, meta);
             if (meta.dropped) {

--- a/dash-pipeline/bmv2/stages/direction_lookup.p4
+++ b/dash-pipeline/bmv2/stages/direction_lookup.p4
@@ -25,9 +25,11 @@ control direction_lookup_stage(
         set_eni_mac_type(dash_eni_mac_type_t.SRC_MAC, dash_eni_mac_override_type);
     }
 
-    action set_inbound_direction() {
+    action set_inbound_direction(
+        @SaiVal[type="sai_dash_eni_mac_override_type_t"] dash_eni_mac_override_type_t dash_eni_mac_override_type
+    ) {
         meta.direction = dash_direction_t.INBOUND;
-        meta.eni_mac_type = dash_eni_mac_type_t.DST_MAC;
+        set_eni_mac_type(dash_eni_mac_type_t.DST_MAC, dash_eni_mac_override_type);
     }
 
     @SaiTable[name = "direction_lookup", api = "dash_direction_lookup"]
@@ -38,10 +40,10 @@ control direction_lookup_stage(
 
         actions = {
             set_outbound_direction;
-            @defaultonly set_inbound_direction;
+            set_inbound_direction;
         }
 
-        const default_action = set_inbound_direction;
+        const default_action = set_inbound_direction(dash_eni_mac_override_type_t.NONE);
     }
 
     apply {

--- a/dash-pipeline/bmv2/stages/eni_lookup.p4
+++ b/dash-pipeline/bmv2/stages/eni_lookup.p4
@@ -9,10 +9,6 @@ control eni_lookup_stage(
         meta.eni_id = eni_id;
     }
 
-    action deny() {
-        meta.dropped = true;
-    }
-    
     @SaiTable[name = "eni_ether_address_map", api = "dash_eni", order=0]
     table eni_ether_address_map {
         key = {
@@ -21,9 +17,9 @@ control eni_lookup_stage(
 
         actions = {
             set_eni;
-            @defaultonly deny;
+            @defaultonly deny(meta);
         }
-        const default_action = deny;
+        const default_action = deny(meta);
     }
 
     apply {

--- a/dash-pipeline/bmv2/stages/trusted_vni.p4
+++ b/dash-pipeline/bmv2/stages/trusted_vni.p4
@@ -1,0 +1,33 @@
+#ifndef _DASH_STAGE_TRUSTED_VNI_P4_
+#define _DASH_STAGE_TRUSTED_VNI_P4_
+
+control trusted_vni_stage(
+    inout headers_t hdr,
+    inout metadata_t meta)
+{
+    action permit() {}
+
+    action deny() {
+        meta.dropped = true;
+    }
+
+    @SaiTable[single_match_priority = "true", api = "dash_trusted_vni"]
+    table trusted_vni {
+        key = {
+            meta.eni_id : exact @SaiVal[type="sai_object_id_t"];
+            meta.rx_encap.vni: range @SaiVal[name = "vni_range"];
+        }
+
+        actions = {
+            permit;
+            @defaultonly deny;
+        }
+        const default_action = deny;
+    }
+
+    apply {
+        trusted_vni.apply();
+    }
+}
+
+#endif /* _DASH_STAGE_TRUSTED_VNI_P4_ */

--- a/dash-pipeline/bmv2/stages/trusted_vni.p4
+++ b/dash-pipeline/bmv2/stages/trusted_vni.p4
@@ -7,7 +7,7 @@ control trusted_vni_stage(
 {
     action permit() {}
 
-    @SaiTable[single_match_priority = "true", api = "dash_trusted_vni", order=1, isobject="false"]
+    @SaiTable[single_match_priority = "true", api = "dash_trusted_vni", order=0, isobject="false"]
     table global_trusted_vni {
         key = {
             meta.rx_encap.vni: range @SaiVal[name = "vni_range"];
@@ -18,7 +18,7 @@ control trusted_vni_stage(
         }
     }
 
-    @SaiTable[single_match_priority = "true", api = "dash_trusted_vni"]
+    @SaiTable[single_match_priority = "true", api = "dash_trusted_vni", order=1]
     table eni_trusted_vni {
         key = {
             meta.eni_id : exact @SaiVal[type="sai_object_id_t"];

--- a/dash-pipeline/bmv2/stages/trusted_vni.p4
+++ b/dash-pipeline/bmv2/stages/trusted_vni.p4
@@ -11,6 +11,17 @@ control trusted_vni_stage(
         meta.dropped = true;
     }
 
+    @SaiTable[single_match_priority = "true", api = "dash_trusted_vni", order=1, isobject="false"]
+    table global_trusted_vni {
+        key = {
+            meta.rx_encap.vni: range @SaiVal[name = "vni_range"];
+        }
+
+        actions = {
+            permit;
+        }
+    }
+
     @SaiTable[single_match_priority = "true", api = "dash_trusted_vni"]
     table trusted_vni {
         key = {
@@ -26,6 +37,10 @@ control trusted_vni_stage(
     }
 
     apply {
+        if (global_trusted_vni.apply().hit) {
+            return;
+        }
+
         trusted_vni.apply();
     }
 }

--- a/test/test-cases/functional/ptf/sai_dash_utils.py
+++ b/test/test-cases/functional/ptf/sai_dash_utils.py
@@ -474,7 +474,7 @@ class VnetAPI(VnetObjects):
 
     def global_trusted_vni_create(self, vni):
         """
-        Create outband CA PA mapping
+        Create global trusted vni
         """
 
         global_trusted_vni_entry = sai_thrift_global_trusted_vni_entry_t(switch_id=self.switch_id,

--- a/test/test-cases/functional/ptf/sai_dash_utils.py
+++ b/test/test-cases/functional/ptf/sai_dash_utils.py
@@ -16,6 +16,7 @@
 Thrift SAI interface basic DASH utils.
 """
 
+import functools
 from sai_thrift.sai_headers import *
 from sai_base_test import *
 
@@ -470,6 +471,22 @@ class VnetAPI(VnetObjects):
             self.neighbor_create(rif, neighbor.ip, neighbor.mac)
             #if add_routes is True:
             #    self.route_create(neighbor.ip_prefix, nhop)
+
+    def global_trusted_vni_create(self, vni):
+        """
+        Create outband CA PA mapping
+        """
+
+        global_trusted_vni_entry = sai_thrift_global_trusted_vni_entry_t(switch_id=self.switch_id,
+                vni_range=sai_thrift_u32_range_t(min=vni, max=vni))
+        sai_thrift_create_global_trusted_vni_entry(self.client, global_trusted_vni_entry)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+        self.add_teardown_obj(self.global_trusted_vni_remove, global_trusted_vni_entry)
+
+        return global_trusted_vni_entry
+
+    def global_trusted_vni_remove(self, global_trusted_vni_entry):
+        sai_thrift_remove_global_trusted_vni_entry(self.client, global_trusted_vni_entry)
 
 
 class VnetApiEndpoints(VnetAPI):
@@ -1520,3 +1537,22 @@ class VnetTrafficMixin:
 
         pkt.getlayer("TCP").seq = seq
         pkt.getlayer("TCP").ack = ack
+
+def configureTrustedVni(func):
+    @functools.wraps(func)
+    def wrapper_configureTrustedVni(self):
+        value = func(self)
+
+        vni_set = set()
+        tx_hosts = ["tx_host", "tx_host_1", "tx_host_2", "tx_host_3", "tx_host_4"]
+        for name in tx_hosts:
+            host = getattr(self, name, None)
+            if host and host.client:
+                vni_set.add(host.client.vni)
+
+        for vni in list(vni_set):
+                self.global_trusted_vni_create(vni)
+
+        return value
+
+    return wrapper_configureTrustedVni

--- a/test/test-cases/functional/ptf/saidashacl.py
+++ b/test/test-cases/functional/ptf/saidashacl.py
@@ -150,6 +150,11 @@ class SaiThriftDashAclTest(VnetAPI):
         self.create_entry(sai_thrift_create_direction_lookup_entry, sai_thrift_remove_direction_lookup_entry,
                           self.dle, action=SAI_DIRECTION_LOOKUP_ENTRY_ACTION_SET_OUTBOUND_DIRECTION)
 
+        self.gtve = sai_thrift_global_trusted_vni_entry_t(switch_id=self.switch_id,
+                vni_range=sai_thrift_u32_range_t(min=self.outbound_vni, max=self.outbound_vni))
+        self.create_entry(sai_thrift_create_global_trusted_vni_entry, sai_thrift_remove_global_trusted_vni_entry,
+                          self.gtve)
+
         self.in_v4_stage1_acl_group_id = self.create_obj(
             sai_thrift_create_dash_acl_group, sai_thrift_remove_dash_acl_group, ip_addr_family=SAI_IP_ADDR_FAMILY_IPV4)
         self.in_v4_stage2_acl_group_id = self.create_obj(

--- a/test/test-cases/functional/ptf/saidashdpapp_sanity.py
+++ b/test/test-cases/functional/ptf/saidashdpapp_sanity.py
@@ -46,6 +46,11 @@ class SaiThriftDpappPktTest(SaiHelperSimplified):
                                                           action=SAI_DIRECTION_LOOKUP_ENTRY_ACTION_SET_OUTBOUND_DIRECTION)
         assert(status == SAI_STATUS_SUCCESS)
 
+        self.gtve = sai_thrift_global_trusted_vni_entry_t(switch_id=self.switch_id,
+                vni_range=sai_thrift_u32_range_t(min=self.outbound_vni, max=self.outbound_vni))
+        status = sai_thrift_create_global_trusted_vni_entry(self.client, self.gtve)
+        assert(status == SAI_STATUS_SUCCESS)
+
         self.in_acl_group_id = sai_thrift_create_dash_acl_group(self.client,
                                                                 ip_addr_family=self.sai_ip_addr_family)
         assert (self.in_acl_group_id != SAI_NULL_OBJECT_ID)
@@ -322,6 +327,7 @@ class SaiThriftDpappPktTest(SaiHelperSimplified):
             status &= sai_thrift_remove_vnet(self.client, self.vnet)
             status &= sai_thrift_remove_dash_acl_group(self.client, self.out_acl_group_id)
             status &= sai_thrift_remove_dash_acl_group(self.client, self.in_acl_group_id)
+            status &= sai_thrift_remove_global_trusted_vni_entry(self.client, self.gtve)
             status &= sai_thrift_remove_direction_lookup_entry(self.client, self.dle)
             status &= sai_thrift_remove_vip_entry(self.client, self.vpe)
             status &= sai_thrift_remove_route_entry(self.client, self.pa_route_entry)

--- a/test/test-cases/functional/ptf/saidashvnet.py
+++ b/test/test-cases/functional/ptf/saidashvnet.py
@@ -38,6 +38,7 @@ class UnderlayRouteTest(VnetApiEndpoints, VnetTrafficMixin):
         self.l3UnderlayHost1toHost2RoutingTest()
         self.l3UnderlayHost2toHost1RoutingTest()
 
+    @configureTrustedVni
     def configureTest(self):
         """
         Setup DUT in accordance with test purpose
@@ -137,6 +138,7 @@ class Vnet2VnetInboundDecapPaValidateSinglePortTest(VnetApiEndpoints, VnetTraffi
         self.vnet2VnetInboundRoutingTest(tx_equal_to_rx=True)
         self.vnet2VnetInboundNegativeTest()
 
+    @configureTrustedVni
     def configureTest(self):
         """
         Setup DUT in accordance with test purpose
@@ -268,6 +270,7 @@ class Vnet2VnetInboundDecapSinglePortTest(Vnet2VnetInboundDecapPaValidateSingleP
     Verifies positive and negative scenarios
     """
 
+    @configureTrustedVni
     def configureTest(self):
         """
         Setup DUT overlay in accordance with test purpose
@@ -397,6 +400,7 @@ class Vnet2VnetInboundMultiplePaValidatesSingleEniSinglePortTest(VnetApiEndpoint
         self.vnet2VnetInboundRoutingPositiveTest(tx_equal_to_rx=True)
         self.vnet2VnetInboundRoutingNegativeTest()
 
+    @configureTrustedVni
     def configureTest(self):
         """
         Setup DUT in accordance with test purpose
@@ -582,6 +586,7 @@ class Vnet2VnetInboundMultiplePaValidatesSingleEniSinglePortOverlayIpv6Test(Vnet
 
         self.vnet2VnetInboundRoutingPositiveTest(tx_equal_to_rx=True)
 
+    @configureTrustedVni
     def configureTest(self):
         """
         Setup DUT in accordance with test purpose
@@ -777,6 +782,7 @@ class Vnet2VnetInboundMultiplePaValidatesMultipleEniSinglePortTest(VnetApiEndpoi
         self.vnet2VnetInboundRoutingPositiveTest(tx_equal_to_rx=True)
         self.vnet2VnetInboundRoutingNegativeTest()
 
+    @configureTrustedVni
     def configureTest(self):
         """
         Setup DUT in accordance with test purpose
@@ -949,6 +955,7 @@ class Vnet2VnetInboundMultiplePaValidatesMultipleEniSinglePortOverlayIpv6Test(Vn
 
         self.vnet2VnetInboundRoutingPositiveTest(tx_equal_to_rx=True)
 
+    @configureTrustedVni
     def configureTest(self):
         """
         Setup DUT in accordance with test purpose
@@ -1128,6 +1135,7 @@ class Vnet2VnetSingleInboundRouteMultiplePaValidateSinglePortTest(VnetApiEndpoin
 
         self.vnet2VnetInboundRoutingTest(tx_equal_to_rx=True)
 
+    @configureTrustedVni
     def configureTest(self):
         """
         Setup DUT in accordance with test purpose
@@ -1251,6 +1259,7 @@ class Vnet2VnetSingleInboundRouteMultiplePaValidateSinglePortIpv6Test(Vnet2VnetS
 
         self.vnet2VnetInboundRoutingTest(tx_equal_to_rx=True)
 
+    @configureTrustedVni
     def configureTest(self):
         """
         Setup DUT in accordance with test purpose
@@ -1383,6 +1392,7 @@ class Vnet2VnetInboundEniSetUpDownSinglePortTest(VnetApiEndpoints, VnetTrafficMi
         self.eni_set_admin_state(self.eni_id, "up")
         self.vnet2VnetEniUpTrafficTest(tx_equal_to_rx=True)
 
+    @configureTrustedVni
     def configureTest(self):
         """
         Setup DUT overlay in accordance with test purpose
@@ -1463,6 +1473,7 @@ class Vnet2VnetOutboundRouteVnetDirectSinglePortTest(VnetApiEndpoints, VnetTraff
         self.vnet2VnetOutboundRoutingTest(tx_equal_to_rx=True)
         self.vnet2VnetOutboundNegativeTest()
 
+    @configureTrustedVni
     def configureTest(self):
         """
         Setup DUT in accordance with test purpose
@@ -1535,6 +1546,7 @@ class Vnet2VnetOutboundRouteVnetDirectSinglePortOverlayIpv6Test(Vnet2VnetOutboun
     def setUp(self):
         super(Vnet2VnetOutboundRouteVnetDirectSinglePortOverlayIpv6Test, self).setUp(overlay_ipv6=True)
 
+    @configureTrustedVni
     def configureTest(self):
         """
         Setup DUT in accordance with test purpose
@@ -1635,6 +1647,7 @@ class Vnet2VnetOutboundRouteVnetSinglePortTest(VnetApiEndpoints, VnetTrafficMixi
         self.vnet2VnetOutboundRoutingTest(tx_equal_to_rx=True)
         self.vnet2VnetOutboundNegativeTest()
 
+    @configureTrustedVni
     def configureTest(self):
         """
         Setup DUT in accordance with test purpose
@@ -1713,6 +1726,7 @@ class Vnet2VnetOutboundRouteVnetSinglePortOverlayIpv6Test(Vnet2VnetOutboundRoute
     def setUp(self):
         super(Vnet2VnetOutboundRouteVnetSinglePortOverlayIpv6Test, self).setUp(overlay_ipv6=True)
 
+    @configureTrustedVni
     def configureTest(self):
         """
         Setup DUT in accordance with test purpose
@@ -1823,6 +1837,7 @@ class Vnet2VnetOutboundEniSetUpDownSinglePortTest(VnetApiEndpoints, VnetTrafficM
         self.eni_set_admin_state(self.eni_id, "up")
         self.vnet2VnetEniUpTrafficTest(tx_equal_to_rx=True)
 
+    @configureTrustedVni
     def configureTest(self):
         """
         Setup DUT in accordance with test purpose
@@ -1910,6 +1925,7 @@ class Vnet2VnetOutboundRouteDirectSinglePortTest(VnetApiEndpoints, VnetTrafficMi
         self.outboundRouteDirectTest(tx_equal_to_rx=True)
         self.outboundRouteDirectNegativeTest()
 
+    @configureTrustedVni
     def configureTest(self):
         """
         Setup DUT in accordance with test purpose
@@ -1978,6 +1994,7 @@ class Vnet2VnetOutboundRouteDirectSinglePortOverlayIpv6Test(Vnet2VnetOutboundRou
     def setUp(self):
         super(Vnet2VnetOutboundRouteDirectSinglePortOverlayIpv6Test, self).setUp(overlay_ipv6=True)
 
+    @configureTrustedVni
     def configureTest(self):
         """
         Setup DUT in accordance with test purpose
@@ -2076,6 +2093,7 @@ class Vnet2VnetSingleOutboundRouteMultipleCa2PaSinglePortTest(VnetApiEndpoints, 
         self.vnet2VnetOutboundRoutingTest(tx_equal_to_rx=True)
         self.vnet2VnetOutboundNegativeTest()
 
+    @configureTrustedVni
     def configureTest(self):
         """
         Setup DUT in accordance with test purpose
@@ -2218,6 +2236,7 @@ class Vnet2VnetSingleOutboundRouteMultipleCa2PaSinglePortIpv6Test(Vnet2VnetSingl
     def setUp(self):
         super(Vnet2VnetSingleOutboundRouteMultipleCa2PaSinglePortIpv6Test, self).setUp(overlay_ipv6=True)
 
+    @configureTrustedVni
     def configureTest(self):
         """
         Setup DUT in accordance with test purpose
@@ -2372,6 +2391,7 @@ class Vnet2VnetOutboundDstVnetIdRouteVnetSinglePortTest(VnetApiEndpoints, VnetTr
         self.vnet2VnetOutboundDstVnetIdTrueTest(tx_equal_to_rx=True)
         self.vnet2VnetOutboundDstVnetIdFalseTest(tx_equal_to_rx=True)
 
+    @configureTrustedVni
     def configureTest(self):
         """
         Setup DUT in accordance with test purpose
@@ -2459,6 +2479,7 @@ class Vnet2VnetOutboundDstVnetIdRouteVnetSinglePortOverlayIpv6Test(Vnet2VnetOutb
     def setUp(self):
         super(Vnet2VnetOutboundDstVnetIdRouteVnetSinglePortOverlayIpv6Test, self).setUp(overlay_ipv6=True)
 
+    @configureTrustedVni
     def configureTest(self):
         """
         Setup DUT in accordance with test purpose
@@ -2570,6 +2591,7 @@ class Vnet2VnetOutboundDstVnetIdRouteVnetDirectSinglePortTest(Vnet2VnetOutboundD
         self.vnet2VnetOutboundDstVnetIdTrueTest(tx_equal_to_rx=True)
         self.vnet2VnetOutboundDstVnetIdFalseTest(tx_equal_to_rx=True)
 
+    @configureTrustedVni
     def configureTest(self):
         """
         Setup DUT in accordance with test purpose
@@ -2642,6 +2664,7 @@ class Vnet2VnetOutboundDstVnetIdRouteVnetDirectSinglePortOverlayIpv6Test(Vnet2Vn
     def setUp(self):
         super(Vnet2VnetOutboundDstVnetIdRouteVnetDirectSinglePortOverlayIpv6Test, self).setUp(overlay_ipv6=True)
 
+    @configureTrustedVni
     def configureTest(self):
         """
         Setup DUT in accordance with test purpose
@@ -2758,6 +2781,7 @@ class Vnet2VnetInboundOutboundMultipleConfigsSinglePortTest(VnetApiEndpoints, Vn
         self.outboundHost3toHost1Test(tx_equal_to_rx=True)
         self.inboundHost1toHost3Test(tx_equal_to_rx=True)
 
+    @configureTrustedVni
     def configureTest(self):
         """
         Setup DUT in accordance with test purpose
@@ -2901,6 +2925,7 @@ class Vnet2VnetInboundOutboundMultipleConfigsSinglePortOverlayIpv6Test(Vnet2Vnet
     with underlay config (neighbour + next hop) but without underlay routes
     """
 
+    @configureTrustedVni
     def configureTest(self):
         """
         Setup DUT in accordance with test purpose
@@ -3054,6 +3079,7 @@ class Vnet2VnetOutboundMultipleEniSameIpPrefixSinglePortTest(VnetApiEndpoints, V
         self.outboundEni1Test(tx_equal_to_rx=True)
         self.outboundEni2Test(tx_equal_to_rx=True)
 
+    @configureTrustedVni
     def configureTest(self):
         """
         Setup DUT in accordance with test purpose
@@ -3228,6 +3254,7 @@ class Vnet2VnetOutboundMultipleEniSameIpPrefixSinglePortOverlayIpv6Test(Vnet2Vne
     def setUp(self):
         super(Vnet2VnetOutboundMultipleEniSameIpPrefixSinglePortOverlayIpv6Test, self).setUp(overlay_ipv6=True)
 
+    @configureTrustedVni
     def configureTest(self):
         """
         Setup DUT in accordance with test purpose
@@ -3410,6 +3437,7 @@ class Vnet2VnetOutboundSingleEniMultipleIpPrefixSinglePortTest(VnetApiEndpoints,
         self.singleEniToOutboundVm2Test(tx_equal_to_rx=True)
         self.singleEniToOutboundVm3Test(tx_equal_to_rx=True)
 
+    @configureTrustedVni
     def configureTest(self):
         """
         Setup DUT in accordance with test purpose
@@ -3564,6 +3592,7 @@ class Vnet2VnetOutboundSingleEniMultipleIpPrefixSinglePortOverlayIpv6Test(Vnet2V
     def setUp(self):
         super(Vnet2VnetOutboundSingleEniMultipleIpPrefixSinglePortOverlayIpv6Test, self).setUp(overlay_ipv6=True)
 
+    @configureTrustedVni
     def configureTest(self):
         """
         Setup DUT in accordance with test purpose
@@ -3708,6 +3737,7 @@ class Vnet2VnetOutboundSameCaPaIpPrefixesSinglePortTest(VnetApiEndpoints, VnetTr
 
         self.vnet2VnetOutboundRouteVnetTest(tx_equal_to_rx=True)
 
+    @configureTrustedVni
     def configureTest(self):
         """
         Setup DUT in accordance with test purpose

--- a/test/test-cases/functional/ptf/saidashvnet_sanity.py
+++ b/test/test-cases/functional/ptf/saidashvnet_sanity.py
@@ -54,6 +54,11 @@ class SaiThriftVnetOutboundUdpPktTest(SaiHelperSimplified):
                                                           action=SAI_DIRECTION_LOOKUP_ENTRY_ACTION_SET_OUTBOUND_DIRECTION)
         assert(status == SAI_STATUS_SUCCESS)
 
+        self.gtve = sai_thrift_global_trusted_vni_entry_t(switch_id=self.switch_id,
+                vni_range=sai_thrift_u32_range_t(min=self.outbound_vni, max=self.outbound_vni))
+        status = sai_thrift_create_global_trusted_vni_entry(self.client, self.gtve)
+        assert(status == SAI_STATUS_SUCCESS)
+
         self.in_acl_group_id = sai_thrift_create_dash_acl_group(self.client,
                                                                 ip_addr_family=self.sai_ip_addr_family)
         assert (self.in_acl_group_id != SAI_NULL_OBJECT_ID)
@@ -278,6 +283,7 @@ class SaiThriftVnetOutboundUdpPktTest(SaiHelperSimplified):
             status &= sai_thrift_remove_vnet(self.client, self.vnet)
             status &= sai_thrift_remove_dash_acl_group(self.client, self.out_acl_group_id)
             status &= sai_thrift_remove_dash_acl_group(self.client, self.in_acl_group_id)
+            status &= sai_thrift_remove_global_trusted_vni_entry(self.client, self.gtve)
             status &= sai_thrift_remove_direction_lookup_entry(self.client, self.dle)
             status &= sai_thrift_remove_vip_entry(self.client, self.vpe)
             if self.configured:


### PR DESCRIPTION
Referring to https://github.com/sonic-net/SONiC/pull/1911 and https://github.com/sonic-net/DASH/pull/665, to support FNIC pipeline, this PR adds the followings:
- ENI mode VM, FNIC
- ENI drop counter `eni_trusted_vni_entry_miss_drop`
- Action `set_inbound_direction` is not defaultonly at table `direction_lookup`
- table `global_trusted_vni` and `eni_trusted_vni`

