### PR TITLE
add eni attribute to get ha flow owner (DPU-driven HA)

### DIFF
--- a/dash-pipeline/SAI/specs/dash_eni.yaml
+++ b/dash-pipeline/SAI/specs/dash_eni.yaml
@@ -666,6 +666,19 @@ sai_apis:
     valid_only: null
     is_vlan: false
     deprecated: false
+  - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
+    name: SAI_ENI_ATTR_IS_OPERATIONAL_HA_FLOW_OWNER
+    description: Get HA flow ownership status
+    type: bool
+    attr_value_field: booldata
+    default: 'false'
+    isresourcetype: false
+    flags: READ_ONLY
+    object_name: null
+    allow_null: false
+    valid_only: null
+    is_vlan: false
+    deprecated: false
   stats:
   - !!python/object:utils.sai_spec.sai_attribute.SaiAttribute
     name: SAI_ENI_STAT_RX_BYTES

--- a/documentation/high-avail/ha-api-hld.md
+++ b/documentation/high-avail/ha-api-hld.md
@@ -226,6 +226,7 @@ To provide the ENI-level HA control, each ENI will have the following SAI attrib
 | -------------- | ---- | ----------- |
 | SAI_ENI_ATTR_HA_SCOPE_ID | `sai_object_id_t` | The HA scope ID of the ENI. |
 | SAI_ENI_ATTR_IS_HA_FLOW_OWNER | `bool` | Determines which DPU in the pair creates flows belonging to this ENI in steady-state. Typically this is set to True for the ENIs on the Active DPU and False for the Standby DPU. |
+| SAI_ENI_ATTR_IS_OPERATIONAL_HA_FLOW_OWNER | `bool` | Read-only. Returns the operational HA flow ownership status of the ENI. |
 
 ### 4.6. Event notifications
 


### PR DESCRIPTION
Today for DPU-driven HA, there is no way to tell which side is the actual operational owner of HA, both sides will show as HA state active. Adding an attribute to get the flow owner, aka. the actual active. 

SAI: https://github.com/opencomputeproject/SAI/pull/2278

sign-off: Jing Zhang zhangjing@microsoft.com  