### PR TITLE
Update ENCAP_U1 functionality by u1_* headers emission and u1_ipv4 checksum

### DIFF
--- a/dash-pipeline/bmv2/dash_bmv2_v1model.p4
+++ b/dash-pipeline/bmv2/dash_bmv2_v1model.p4
@@ -5,28 +5,32 @@ control dash_verify_checksum(inout headers_t hdr,
     apply { }
 }
 
+#define UPDATE_IPV4_CHECKSUM(IPHDR) \
+    update_checksum( \
+        IPHDR.isValid(), \
+        { \
+            IPHDR.version, \
+            IPHDR.ihl, \
+            IPHDR.diffserv, \
+            IPHDR.total_len, \
+            IPHDR.identification, \
+            IPHDR.frag_offset, \
+            IPHDR.flags, \
+            IPHDR.ttl, \
+            IPHDR.protocol, \
+            IPHDR.src_addr, \
+            IPHDR.dst_addr \
+        }, \
+        IPHDR.hdr_checksum, \
+        HashAlgorithm.csum16)
+
 control dash_compute_checksum(inout headers_t hdr,
                           inout metadata_t meta)
 {
     apply {
 #ifdef TARGET_BMV2_V1MODEL
-        update_checksum(
-         hdr.u0_ipv4.isValid(),
-         {
-             hdr.u0_ipv4.version,
-             hdr.u0_ipv4.ihl,
-             hdr.u0_ipv4.diffserv,
-             hdr.u0_ipv4.total_len,
-             hdr.u0_ipv4.identification,
-             hdr.u0_ipv4.frag_offset,
-             hdr.u0_ipv4.flags,
-             hdr.u0_ipv4.ttl,
-             hdr.u0_ipv4.protocol,
-             hdr.u0_ipv4.src_addr,
-             hdr.u0_ipv4.dst_addr
-         },
-         hdr.u0_ipv4.hdr_checksum,
-         HashAlgorithm.csum16);
+        UPDATE_IPV4_CHECKSUM(hdr.u0_ipv4);
+        UPDATE_IPV4_CHECKSUM(hdr.u1_ipv4);
 #endif // TARGET_BMV2_V1MODEL
     }
 }

--- a/dash-pipeline/bmv2/dash_parser.p4
+++ b/dash-pipeline/bmv2/dash_parser.p4
@@ -183,6 +183,15 @@ control dash_deparser(
         packet.emit(hdr.flow_u0_encap_data);
         packet.emit(hdr.flow_u1_encap_data);
 
+        packet.emit(hdr.u1_ethernet);
+        packet.emit(hdr.u1_ipv4);
+        packet.emit(hdr.u1_ipv4options);
+        packet.emit(hdr.u1_ipv6);
+        packet.emit(hdr.u1_udp);
+        packet.emit(hdr.u1_tcp);
+        packet.emit(hdr.u1_vxlan);
+        packet.emit(hdr.u1_nvgre);
+
         packet.emit(hdr.u0_ethernet);
         packet.emit(hdr.u0_ipv4);
         packet.emit(hdr.u0_ipv4options);
@@ -191,6 +200,7 @@ control dash_deparser(
         packet.emit(hdr.u0_tcp);
         packet.emit(hdr.u0_vxlan);
         packet.emit(hdr.u0_nvgre);
+
         packet.emit(hdr.customer_ethernet);
         packet.emit(hdr.customer_ipv4);
         packet.emit(hdr.customer_ipv6);


### PR DESCRIPTION
**Summary**
This PR updates the ENCAP_U1 functionality in the DASH pipeline by adding the missing deparser emission for u1_* headers and IPv4 checksum update for u1_ipv4.

These updates were made while fixing the saidashflow test case for double encapsulation (ENCAP_U0 | ENCAP_U1), which was failing due to incomplete U1 packet output.

**Background**
The pipeline’s logic for ENCAP_U1 already existed, but packets generated for ENCAP_U0 | ENCAP_U1 flows were missing the U1 encapsulation layer because:

- The deparser did not emit u1_* headers.
- IPv4 checksum calculation did not cover for u1_ipv4
 
As a result, the FlowHitActionEncapU0EncapU1 test failed and was disabled.