### PR TITLE
Change mapping key IP to prefix

### DIFF
--- a/dash-pipeline/SAI/specs/dash_outbound_ca_to_pa.yaml
+++ b/dash-pipeline/SAI/specs/dash_outbound_ca_to_pa.yaml
@@ -39,8 +39,8 @@ sai_apis:
       valid_only: null
     - !!python/object:utils.sai_spec.sai_struct_entry.SaiStructEntry
       name: dip
-      description: Exact matched key dip
-      type: sai_ip_address_t
+      description: LPM matched key dip
+      type: sai_ip_prefix_t
       objects: null
       valid_only: null
   attributes:
@@ -289,8 +289,8 @@ sai_apis:
       - !!python/object:utils.sai_spec.sai_api_p4_meta.SaiApiP4MetaKey
         name: dip
         id: 3
-        match_type: exact
-        field: ipaddr
+        match_type: lpm
+        field: ipPrefix
         bitwidth: 128
         ip_is_v6_field_id: 2
         is_object_key: false

--- a/dash-pipeline/bmv2/stages/outbound_mapping.p4
+++ b/dash-pipeline/bmv2/stages/outbound_mapping.p4
@@ -16,7 +16,7 @@ control outbound_mapping_stage(
             /* Flow for express route */
             meta.dst_vnet_id: exact @SaiVal[type="sai_object_id_t"];
             meta.is_lkup_dst_ip_v6 : exact @SaiVal[name = "dip_is_v6"];
-            meta.lkup_dst_ip_addr : exact @SaiVal[name = "dip"];
+            meta.lkup_dst_ip_addr : lpm @SaiVal[name = "dip"];
         }
 
         actions = {

--- a/test/test-cases/functional/ptf/sai_dash_utils.py
+++ b/test/test-cases/functional/ptf/sai_dash_utils.py
@@ -373,10 +373,20 @@ class VnetAPI(VnetObjects):
         """
         Create outband CA PA mapping
         """
+        
+        # Ensure dip has a prefix length for LPM matching
+        if "/" not in dip:
+            # Auto-detect IPv4 vs IPv6 and add appropriate prefix
+            if ":" in dip:
+                # IPv6 address - add /128 for single host
+                dip = dip + "/128"
+            else:
+                # IPv4 address - add /32 for single host
+                dip = dip + "/32"
 
         ca_to_pa_entry = sai_thrift_outbound_ca_to_pa_entry_t(switch_id=self.switch_id,
                                                               dst_vnet_id=dst_vnet_id,
-                                                              dip=sai_ipaddress(dip))
+                                                              dip=sai_ipprefix(dip))
         sai_thrift_create_outbound_ca_to_pa_entry(self.client, ca_to_pa_entry,
                                                   action=SAI_OUTBOUND_CA_TO_PA_ENTRY_ACTION_SET_TUNNEL_MAPPING,
                                                   underlay_dip=sai_ipaddress(underlay_dip),

--- a/test/test-cases/functional/ptf/saidashacl.py
+++ b/test/test-cases/functional/ptf/saidashacl.py
@@ -242,8 +242,9 @@ class SaiThriftDashAclTest(VnetAPI):
         self.create_entry(sai_thrift_create_eni_ether_address_map_entry,
                           sai_thrift_remove_eni_ether_address_map_entry, self.eam, eni_id=self.eni)
 
-        dip = sai_thrift_ip_address_t(addr_family=SAI_IP_ADDR_FAMILY_IPV4,
-                                      addr=sai_thrift_ip_addr_t(ip4=self.dst_ca_ip))
+        dip = sai_thrift_ip_prefix_t(addr_family=SAI_IP_ADDR_FAMILY_IPV4,
+                                     addr=sai_thrift_ip_addr_t(ip4=self.dst_ca_ip),
+                                     mask=sai_thrift_ip_addr_t(ip4="255.255.255.255"))
 
         ca_prefix = sai_thrift_ip_prefix_t(addr_family=SAI_IP_ADDR_FAMILY_IPV4,
                                            addr=sai_thrift_ip_addr_t(

--- a/test/test-cases/functional/ptf/saidashdpapp_sanity.py
+++ b/test/test-cases/functional/ptf/saidashdpapp_sanity.py
@@ -142,8 +142,15 @@ class SaiThriftDpappPktTest(SaiHelperSimplified):
                                                                eni_id=self.eni)
         assert(status == SAI_STATUS_SUCCESS)
 
-        dip = sai_thrift_ip_address_t(addr_family=self.sai_ip_addr_family,
-                                      addr=sai_thrift_ip_addr_t(**{self.ip_addr_family_attr: self.dst_ca_ip}))
+        # Set appropriate mask for IPv4 (/32) or IPv6 (/128)
+        if self.sai_ip_addr_family == SAI_IP_ADDR_FAMILY_IPV6:
+            mask_str = "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"
+        else:
+            mask_str = "255.255.255.255"
+        
+        dip = sai_thrift_ip_prefix_t(addr_family=self.sai_ip_addr_family,
+                                     addr=sai_thrift_ip_addr_t(**{self.ip_addr_family_attr: self.dst_ca_ip}),
+                                     mask=sai_thrift_ip_addr_t(**{self.ip_addr_family_attr: mask_str}))
 
         # TODO: Enable ACL rule for IPv6
         if self.sai_ip_addr_family == SAI_IP_ADDR_FAMILY_IPV4:

--- a/test/test-cases/functional/ptf/saidashflow.py
+++ b/test/test-cases/functional/ptf/saidashflow.py
@@ -383,8 +383,9 @@ class SaiThriftDashFlowTest(VnetAPI):
         self.create_entry(sai_thrift_create_eni_ether_address_map_entry,
                           sai_thrift_remove_eni_ether_address_map_entry, self.eam, eni_id=self.eni)
 
-        dip = sai_thrift_ip_address_t(addr_family=SAI_IP_ADDR_FAMILY_IPV4,
-                                      addr=sai_thrift_ip_addr_t(ip4=self.dst_ca_ip))
+        dip = sai_thrift_ip_prefix_t(addr_family=SAI_IP_ADDR_FAMILY_IPV4,
+                                     addr=sai_thrift_ip_addr_t(ip4=self.dst_ca_ip),
+                                     mask=sai_thrift_ip_addr_t(ip4="255.255.255.255"))
 
         ca_prefix = sai_thrift_ip_prefix_t(addr_family=SAI_IP_ADDR_FAMILY_IPV4,
                                            addr=sai_thrift_ip_addr_t(

--- a/test/test-cases/functional/ptf/saidashvnet.py
+++ b/test/test-cases/functional/ptf/saidashvnet.py
@@ -2635,7 +2635,7 @@ class Vnet2VnetOutboundDstVnetIdRouteVnetDirectSinglePortTest(Vnet2VnetOutboundD
                                                  dst_vnet_id=dst_vnet_0,
                                                  overlay_ip="192.168.1.111")
         self.outbound_ca_to_pa_create(dst_vnet_id=dst_vnet_0,
-                                      dip="192.168.1.111",
+                                      dip="192.168.1.111/32",
                                       underlay_dip=self.rx_host_0.ip,
                                       overlay_dmac=self.rx_host.client.mac,
                                       use_dst_vnet_vni=True)
@@ -2645,7 +2645,7 @@ class Vnet2VnetOutboundDstVnetIdRouteVnetDirectSinglePortTest(Vnet2VnetOutboundD
                                                  dst_vnet_id=dst_vnet_1,
                                                  overlay_ip="192.168.2.222")
         self.outbound_ca_to_pa_create(dst_vnet_id=dst_vnet_1,
-                                      dip="192.168.2.222",
+                                      dip="192.168.2.222/32",
                                       underlay_dip=self.rx_host_1.ip,
                                       overlay_dmac=self.rx_host_1.client.mac,
                                       use_dst_vnet_vni=False)
@@ -2708,7 +2708,7 @@ class Vnet2VnetOutboundDstVnetIdRouteVnetDirectSinglePortOverlayIpv6Test(Vnet2Vn
                                                  dst_vnet_id=dst_vnet_0,
                                                  overlay_ip="bbbb::bc")
         self.outbound_ca_to_pa_create(dst_vnet_id=dst_vnet_0,
-                                      dip="bbbb::bc",
+                                      dip="bbbb::bc/128",
                                       underlay_dip=self.rx_host_0.ip,
                                       overlay_dmac=self.rx_host.client.mac,
                                       use_dst_vnet_vni=True)
@@ -2718,7 +2718,7 @@ class Vnet2VnetOutboundDstVnetIdRouteVnetDirectSinglePortOverlayIpv6Test(Vnet2Vn
                                                  dst_vnet_id=dst_vnet_1,
                                                  overlay_ip="cccc::bc")
         self.outbound_ca_to_pa_create(dst_vnet_id=dst_vnet_1,
-                                      dip="cccc::bc",
+                                      dip="cccc::bc/128",
                                       underlay_dip=self.rx_host_1.ip,
                                       overlay_dmac=self.rx_host_1.client.mac,
                                       use_dst_vnet_vni=False)
@@ -3203,7 +3203,7 @@ class Vnet2VnetOutboundMultipleEniSameIpPrefixSinglePortTest(VnetApiEndpoints, V
                                                  dst_vnet_id=dst_vnet_2,
                                                  overlay_ip="192.168.1.111")
         self.outbound_ca_to_pa_create(dst_vnet_id=dst_vnet_2,
-                                      dip="192.168.1.111",
+                                      dip="192.168.1.111/32",
                                       underlay_dip=self.rx_host_2.ip,
                                       overlay_dmac=self.rx_host_2.client.mac,
                                       use_dst_vnet_vni=True)
@@ -3377,7 +3377,7 @@ class Vnet2VnetOutboundMultipleEniSameIpPrefixSinglePortOverlayIpv6Test(Vnet2Vne
                                                  dst_vnet_id=dst_vnet_2,
                                                  overlay_ip="bbbb::bc")
         self.outbound_ca_to_pa_create(dst_vnet_id=dst_vnet_2,
-                                      dip="bbbb::bc",
+                                      dip="bbbb::bc/128",
                                       underlay_dip=self.rx_host_2.ip,
                                       overlay_dmac=self.rx_host_2.client.mac,
                                       use_dst_vnet_vni=True)

--- a/test/test-cases/functional/ptf/saidashvnet_sanity.py
+++ b/test/test-cases/functional/ptf/saidashvnet_sanity.py
@@ -136,8 +136,15 @@ class SaiThriftVnetOutboundUdpPktTest(SaiHelperSimplified):
                                                                eni_id=self.eni)
         assert(status == SAI_STATUS_SUCCESS)
 
-        dip = sai_thrift_ip_address_t(addr_family=self.sai_ip_addr_family,
-                                      addr=sai_thrift_ip_addr_t(**{self.ip_addr_family_attr: self.dst_ca_ip}))
+        # Set appropriate mask for IPv4 (/32) or IPv6 (/128)
+        if self.sai_ip_addr_family == SAI_IP_ADDR_FAMILY_IPV6:
+            mask_str = "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"
+        else:
+            mask_str = "255.255.255.255"
+        
+        dip = sai_thrift_ip_prefix_t(addr_family=self.sai_ip_addr_family,
+                                     addr=sai_thrift_ip_addr_t(**{self.ip_addr_family_attr: self.dst_ca_ip}),
+                                     mask=sai_thrift_ip_addr_t(**{self.ip_addr_family_attr: mask_str}))
 
         # TODO: Enable ACL rule for IPv6
         if self.sai_ip_addr_family == SAI_IP_ADDR_FAMILY_IPV4:


### PR DESCRIPTION
Some use cases have multiplle sequential addresses mapped to the same PA. For such cases, aggregation into prefixes provides a better scale.