### PR TITLE
Add dp_channel_tunnel_key attribute to HA set

### DIFF
--- a/dash-pipeline/SAI/specs/dash_ha.yaml
+++ b/dash-pipeline/SAI/specs/dash_ha.yaml
@@ -140,6 +140,19 @@ sai_apis:
     valid_only: null
     is_vlan: false
     deprecated: false
+  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
+    name: SAI_HA_SET_ATTR_DP_CHANNEL_TUNNEL_KEY
+    description: Action parameter data plane channel tunnel key
+    type: sai_uint32_t
+    attr_value_field: u32
+    default: '0'
+    isresourcetype: false
+    flags: CREATE_AND_SET
+    object_name: null
+    allow_null: false
+    valid_only: null
+    is_vlan: false
+    deprecated: false
   stats:
   - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
     name: SAI_HA_SET_STAT_DP_PROBE_REQ_RX_BYTES
@@ -479,6 +492,12 @@ sai_apis:
               id: 12
               field: u32
               bitwidth: 32
+              ip_is_v6_field_id: 0
+              skipattr: null
+            SAI_HA_SET_ATTR_DP_CHANNEL_TUNNEL_KEY: !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaActionParam
+              id: 13
+              field: u32
+              bitwidth: 24
               ip_is_v6_field_id: 0
               skipattr: null
 - !!python/object:utils.sai_spec.sai_api.SaiApi

--- a/dash-pipeline/bmv2/dash_metadata.p4
+++ b/dash-pipeline/bmv2/dash_metadata.p4
@@ -139,6 +139,7 @@ struct ha_data_t {
     bit<16> dp_channel_dst_port;
     bit<16> dp_channel_src_port_min;
     bit<16> dp_channel_src_port_max;
+    bit<24> dp_channel_tunnel_key;
 }
 
 #ifdef TARGET_DPDK_PNA

--- a/dash-pipeline/bmv2/stages/ha.p4
+++ b/dash-pipeline/bmv2/stages/ha.p4
@@ -71,7 +71,8 @@ control ha_stage(inout headers_t hdr,
         bit<32> dp_channel_probe_interval_ms,
         bit<32> dp_channel_probe_fail_threshold,
         @SaiVal[isreadonly="true"] bit<1> dp_channel_is_alive,
-        bit<32> dpu_driven_ha_switchover_wait_time_ms
+        bit<32> dpu_driven_ha_switchover_wait_time_ms,
+        bit<24> dp_channel_tunnel_key
     ) {
         meta.ha.peer_ip_is_v6 = peer_ip_is_v6;
         meta.ha.peer_ip = peer_ip;
@@ -79,6 +80,7 @@ control ha_stage(inout headers_t hdr,
         meta.ha.dp_channel_dst_port = dp_channel_dst_port;
         meta.ha.dp_channel_src_port_min = dp_channel_min_src_port;
         meta.ha.dp_channel_src_port_max = dp_channel_max_src_port;
+        meta.ha.dp_channel_tunnel_key = dp_channel_tunnel_key;
     }
 
     @SaiTable[api = "dash_ha", order=0, isobject="true"]


### PR DESCRIPTION
According to the [4.2.1.2. Forwarding packet to remote DPU](https://github.com/sonic-net/SONiC/blob/master/doc/smart-switch/high-availability/smart-switch-ha-hld.md#4212-forwarding-packet-to-remote-dpu) section 1, the tunneled packets MUST have an VxLan encap as the outer packet, with a specified NPU tunnel VNI number as identifier.

This PR adds the HA set attribute to specify the VNI of the tunnel.