### PR TITLE
[ci] Run github workflow on ubuntu-22.04 instead of ubuntu-20.04

### DIFF
--- a/.github/workflows/dash-bmv2-bldr-docker.yml
+++ b/.github/workflows/dash-bmv2-bldr-docker.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   build:
     name: Build docker dash-bmv2-bldr image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: ./dash-pipeline

--- a/.github/workflows/dash-bmv2-ci.yml
+++ b/.github/workflows/dash-bmv2-ci.yml
@@ -40,7 +40,7 @@ on:
 jobs:
   build:
     name: Build and Test DASH Pipeline
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       docker_fg_flags: --privileged
       docker_fg_root_flags: --privileged -u root

--- a/.github/workflows/dash-dpdk-ci.yml
+++ b/.github/workflows/dash-dpdk-ci.yml
@@ -40,7 +40,7 @@ on:
 jobs:
   build:
     name: Build DASH Pipeline for P4-DPDK
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       docker_fg_flags: --privileged
       docker_fg_root_flags: --privileged -u root

--- a/.github/workflows/dash-grpc1.43.2-docker.yml
+++ b/.github/workflows/dash-grpc1.43.2-docker.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   build:
     name: Build docker dash-grpc1.43.2 image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: ./dash-pipeline

--- a/.github/workflows/dash-p4c-bmv2-docker.yml
+++ b/.github/workflows/dash-p4c-bmv2-docker.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   build:
     name: Build docker dash-p4c-bmv2 image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: ./dash-pipeline

--- a/.github/workflows/dash-p4c-dpdk-docker.yml
+++ b/.github/workflows/dash-p4c-dpdk-docker.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   build:
     name: Build docker dash-p4c-dpdk image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: ./dash-pipeline

--- a/.github/workflows/dash-saichallenger-client-bldr-docker.yml
+++ b/.github/workflows/dash-saichallenger-client-bldr-docker.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   build:
     name: Build dash-saichallenger-client-bldr-image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       docker_fg_flags: -u root --privileged
       docker_bg_flags: -d -u root --privileged

--- a/.github/workflows/dash-saichallenger-client-docker.yml
+++ b/.github/workflows/dash-saichallenger-client-docker.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   build:
     name: Build dash-saichallenger-client-image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       docker_fg_flags: -u root --privileged
       docker_bg_flags: -d -u root --privileged

--- a/.github/workflows/dash-saithrift-bldr-docker.yml
+++ b/.github/workflows/dash-saithrift-bldr-docker.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   build:
     name: Build dash-saithrift-bldr-image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       docker_fg_flags: -u root --privileged
       docker_bg_flags: -d -u root --privileged

--- a/.github/workflows/dash-saithrift-client-bldr-docker.yml
+++ b/.github/workflows/dash-saithrift-client-bldr-docker.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   build:
     name: Build dash-saithrift-client-bldr-image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       docker_fg_flags: -u root --privileged
       docker_bg_flags: -d -u root --privileged

--- a/.github/workflows/dash-saithrift-client-docker.yml
+++ b/.github/workflows/dash-saithrift-client-docker.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   build:
     name: Build dash-saithrift-client-image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       docker_fg_flags: -u root --privileged
       docker_bg_flags: -d -u root --privileged


### PR DESCRIPTION
- Problem
  All workflows are failing on ubuntu-20.04 runner. The reason is as below:

  `This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101`

- Solution
  Update the ubuntu version to ubuntu-22.04